### PR TITLE
chore(deploy): run migrations only in pre-deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:remote": "infisical run --env=dev -- next dev",
     "dev:local": "infisical run --env=dev -- next dev",
     "build": "next build",
-    "start": "npm run db:migrate && npm run start:app",
+    "start": "npm run start:app",
     "lint": "eslint",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- remove database migration execution from npm start
- keep application startup delegated to npm run start:app
- rely on the verified Railway pre-deploy command for npm run db:migrate

## Deployment precondition
Railway production now has the pre-deploy command npm run db:migrate, healthcheck path /api/health, and a 300-second timeout. The settings deployment is active and successful, and production health returns 200.

## Verification
- npm run test -- --run (87 files, 564 tests)
- npm run lint
- npm run build
- git diff --check