### PR TITLE
chore(ci): update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -71,12 +71,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- update actions/checkout from v4 to v7
- update actions/setup-node from v4 to v7
- move CI jobs from Node 20 to Node 22 to match Railway production
- remove the deprecated Node 20 action-runtime warning

## Verification
- official latest releases checked: checkout v7.0.1 and setup-node v7.0.0
- npm run test -- --run tests/lib/backend-log-ci-contract.test.ts (3 tests)
- git diff --check

The PR checks themselves validate install, lint, typecheck, tests, and build on Node 22 with the updated actions.