### PR TITLE
fix(ui): restore branded user navbar

### DIFF
--- a/src/components/layout/PublicNavigationBar.tsx
+++ b/src/components/layout/PublicNavigationBar.tsx
@@ -57,7 +57,7 @@ export default function PublicNavigationBar({ onRequestLogout }: PublicNavigatio
 
     return (
         <nav
-            className="sticky top-0 z-50 border-b bg-background/90 text-foreground shadow-xs backdrop-blur-xl"
+            className="sticky top-0 z-50 border-b border-border/70 bg-background/95 text-foreground shadow-sm backdrop-blur-xl"
             aria-label="เมนูหลัก"
             data-surface="public"
         >
@@ -76,7 +76,12 @@ export default function PublicNavigationBar({ onRequestLogout }: PublicNavigatio
                         className="size-9 object-contain"
                         priority
                     />
-                    <span className="font-heading text-xl font-bold tracking-tight">MilerDev</span>
+                    <span
+                        className="font-heading text-xl font-bold tracking-tight transition-colors group-hover:text-primary motion-reduce:transition-none"
+                        translate="no"
+                    >
+                        MilerDev
+                    </span>
                 </Link>
 
                 <div className="hidden flex-1 items-center justify-center gap-1 lg:flex">
@@ -84,7 +89,7 @@ export default function PublicNavigationBar({ onRequestLogout }: PublicNavigatio
                         <Button
                             key={href}
                             asChild
-                            variant={isActive(href) ? 'secondary' : 'ghost'}
+                            variant="navigation"
                             size="sm"
                         >
                             <Link

--- a/src/components/layout/UserNavigationMenus.tsx
+++ b/src/components/layout/UserNavigationMenus.tsx
@@ -106,7 +106,13 @@ export default function UserNavigationMenus({
         <div className="flex items-center gap-1">
             <Popover open={notificationsOpen} onOpenChange={setNotificationPanel}>
                 <PopoverTrigger asChild>
-                    <Button type="button" variant="ghost" size="icon" aria-label="การแจ้งเตือน">
+                    <Button
+                        type="button"
+                        variant="navigation"
+                        size="icon"
+                        className="relative"
+                        aria-label="การแจ้งเตือน"
+                    >
                         <Bell data-icon="inline-start" aria-hidden="true" />
                         {unreadCount > 0 && (
                             <Badge
@@ -120,6 +126,7 @@ export default function UserNavigationMenus({
                 </PopoverTrigger>
                 <PopoverContent
                     align="end"
+                    sideOffset={10}
                     className="w-[min(24rem,calc(100vw-2rem))] gap-0 overflow-hidden p-0"
                     aria-label="การแจ้งเตือน"
                 >
@@ -229,27 +236,38 @@ export default function UserNavigationMenus({
                     <Button
                         ref={userTriggerRef}
                         type="button"
-                        variant="ghost"
+                        variant="navigation"
+                        size="navigation"
                         aria-label={`เมนูผู้ใช้ ${session.user?.name || 'ผู้ใช้'}`}
                     >
                         <UserAvatar image={session.user?.image} name={session.user?.name} />
-                        <ChevronDown data-icon="inline-end" aria-hidden="true" />
+                        <span className="flex transition-transform duration-150 group-data-[state=open]/button:rotate-180 motion-reduce:transition-none">
+                            <ChevronDown data-icon="inline-end" aria-hidden="true" />
+                        </span>
                     </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-72">
-                    <DropdownMenuLabel>
-                        <div className="flex min-w-0 items-center gap-3">
-                            <UserAvatar image={session.user?.image} name={session.user?.name} size="lg" />
-                            <span className="min-w-0">
-                                <strong className="block truncate">{session.user?.name || 'ผู้ใช้'}</strong>
-                                <span className="block truncate">{session.user?.email}</span>
-                            </span>
-                        </div>
-                    </DropdownMenuLabel>
+                <DropdownMenuContent align="end" sideOffset={10} className="w-72">
+                    <DropdownMenuGroup>
+                        <DropdownMenuLabel variant="account">
+                            <div className="flex min-w-0 items-center gap-3">
+                                <UserAvatar image={session.user?.image} name={session.user?.name} size="lg" />
+                                <span className="min-w-0">
+                                    <strong className="block truncate text-sm font-semibold text-popover-foreground">
+                                        {session.user?.name || 'ผู้ใช้'}
+                                    </strong>
+                                    {session.user?.email && (
+                                        <span className="block truncate text-xs font-normal text-muted-foreground">
+                                            {session.user.email}
+                                        </span>
+                                    )}
+                                </span>
+                            </div>
+                        </DropdownMenuLabel>
+                    </DropdownMenuGroup>
                     <DropdownMenuSeparator />
                     <DropdownMenuGroup>
                         {USER_MENU_LINKS.map(({ href, label, icon: Icon }) => (
-                            <DropdownMenuItem key={href} asChild>
+                            <DropdownMenuItem key={href} variant="navigation" asChild>
                                 <Link href={href} aria-current={isActive(href) ? 'page' : undefined}>
                                     <Icon aria-hidden="true" />
                                     {label}
@@ -257,8 +275,11 @@ export default function UserNavigationMenus({
                             </DropdownMenuItem>
                         ))}
                         {isAdmin && (
-                            <DropdownMenuItem asChild>
-                                <Link href="/admin">
+                            <DropdownMenuItem variant="navigation" asChild>
+                                <Link
+                                    href="/admin"
+                                    aria-current={isActive('/admin') ? 'page' : undefined}
+                                >
                                     <ShieldCheck aria-hidden="true" />
                                     Admin Panel
                                 </Link>
@@ -269,6 +290,7 @@ export default function UserNavigationMenus({
                     <DropdownMenuGroup>
                         <DropdownMenuItem
                             variant="destructive"
+                            className="min-h-11 gap-3"
                             onSelect={() => onLogout(userTriggerRef.current)}
                         >
                             <LogOut aria-hidden="true" />

--- a/src/components/layout/navigation-config.tsx
+++ b/src/components/layout/navigation-config.tsx
@@ -44,7 +44,7 @@ export function UserAvatar({
     const fallback = name?.trim().charAt(0).toUpperCase() || 'U';
 
     return (
-        <Avatar size={size}>
+        <Avatar size={size} variant="brand">
             {image && <AvatarImage src={image} alt={name || 'รูปโปรไฟล์ผู้ใช้'} />}
             <AvatarFallback aria-hidden>{fallback}</AvatarFallback>
         </Avatar>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -8,14 +8,17 @@ import { cn } from "@/lib/utils"
 function Avatar({
   className,
   size = "default",
+  variant = "default",
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Root> & {
   size?: "default" | "sm" | "lg"
+  variant?: "default" | "brand"
 }) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
       data-size={size}
+      data-variant={variant}
       className={cn(
         "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
         className
@@ -49,7 +52,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs group-data-[variant=brand]/avatar:bg-primary group-data-[variant=brand]/avatar:font-bold group-data-[variant=brand]/avatar:text-primary-foreground",
         className
       )}
       {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,6 +20,8 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
           "hover:bg-secondary hover:text-secondary-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        navigation:
+          "bg-transparent text-muted-foreground hover:border-border hover:bg-secondary hover:text-secondary-foreground aria-[current=page]:bg-secondary aria-[current=page]:text-secondary-foreground aria-expanded:border-border aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive dark:hover:bg-destructive/90 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
@@ -31,6 +33,8 @@ const buttonVariants = cva(
         sm: "h-9 gap-1.5 rounded-lg px-3.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         lg: "h-12 gap-2 px-6 text-base has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5",
         hero: "h-13 gap-2 px-6 text-base",
+        navigation:
+          "h-11 gap-1 px-1.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
         icon: "size-11",
         "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -65,7 +65,7 @@ function DropdownMenuItem({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
   inset?: boolean
-  variant?: "default" | "destructive"
+  variant?: "default" | "destructive" | "navigation"
 }) {
   return (
     <DropdownMenuPrimitive.Item
@@ -73,7 +73,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/dropdown-menu-item relative flex cursor-default items-center gap-2.5 rounded-xl px-3 py-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-9.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-2.5 rounded-xl px-3 py-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground aria-[current=page]:bg-secondary aria-[current=page]:text-secondary-foreground aria-[current=page]:**:text-secondary-foreground data-inset:pl-9.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=navigation]:min-h-11 data-[variant=navigation]:gap-3 data-[variant=navigation]:text-muted-foreground data-[variant=navigation]:focus:bg-secondary data-[variant=navigation]:focus:text-secondary-foreground data-[variant=navigation]:focus:**:text-secondary-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className
       )}
       {...props}
@@ -161,16 +161,19 @@ function DropdownMenuRadioItem({
 function DropdownMenuLabel({
   className,
   inset,
+  variant = "default",
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
   inset?: boolean
+  variant?: "default" | "account"
 }) {
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
+      data-variant={variant}
       className={cn(
-        "px-3 py-2.5 text-xs text-muted-foreground data-inset:pl-9.5",
+        "px-3 py-2.5 text-xs text-muted-foreground data-inset:pl-9.5 data-[variant=account]:p-3 data-[variant=account]:text-popover-foreground",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- restore branded active and open states for the public navbar
- polish the authenticated account dropdown with semantic shadcn variants
- preserve Radix keyboard behavior and the non-modal scroll-lock fix

## Verification
- npm run test -- --run (562 tests)
- npm run lint
- npm run build
- browser QA at 390, 768, 1024, and 1440 px
- verified dropdown after scrolling 1,400 px without body scroll lock