### PR TITLE
test(deploy): add production smoke checks

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,43 @@
+name: Production Smoke
+
+on:
+  deployment_status:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke Test
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'beneficial-dream / production')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout deployed commit
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Test production
+        run: npm run test:e2e:production
+        env:
+          PLAYWRIGHT_BASE_URL: https://milerdev.com

--- a/e2e/production-smoke.spec.ts
+++ b/e2e/production-smoke.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Production deployment', () => {
+  test('health endpoint confirms the app and database are ready', async ({ request }) => {
+    const response = await request.get('/api/health');
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
+    expect(response.headers()['cache-control']).toContain('no-store');
+  });
+
+  test('homepage renders', async ({ page }) => {
+    const response = await page.goto('/');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page).toHaveTitle(/Miler/i);
+    await expect(page.locator('main')).toBeVisible();
+  });
+
+  test('login page renders its credential fields', async ({ page }) => {
+    const response = await page.goto('/login');
+
+    expect(response?.ok()).toBe(true);
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "docker:down": "docker compose down",
     "docker:logs": "docker compose logs mysql",
     "docker:mysql": "docker exec -it milerdev-mysql mysql -uroot -proot milerdev",
-    "start:app": "next start"
+    "start:app": "next start",
+    "test:e2e:production": "playwright test --config=playwright.production.config.ts"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "1.11.3",

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'production-smoke.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'line',
+  timeout: 30_000,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://milerdev.com',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- add a read-only Playwright smoke suite for production health, homepage, and login
- run the suite after Railway reports a successful production deployment
- allow manual smoke runs through GitHub Actions

## Safety

- does not authenticate, submit forms, or mutate production data
- does not change the database schema or migration flow
- reports post-deploy failures but does not perform automatic rollback

## Verification

- `npm run test:e2e:production` (3 passed against https://milerdev.com)
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test -- --run` (564 passed)
- `npm run build`
- `git diff --check`