### PR TITLE
chore(deploy): prepare Railway health checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:remote": "infisical run --env=dev -- next dev",
     "dev:local": "infisical run --env=dev -- next dev",
     "build": "next build",
-    "start": "tsx src/lib/db/migrate.ts && next start",
+    "start": "npm run db:migrate && npm run start:app",
     "lint": "eslint",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -29,7 +29,8 @@
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
     "docker:logs": "docker compose logs mysql",
-    "docker:mysql": "docker exec -it milerdev-mysql mysql -uroot -proot milerdev"
+    "docker:mysql": "docker exec -it milerdev-mysql mysql -uroot -proot milerdev",
+    "start:app": "next start"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "1.11.3",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,27 @@
+import { sql } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { db } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const RESPONSE_HEADERS = {
+  'Cache-Control': 'no-store, max-age=0',
+};
+
+export async function GET() {
+  try {
+    await db.execute(sql`SELECT 1`);
+
+    return NextResponse.json(
+      { status: 'ok' },
+      { headers: RESPONSE_HEADERS },
+    );
+  } catch {
+    return NextResponse.json(
+      { status: 'unavailable' },
+      { status: 503, headers: RESPONSE_HEADERS },
+    );
+  }
+}

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execute } = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: { execute },
+}));
+
+import { GET } from '@/app/api/health/route';
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 when the application can reach the database', async () => {
+    execute.mockResolvedValueOnce(undefined);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store, max-age=0');
+    await expect(response.json()).resolves.toEqual({ status: 'ok' });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it('returns a generic 503 response without leaking the database error', async () => {
+    execute.mockRejectedValueOnce(new Error('connection details'));
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Cache-Control')).toBe('no-store, max-age=0');
+    await expect(response.json()).resolves.toEqual({ status: 'unavailable' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a database-backed `/api/health` readiness endpoint
- return a generic 503 without leaking database errors
- add a dedicated `start:app` script while retaining startup migrations for the safe rollout phase
- cover healthy and unavailable database responses

## Verification
- `npm run test -- --run` (87 files, 564 tests)
- `npm run lint`
- `npm run build`
- `git diff --check`
- local `/api/health` returned `{status:ok}`

## Rollout
1. Merge and verify `/api/health` in production.
2. Configure Railway pre-deploy as `npm run db:migrate` and healthcheck path as `/api/health`.
3. Follow up by changing `npm start` to application startup only.