### PR TITLE
feat(analytics): enforce governance controls

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -154,7 +154,7 @@ async function main() {
     // =====================
     const settingsData = [
         { key: 'site_name', value: 'MilerDev', type: 'string', desc: 'ชื่อเว็บไซต์' },
-        { key: 'analytics_enabled', value: 'true', type: 'boolean', desc: 'เปิด/ปิด Analytics' },
+        { key: 'analytics_enabled', value: 'false', type: 'boolean', desc: 'เปิด/ปิด Analytics' },
         { key: 'maintenance_mode', value: 'false', type: 'boolean', desc: 'โหมดปิดปรับปรุง' },
     ];
     for (const s of settingsData) {

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -1,13 +1,20 @@
+import { createId } from '@paralleldrive/cuid2';
+import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
-import { logError } from '@/lib/error-handler';
+
+import {
+  AnalyticsControlError,
+  getAnalyticsControlState,
+  recordAnalyticsGovernanceDecision,
+  setAnalyticsOperationalEnabled,
+  type AnalyticsGovernanceDecisionInput,
+} from '@/lib/analytics-control';
 import { requireAdmin } from '@/lib/auth-helpers';
 import { db } from '@/lib/db';
-import { settings, auditLogs } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
-import { createId } from '@paralleldrive/cuid2';
+import { auditLogs, settings } from '@/lib/db/schema';
+import { logError } from '@/lib/error-handler';
 import { getClientIP } from '@/lib/rate-limit';
 
-// Default settings
 const defaultSettings = [
   { key: 'site_name', value: 'Course Platform', type: 'string', description: 'ชื่อเว็บไซต์' },
   { key: 'site_description', value: 'ระบบเรียนออนไลน์', type: 'string', description: 'คำอธิบายเว็บไซต์' },
@@ -24,133 +31,173 @@ const defaultSettings = [
   { key: 'smtp_from', value: '', type: 'string', description: 'Email ผู้ส่ง' },
 ];
 
-// GET /api/admin/settings - Get all settings
+function analyticsControlErrorResponse(error: AnalyticsControlError) {
+  if (error.code === 'GOVERNANCE_REQUIRED') {
+    return NextResponse.json(
+      { error: 'ต้องบันทึกและอนุมัตินโยบายข้อมูล Analytics ก่อนเปิดใช้งาน' },
+      { status: 409 },
+    );
+  }
+  if (error.code === 'INVALID_GOVERNANCE_DECISION') {
+    return NextResponse.json({ error: 'ข้อมูลการอนุมัติ Analytics ไม่ถูกต้อง' }, { status: 400 });
+  }
+  return NextResponse.json(
+    { error: 'ไม่สามารถยืนยันสถานะ Analytics หลังบันทึกได้' },
+    { status: 503 },
+  );
+}
+
+function parseOperationalValue(value: unknown): boolean | null {
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+  return null;
+}
+
+// GET /api/admin/settings - Get all settings and observable analytics state.
 export async function GET() {
   try {
     const authResult = await requireAdmin();
     if (authResult instanceof NextResponse) return authResult;
 
-    // Get all settings from DB
-    const settingsList = await db.select().from(settings);
-    
-    // Create a map of existing settings
-    const settingsMap = new Map(settingsList.map(s => [s.key, s]));
-    
-    // Merge with defaults (show all default keys even if not in DB)
-    const mergedSettings = defaultSettings.map(def => {
-      const existing = settingsMap.get(def.key);
-      if (existing) {
-        return {
-          ...existing,
-          description: def.description,
-        };
-      }
+    const [settingsList, analyticsControl] = await Promise.all([
+      db.select().from(settings),
+      getAnalyticsControlState({ fresh: true }),
+    ]);
+    const settingsMap = new Map(settingsList.map((setting) => [setting.key, setting]));
+    const mergedSettings = defaultSettings.map((definition) => {
+      const existing = settingsMap.get(definition.key);
+      if (existing) return { ...existing, description: definition.description };
       return {
         id: null,
-        key: def.key,
-        value: def.value,
-        type: def.type,
-        description: def.description,
+        key: definition.key,
+        value: definition.value,
+        type: definition.type,
+        description: definition.description,
         updatedAt: null,
         updatedBy: null,
       };
     });
 
-    // Group settings by category
     const grouped = {
-      general: mergedSettings.filter(s => ['site_name', 'site_description', 'contact_email', 'currency'].includes(s.key)),
-      features: mergedSettings.filter(s => ['enable_registration', 'enable_payment', 'maintenance_mode'].includes(s.key)),
-      upload: mergedSettings.filter(s => ['max_upload_size'].includes(s.key)),
-      email: mergedSettings.filter(s => ['smtp_host', 'smtp_port', 'smtp_user', 'smtp_from'].includes(s.key)),
+      general: mergedSettings.filter((setting) => [
+        'site_name', 'site_description', 'contact_email', 'currency',
+      ].includes(setting.key)),
+      features: mergedSettings.filter((setting) => [
+        'enable_registration', 'enable_payment', 'maintenance_mode',
+      ].includes(setting.key)),
+      upload: mergedSettings.filter((setting) => setting.key === 'max_upload_size'),
+      email: mergedSettings.filter((setting) => [
+        'smtp_host', 'smtp_port', 'smtp_user', 'smtp_from',
+      ].includes(setting.key)),
     };
 
-    return NextResponse.json({ settings: mergedSettings, grouped });
+    return NextResponse.json({ settings: mergedSettings, grouped, analyticsControl });
   } catch (error) {
-    logError(error instanceof Error ? error : new Error(String(error)), { action: 'Error fetching settings:' });
-    return NextResponse.json(
-      { error: 'เกิดข้อผิดพลาด' },
-      { status: 500 }
-    );
+    logError(error instanceof Error ? error : new Error(String(error)), {
+      action: 'Error fetching settings:',
+    });
+    return NextResponse.json({ error: 'เกิดข้อผิดพลาด' }, { status: 500 });
   }
 }
 
-// PUT /api/admin/settings - Update settings
+// PUT /api/admin/settings - Update settings.
 export async function PUT(request: Request) {
   try {
     const authResult = await requireAdmin();
     if (authResult instanceof NextResponse) return authResult;
     const { session } = authResult;
 
-    const body = await request.json();
-    const { key, value } = body;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'ข้อมูลไม่ถูกต้อง' }, { status: 400 });
+    }
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json({ error: 'ข้อมูลไม่ถูกต้อง' }, { status: 400 });
+    }
 
-    if (!key) {
+    const { key, value } = body as { key?: unknown; value?: unknown };
+    if (typeof key !== 'string' || !key) {
       return NextResponse.json({ error: 'กรุณาระบุ key' }, { status: 400 });
     }
 
-    // Only allow known settings keys
-    const allowedKeys = defaultSettings.map(s => s.key);
+    const auditContext = {
+      ipAddress: getClientIP(request),
+      userAgent: request.headers.get('user-agent'),
+    };
+
+    if (key === 'analytics_enabled') {
+      const enabled = parseOperationalValue(value);
+      if (enabled === null) {
+        return NextResponse.json({ error: 'ค่า Analytics ต้องเป็น true หรือ false' }, { status: 400 });
+      }
+
+      const analyticsControl = await setAnalyticsOperationalEnabled({
+        enabled,
+        actorId: session.user.id,
+        auditContext,
+      });
+      return NextResponse.json({ message: 'บันทึกการตั้งค่าสำเร็จ', analyticsControl });
+    }
+
+    if (key === 'analytics_governance_decision') {
+      const analyticsControl = await recordAnalyticsGovernanceDecision({
+        decision: value as AnalyticsGovernanceDecisionInput,
+        actorId: session.user.id,
+        auditContext,
+      });
+      return NextResponse.json({ message: 'บันทึกการอนุมัติ Analytics สำเร็จ', analyticsControl });
+    }
+
+    const allowedKeys = defaultSettings.map((setting) => setting.key);
     if (!allowedKeys.includes(key)) {
       return NextResponse.json({ error: 'key ไม่ถูกต้อง' }, { status: 400 });
     }
 
-    // Get IP and User Agent for audit log
-    const ipAddress = getClientIP(request);
-    const userAgent = request.headers.get('user-agent') || 'unknown';
-
-    // Check if setting exists
     const [existing] = await db
       .select()
       .from(settings)
       .where(eq(settings.key, key))
       .limit(1);
-
-    const oldValue = existing?.value || null;
+    const oldValue = existing?.value ?? null;
 
     if (existing) {
-      // Update existing
       await db
         .update(settings)
-        .set({
-          value: String(value),
-          updatedAt: new Date(),
-          updatedBy: session.user.id,
-        })
+        .set({ value: String(value), updatedAt: new Date(), updatedBy: session.user.id })
         .where(eq(settings.key, key));
     } else {
-      // Create new
-      const defaultSetting = defaultSettings.find(d => d.key === key);
+      const defaultSetting = defaultSettings.find((setting) => setting.key === key);
       await db.insert(settings).values({
         id: createId(),
         key,
         value: String(value),
-        type: (defaultSetting?.type || 'string') as 'string' | 'number' | 'boolean' | 'json',
-        description: defaultSetting?.description || null,
+        type: (defaultSetting?.type ?? 'string') as 'string' | 'number' | 'boolean' | 'json',
+        description: defaultSetting?.description ?? null,
         updatedAt: new Date(),
         updatedBy: session.user.id,
       });
     }
 
-    // Log the change
     await db.insert(auditLogs).values({
       id: createId(),
       userId: session.user.id,
       action: existing ? 'update' : 'create',
       entityType: 'setting',
       entityId: key,
-      oldValue: oldValue,
+      oldValue,
       newValue: String(value),
-      ipAddress,
-      userAgent,
+      ipAddress: auditContext.ipAddress,
+      userAgent: auditContext.userAgent ?? 'unknown',
     });
 
     return NextResponse.json({ message: 'บันทึกการตั้งค่าสำเร็จ' });
   } catch (error) {
-    logError(error instanceof Error ? error : new Error(String(error)), { action: 'Error updating setting:' });
-    return NextResponse.json(
-      { error: 'เกิดข้อผิดพลาดในการบันทึก' },
-      { status: 500 }
-    );
+    if (error instanceof AnalyticsControlError) return analyticsControlErrorResponse(error);
+    logError(error instanceof Error ? error : new Error(String(error)), {
+      action: 'Error updating setting:',
+    });
+    return NextResponse.json({ error: 'เกิดข้อผิดพลาดในการบันทึก' }, { status: 500 });
   }
 }
-

--- a/src/app/api/analytics/events/route.ts
+++ b/src/app/api/analytics/events/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 
 import { clientAnalyticsEventSchema } from '@/lib/analytics-contract';
 import {
-  isAnalyticsEnabled,
+  isAnalyticsEventEnabled,
   isPublishedAnalyticsTarget,
   recordClientAnalyticsEvent,
 } from '@/lib/analytics';
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    if (!(await isAnalyticsEnabled())) {
+    if (!(await isAnalyticsEventEnabled(parsed.data.eventName))) {
       return new NextResponse(null, { status: 204 });
     }
 

--- a/src/lib/analytics-contract.ts
+++ b/src/lib/analytics-contract.ts
@@ -58,6 +58,37 @@ export const clientAnalyticsEventSchema = z.object({
   }
 });
 
+export const serverAnalyticsEventSchema = z.object({
+  eventName: z.enum(SERVER_ANALYTICS_EVENT_NAMES),
+  userId: analyticsIdSchema.optional(),
+  courseId: analyticsIdSchema.optional(),
+  bundleId: analyticsIdSchema.optional(),
+  paymentId: analyticsIdSchema.optional(),
+}).strict().superRefine((value, context) => {
+  const hasCourse = Boolean(value.courseId);
+  const hasBundle = Boolean(value.bundleId);
+  const hasOneProduct = hasCourse !== hasBundle;
+
+  if (value.eventName === 'registration_completed') {
+    if (!value.userId || hasCourse || hasBundle || value.paymentId) {
+      context.addIssue({ code: 'custom', message: 'Invalid Registration event' });
+    }
+    return;
+  }
+
+  if (value.eventName === 'free_enrollment_completed') {
+    if (!value.userId || !hasOneProduct || value.paymentId) {
+      context.addIssue({ code: 'custom', message: 'Invalid Free enrollment event' });
+    }
+    return;
+  }
+
+  if (!value.userId || !value.paymentId || !hasOneProduct) {
+    context.addIssue({ code: 'custom', message: 'Paid events require a user, payment, and one product' });
+  }
+});
+
 export type ClientAnalyticsEvent = z.infer<typeof clientAnalyticsEventSchema>;
+export type ServerAnalyticsEvent = z.infer<typeof serverAnalyticsEventSchema>;
 export type AnalyticsPlacement = z.infer<typeof analyticsPlacementSchema>;
 export type ServerAnalyticsEventName = typeof SERVER_ANALYTICS_EVENT_NAMES[number];

--- a/src/lib/analytics-control.ts
+++ b/src/lib/analytics-control.ts
@@ -1,0 +1,361 @@
+import { eq, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+
+import {
+  CLIENT_ANALYTICS_EVENT_NAMES,
+  SERVER_ANALYTICS_EVENT_NAMES,
+  type ClientAnalyticsEvent,
+  type ServerAnalyticsEventName,
+} from '@/lib/analytics-contract';
+import { db } from '@/lib/db';
+import { auditLogs, settings } from '@/lib/db/schema';
+
+export const ANALYTICS_CONTROL_CACHE_MAX_AGE_MS = 5_000;
+
+export const ANALYTICS_EVENT_CLASSES = [
+  'product_interaction',
+  'account_lifecycle',
+  'commerce',
+  'enrollment',
+] as const;
+
+export type AnalyticsEventClass = typeof ANALYTICS_EVENT_CLASSES[number];
+type AnalyticsEventName = ClientAnalyticsEvent['eventName'] | ServerAnalyticsEventName;
+
+const ANALYTICS_ENABLED_KEY = 'analytics_enabled' as const;
+const ANALYTICS_GOVERNANCE_KEY = 'analytics_governance_decision' as const;
+const ANALYTICS_CONTROL_KEYS = [ANALYTICS_ENABLED_KEY, ANALYTICS_GOVERNANCE_KEY] as const;
+
+const policyText = z.string().trim().min(1).max(1_000);
+const analyticsActorIdSchema = z.string().trim().min(1).max(36);
+
+export const analyticsGovernanceDecisionInputSchema = z.object({
+  ownerRole: z.enum(['product_owner', 'privacy_owner']),
+  purpose: policyText,
+  lawfulBasisOrConsent: policyText,
+  collectionNotice: policyText,
+  rawEventRetentionDays: z.number().int().min(1).max(3_650),
+  aggregateRetentionDays: z.number().int().min(1).max(3_650),
+  accessPolicy: policyText,
+  deletionPolicy: policyText,
+  withdrawalPolicy: policyText,
+  approvedEventClasses: z.array(z.enum(ANALYTICS_EVENT_CLASSES)).min(1).max(ANALYTICS_EVENT_CLASSES.length)
+    .refine((values) => new Set(values).size === values.length, 'Event classes must be unique'),
+}).strict();
+
+const storedGovernanceDecisionSchema = analyticsGovernanceDecisionInputSchema.extend({
+  version: z.literal(1),
+  status: z.literal('approved'),
+  decidedBy: analyticsActorIdSchema,
+  decidedAt: z.string().datetime(),
+}).strict();
+
+export type AnalyticsGovernanceDecisionInput = z.infer<typeof analyticsGovernanceDecisionInputSchema>;
+export type AnalyticsGovernanceDecision = z.infer<typeof storedGovernanceDecisionSchema>;
+
+const eventClassByName: Record<AnalyticsEventName, AnalyticsEventClass> = {
+  home_primary_cta_clicked: 'product_interaction',
+  course_viewed: 'product_interaction',
+  bundle_viewed: 'product_interaction',
+  checkout_opened: 'product_interaction',
+  registration_completed: 'account_lifecycle',
+  payment_initiated: 'commerce',
+  purchase_completed: 'commerce',
+  free_enrollment_completed: 'enrollment',
+};
+
+for (const eventName of [...CLIENT_ANALYTICS_EVENT_NAMES, ...SERVER_ANALYTICS_EVENT_NAMES]) {
+  if (!eventClassByName[eventName]) throw new Error(`Missing analytics event class for ${eventName}`);
+}
+
+export interface AnalyticsControlRecord {
+  value: string | null;
+  updatedAt: Date | null;
+}
+
+export interface AnalyticsControlSnapshot {
+  operational: AnalyticsControlRecord | null;
+  governance: AnalyticsControlRecord | null;
+}
+
+export interface AnalyticsAuditContext {
+  ipAddress: string | null;
+  userAgent: string | null;
+}
+
+export interface AnalyticsControlWrite {
+  key: typeof ANALYTICS_ENABLED_KEY | typeof ANALYTICS_GOVERNANCE_KEY;
+  value: string;
+  type: 'boolean' | 'json';
+  description: string;
+  actorId: string;
+  auditContext: AnalyticsAuditContext;
+  now: Date;
+}
+
+export interface AnalyticsControlStore {
+  read(): Promise<AnalyticsControlSnapshot>;
+  write(input: AnalyticsControlWrite): Promise<void>;
+}
+
+export interface AnalyticsControlState {
+  operationalEnabled: boolean;
+  governanceApproved: boolean;
+  effectiveEnabled: boolean;
+  effectiveEventClasses: AnalyticsEventClass[];
+  governanceDecision: AnalyticsGovernanceDecision | null;
+  revision: string;
+  observedAt: string;
+  cacheMaxAgeMs: number;
+}
+
+type AnalyticsControlErrorCode =
+  | 'INVALID_GOVERNANCE_DECISION'
+  | 'GOVERNANCE_REQUIRED'
+  | 'READBACK_FAILED';
+
+export class AnalyticsControlError extends Error {
+  constructor(public readonly code: AnalyticsControlErrorCode) {
+    super(code);
+    this.name = 'AnalyticsControlError';
+  }
+}
+
+function parseStoredDecision(record: AnalyticsControlRecord | null): AnalyticsGovernanceDecision | null {
+  if (!record?.value) return null;
+
+  try {
+    const parsedJson: unknown = JSON.parse(record.value);
+    const parsed = storedGovernanceDecisionSchema.safeParse(parsedJson);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function fingerprint(value: string | null | undefined): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < (value?.length ?? 0); index += 1) {
+    hash ^= value?.charCodeAt(index) ?? 0;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function createState(snapshot: AnalyticsControlSnapshot, observedAt: Date): AnalyticsControlState {
+  const operationalEnabled = snapshot.operational?.value?.trim().toLowerCase() === 'true';
+  const governanceDecision = parseStoredDecision(snapshot.governance);
+  const effectiveEventClasses = operationalEnabled && governanceDecision
+    ? [...governanceDecision.approvedEventClasses]
+    : [];
+  const operationalVersion = snapshot.operational?.updatedAt?.toISOString() ?? 'missing';
+  const governanceVersion = snapshot.governance?.updatedAt?.toISOString() ?? 'missing';
+  const governanceFingerprint = fingerprint(snapshot.governance?.value);
+
+  return {
+    operationalEnabled,
+    governanceApproved: Boolean(governanceDecision),
+    effectiveEnabled: effectiveEventClasses.length > 0,
+    effectiveEventClasses,
+    governanceDecision,
+    revision: `operational:${operationalVersion}:${operationalEnabled};governance:${governanceVersion}:${governanceFingerprint}`,
+    observedAt: observedAt.toISOString(),
+    cacheMaxAgeMs: ANALYTICS_CONTROL_CACHE_MAX_AGE_MS,
+  };
+}
+
+function assertActorId(actorId: string): void {
+  if (!analyticsActorIdSchema.safeParse(actorId).success) {
+    throw new AnalyticsControlError('READBACK_FAILED');
+  }
+}
+
+export function createAnalyticsControlService(
+  store: AnalyticsControlStore,
+  options: { now?: () => Date } = {},
+) {
+  const now = options.now ?? (() => new Date());
+  let cache: { state: AnalyticsControlState; expiresAt: number } | null = null;
+
+  async function getState(readOptions: { fresh?: boolean } = {}): Promise<AnalyticsControlState> {
+    const observedAt = now();
+    if (!readOptions.fresh && cache && cache.expiresAt > observedAt.getTime()) {
+      return cache.state;
+    }
+
+    const state = createState(await store.read(), observedAt);
+    cache = {
+      state,
+      expiresAt: observedAt.getTime() + ANALYTICS_CONTROL_CACHE_MAX_AGE_MS,
+    };
+    return state;
+  }
+
+  function invalidate(): void {
+    cache = null;
+  }
+
+  async function recordGovernanceDecision(input: {
+    decision: AnalyticsGovernanceDecisionInput;
+    actorId: string;
+    auditContext: AnalyticsAuditContext;
+  }): Promise<AnalyticsControlState> {
+    assertActorId(input.actorId);
+    const decision = analyticsGovernanceDecisionInputSchema.safeParse(input.decision);
+    if (!decision.success) throw new AnalyticsControlError('INVALID_GOVERNANCE_DECISION');
+
+    const changedAt = now();
+    const storedDecision: AnalyticsGovernanceDecision = {
+      ...decision.data,
+      version: 1,
+      status: 'approved',
+      decidedBy: input.actorId,
+      decidedAt: changedAt.toISOString(),
+    };
+    await store.write({
+      key: ANALYTICS_GOVERNANCE_KEY,
+      value: JSON.stringify(storedDecision),
+      type: 'json',
+      description: 'Approved analytics data-governance decision',
+      actorId: input.actorId,
+      auditContext: input.auditContext,
+      now: changedAt,
+    });
+    invalidate();
+
+    const readBack = await getState({ fresh: true });
+    if (readBack.governanceDecision?.decidedAt !== storedDecision.decidedAt) {
+      throw new AnalyticsControlError('READBACK_FAILED');
+    }
+    return readBack;
+  }
+
+  async function setOperationalEnabled(input: {
+    enabled: boolean;
+    actorId: string;
+    auditContext: AnalyticsAuditContext;
+  }): Promise<AnalyticsControlState> {
+    assertActorId(input.actorId);
+    if (input.enabled && !(await getState({ fresh: true })).governanceApproved) {
+      throw new AnalyticsControlError('GOVERNANCE_REQUIRED');
+    }
+
+    const changedAt = now();
+    await store.write({
+      key: ANALYTICS_ENABLED_KEY,
+      value: String(input.enabled),
+      type: 'boolean',
+      description: 'Global optional analytics kill switch',
+      actorId: input.actorId,
+      auditContext: input.auditContext,
+      now: changedAt,
+    });
+    invalidate();
+
+    const readBack = await getState({ fresh: true });
+    if (
+      readBack.operationalEnabled !== input.enabled
+      || (input.enabled && !readBack.effectiveEnabled)
+    ) {
+      throw new AnalyticsControlError('READBACK_FAILED');
+    }
+    return readBack;
+  }
+
+  async function isEventEnabled(eventName: AnalyticsEventName): Promise<boolean> {
+    const state = await getState();
+    return state.operationalEnabled
+      && state.effectiveEventClasses.includes(eventClassByName[eventName]);
+  }
+
+  return { getState, invalidate, isEventEnabled, recordGovernanceDecision, setOperationalEnabled };
+}
+
+type DatabaseTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+async function writeSettingWithAudit(tx: DatabaseTransaction, input: AnalyticsControlWrite) {
+  const [existing] = await tx
+    .select({ value: settings.value })
+    .from(settings)
+    .where(eq(settings.key, input.key))
+    .limit(1)
+    .for('update');
+
+  if (existing) {
+    await tx.update(settings).set({
+      value: input.value,
+      type: input.type,
+      description: input.description,
+      updatedAt: input.now,
+      updatedBy: input.actorId,
+    }).where(eq(settings.key, input.key));
+  } else {
+    await tx.insert(settings).values({
+      key: input.key,
+      value: input.value,
+      type: input.type,
+      description: input.description,
+      updatedAt: input.now,
+      updatedBy: input.actorId,
+    });
+  }
+
+  await tx.insert(auditLogs).values({
+    userId: input.actorId,
+    action: existing ? 'update' : 'create',
+    entityType: 'setting',
+    entityId: input.key,
+    oldValue: existing?.value ?? null,
+    newValue: input.value,
+    ipAddress: input.auditContext.ipAddress,
+    userAgent: input.auditContext.userAgent,
+    createdAt: input.now,
+  });
+}
+
+const drizzleAnalyticsControlStore: AnalyticsControlStore = {
+  async read() {
+    const rows = await db
+      .select({ key: settings.key, value: settings.value, updatedAt: settings.updatedAt })
+      .from(settings)
+      .where(inArray(settings.key, [...ANALYTICS_CONTROL_KEYS]));
+    const byKey = new Map(rows.map((row) => [row.key, row]));
+    return {
+      operational: byKey.get(ANALYTICS_ENABLED_KEY) ?? null,
+      governance: byKey.get(ANALYTICS_GOVERNANCE_KEY) ?? null,
+    };
+  },
+  write(input) {
+    return db.transaction((tx) => writeSettingWithAudit(tx, input));
+  },
+};
+
+export const analyticsControl = createAnalyticsControlService(drizzleAnalyticsControlStore);
+
+export function getAnalyticsControlState(options?: { fresh?: boolean }) {
+  return analyticsControl.getState(options);
+}
+
+export function isAnalyticsEventEnabled(eventName: AnalyticsEventName) {
+  return analyticsControl.isEventEnabled(eventName);
+}
+
+export function recordAnalyticsGovernanceDecision(input: {
+  decision: AnalyticsGovernanceDecisionInput;
+  actorId: string;
+  auditContext: AnalyticsAuditContext;
+}) {
+  return analyticsControl.recordGovernanceDecision(input);
+}
+
+export function setAnalyticsOperationalEnabled(input: {
+  enabled: boolean;
+  actorId: string;
+  auditContext: AnalyticsAuditContext;
+}) {
+  return analyticsControl.setOperationalEnabled(input);
+}
+
+export function resetAnalyticsControlCache(): void {
+  analyticsControl.invalidate();
+}

--- a/src/lib/analytics-retention.ts
+++ b/src/lib/analytics-retention.ts
@@ -1,0 +1,81 @@
+import { lt } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { getAnalyticsControlState } from '@/lib/analytics-control';
+import { db } from '@/lib/db';
+import { analyticsEvents } from '@/lib/db/schema';
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_BATCH_SIZE = 1_000;
+
+const retentionRequestSchema = z.object({
+  now: z.date().refine((date) => !Number.isNaN(date.getTime()), 'Invalid date'),
+  rawEventRetentionDays: z.number().int().min(1).max(3_650),
+  batchSize: z.number().int().min(1).max(5_000).default(DEFAULT_BATCH_SIZE),
+}).strict();
+
+export interface AnalyticsRetentionStore {
+  deleteRawEventsBefore(cutoff: Date, batchSize: number): Promise<number>;
+}
+
+export class AnalyticsRetentionError extends Error {
+  constructor(public readonly code: 'INVALID_POLICY' | 'GOVERNANCE_REQUIRED') {
+    super(code);
+    this.name = 'AnalyticsRetentionError';
+  }
+}
+
+export function createAnalyticsRetentionPolicy(store: AnalyticsRetentionStore) {
+  return {
+    async deleteExpiredRawEvents(input: {
+      now: Date;
+      rawEventRetentionDays: number;
+      batchSize?: number;
+    }) {
+      const parsed = retentionRequestSchema.safeParse(input);
+      if (!parsed.success) throw new AnalyticsRetentionError('INVALID_POLICY');
+
+      const cutoff = new Date(
+        parsed.data.now.getTime() - parsed.data.rawEventRetentionDays * DAY_MS,
+      );
+      const deletedCount = await store.deleteRawEventsBefore(cutoff, parsed.data.batchSize);
+      return { cutoff, deletedCount, batchSize: parsed.data.batchSize };
+    },
+  };
+}
+
+function affectedRows(result: unknown): number {
+  const candidate = Array.isArray(result) ? result[0] : result;
+  if (!candidate || typeof candidate !== 'object' || !('affectedRows' in candidate)) return 0;
+  const count = Number((candidate as { affectedRows: unknown }).affectedRows);
+  return Number.isFinite(count) ? count : 0;
+}
+
+const drizzleAnalyticsRetentionStore: AnalyticsRetentionStore = {
+  async deleteRawEventsBefore(cutoff, batchSize) {
+    const result = await db
+      .delete(analyticsEvents)
+      .where(lt(analyticsEvents.createdAt, cutoff))
+      .limit(batchSize);
+    return affectedRows(result);
+  },
+};
+
+export const analyticsRetentionPolicy = createAnalyticsRetentionPolicy(
+  drizzleAnalyticsRetentionStore,
+);
+
+export async function runAnalyticsRawEventRetention(input: {
+  now?: Date;
+  batchSize?: number;
+} = {}) {
+  const state = await getAnalyticsControlState({ fresh: true });
+  const rawEventRetentionDays = state.governanceDecision?.rawEventRetentionDays;
+  if (!rawEventRetentionDays) throw new AnalyticsRetentionError('GOVERNANCE_REQUIRED');
+
+  return analyticsRetentionPolicy.deleteExpiredRawEvents({
+    now: input.now ?? new Date(),
+    rawEventRetentionDays,
+    batchSize: input.batchSize,
+  });
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,38 +1,29 @@
 import { and, eq } from 'drizzle-orm';
 
+import {
+  getAnalyticsControlState,
+  isAnalyticsEventEnabled,
+  resetAnalyticsControlCache,
+} from '@/lib/analytics-control';
+import {
+  clientAnalyticsEventSchema,
+  serverAnalyticsEventSchema,
+  type AnalyticsPlacement,
+  type ClientAnalyticsEvent,
+  type ServerAnalyticsEvent,
+  type ServerAnalyticsEventName,
+} from '@/lib/analytics-contract';
 import { db } from '@/lib/db';
-import { analyticsEvents, courses, bundles, settings } from '@/lib/db/schema';
+import { analyticsEvents, bundles, courses } from '@/lib/db/schema';
 import { isDuplicateKeyError } from '@/lib/db/safe-insert';
 import { logEvent } from '@/lib/error-handler';
-import type {
-  AnalyticsPlacement,
-  ClientAnalyticsEvent,
-  ServerAnalyticsEventName,
-} from '@/lib/analytics-contract';
-
-const ANALYTICS_SETTING_KEY = 'analytics_enabled';
-const ANALYTICS_SETTING_CACHE_MS = 60_000;
-
-let analyticsSettingCache: { enabled: boolean; expiresAt: number } | null = null;
 
 export async function isAnalyticsEnabled(): Promise<boolean> {
-  const now = Date.now();
-  if (analyticsSettingCache && analyticsSettingCache.expiresAt > now) {
-    return analyticsSettingCache.enabled;
-  }
-
-  const [setting] = await db
-    .select({ value: settings.value })
-    .from(settings)
-    .where(eq(settings.key, ANALYTICS_SETTING_KEY))
-    .limit(1);
-  const enabled = setting?.value?.trim().toLowerCase() === 'true';
-  analyticsSettingCache = { enabled, expiresAt: now + ANALYTICS_SETTING_CACHE_MS };
-  return enabled;
+  return (await getAnalyticsControlState()).effectiveEnabled;
 }
 
 export function resetAnalyticsSettingCache(): void {
-  analyticsSettingCache = null;
+  resetAnalyticsControlCache();
 }
 
 async function insertAnalyticsEvent(input: {
@@ -45,7 +36,7 @@ async function insertAnalyticsEvent(input: {
   placement?: AnalyticsPlacement;
 }): Promise<boolean> {
   try {
-    if (!(await isAnalyticsEnabled())) return false;
+    if (!(await isAnalyticsEventEnabled(input.eventName))) return false;
 
     await db.insert(analyticsEvents).values({
       eventName: input.eventName,
@@ -70,21 +61,20 @@ export async function recordClientAnalyticsEvent(
   input: ClientAnalyticsEvent,
   userId?: string | null,
 ): Promise<boolean> {
+  const parsed = clientAnalyticsEventSchema.safeParse(input);
+  if (!parsed.success) return false;
+
   return insertAnalyticsEvent({
-    ...input,
+    ...parsed.data,
     source: 'client',
     userId,
   });
 }
 
-export async function recordServerAnalyticsEvent(input: {
-  eventName: ServerAnalyticsEventName;
-  userId?: string | null;
-  courseId?: string | null;
-  bundleId?: string | null;
-  paymentId?: string | null;
-}): Promise<boolean> {
-  return insertAnalyticsEvent({ ...input, source: 'server' });
+export async function recordServerAnalyticsEvent(input: ServerAnalyticsEvent): Promise<boolean> {
+  const parsed = serverAnalyticsEventSchema.safeParse(input);
+  if (!parsed.success) return false;
+  return insertAnalyticsEvent({ ...parsed.data, source: 'server' });
 }
 
 export async function isPublishedAnalyticsTarget(input: {
@@ -111,3 +101,5 @@ export async function isPublishedAnalyticsTarget(input: {
 
   return true;
 }
+
+export { isAnalyticsEventEnabled };

--- a/tests/api/admin-analytics-settings.test.ts
+++ b/tests/api/admin-analytics-settings.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth-helpers', () => ({ requireAdmin: vi.fn() }));
+vi.mock('@/lib/db', () => ({ db: {} }));
+vi.mock('@/lib/error-handler', () => ({ logError: vi.fn() }));
+vi.mock('@/lib/rate-limit', () => ({ getClientIP: vi.fn().mockReturnValue('127.0.0.1') }));
+vi.mock('@/lib/analytics-control', () => {
+  class AnalyticsControlError extends Error {
+    constructor(public readonly code: string) {
+      super(code);
+    }
+  }
+
+  return {
+    AnalyticsControlError,
+    getAnalyticsControlState: vi.fn(),
+    recordAnalyticsGovernanceDecision: vi.fn(),
+    setAnalyticsOperationalEnabled: vi.fn(),
+  };
+});
+
+import {
+  AnalyticsControlError,
+  recordAnalyticsGovernanceDecision,
+  setAnalyticsOperationalEnabled,
+} from '@/lib/analytics-control';
+import { requireAdmin } from '@/lib/auth-helpers';
+
+const effectiveState = {
+  operationalEnabled: true,
+  governanceApproved: true,
+  effectiveEnabled: true,
+  effectiveEventClasses: ['product_interaction'],
+  governanceDecision: null,
+  revision: 'revision-2',
+  observedAt: '2026-08-31T00:00:00.000Z',
+  cacheMaxAgeMs: 5_000,
+};
+
+function put(body: unknown) {
+  return import('@/app/api/admin/settings/route').then(({ PUT }) => PUT(new Request(
+    'http://localhost/api/admin/settings',
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'user-agent': 'vitest' },
+      body: JSON.stringify(body),
+    },
+  )));
+}
+
+describe('admin analytics settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue({
+      session: { user: { id: 'admin-1' } },
+    } as never);
+    vi.mocked(setAnalyticsOperationalEnabled).mockResolvedValue(effectiveState as never);
+    vi.mocked(recordAnalyticsGovernanceDecision).mockResolvedValue(effectiveState as never);
+  });
+
+  it('updates the kill switch through the audited control boundary and returns read-back state', async () => {
+    const response = await put({ key: 'analytics_enabled', value: 'true' });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ analyticsControl: effectiveState });
+    expect(setAnalyticsOperationalEnabled).toHaveBeenCalledWith({
+      enabled: true,
+      actorId: 'admin-1',
+      auditContext: { ipAddress: '127.0.0.1', userAgent: 'vitest' },
+    });
+  });
+
+  it('refuses enablement when the governance gate has not been recorded', async () => {
+    vi.mocked(setAnalyticsOperationalEnabled).mockRejectedValue(
+      new AnalyticsControlError('GOVERNANCE_REQUIRED' as never),
+    );
+
+    const response = await put({ key: 'analytics_enabled', value: true });
+
+    expect(response.status).toBe(409);
+    expect(recordAnalyticsGovernanceDecision).not.toHaveBeenCalled();
+  });
+
+  it('records a structured owner decision instead of accepting free-form JSON', async () => {
+    const decision = {
+      ownerRole: 'privacy_owner',
+      purpose: 'Measure product journeys.',
+      lawfulBasisOrConsent: 'Consent required.',
+      collectionNotice: 'Privacy notice.',
+      rawEventRetentionDays: 30,
+      aggregateRetentionDays: 365,
+      accessPolicy: 'Named owners only.',
+      deletionPolicy: 'Delete raw analytics only.',
+      withdrawalPolicy: 'Disable optional collection.',
+      approvedEventClasses: ['product_interaction'],
+    };
+
+    const response = await put({ key: 'analytics_governance_decision', value: decision });
+
+    expect(response.status).toBe(200);
+    expect(recordAnalyticsGovernanceDecision).toHaveBeenCalledWith({
+      decision,
+      actorId: 'admin-1',
+      auditContext: { ipAddress: '127.0.0.1', userAgent: 'vitest' },
+    });
+  });
+
+  it('rejects non-canonical switch values before storage', async () => {
+    const response = await put({ key: 'analytics_enabled', value: 'yes' });
+
+    expect(response.status).toBe(400);
+    expect(setAnalyticsOperationalEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/analytics.test.ts
+++ b/tests/api/analytics.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/lib/auth', () => ({ auth: vi.fn() }));
 vi.mock('@/lib/analytics', () => ({
-  isAnalyticsEnabled: vi.fn(),
+  isAnalyticsEventEnabled: vi.fn(),
   isPublishedAnalyticsTarget: vi.fn(),
   recordClientAnalyticsEvent: vi.fn(),
 }));
@@ -15,7 +15,7 @@ vi.mock('@/lib/rate-limit', () => ({
 }));
 
 import {
-  isAnalyticsEnabled,
+  isAnalyticsEventEnabled,
   isPublishedAnalyticsTarget,
   recordClientAnalyticsEvent,
 } from '@/lib/analytics';
@@ -49,25 +49,30 @@ describe('POST /api/analytics/events', () => {
       remaining: 99,
       resetTime: Date.now() + 60_000,
     });
-    vi.mocked(isAnalyticsEnabled).mockResolvedValue(true);
+    vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(true);
     vi.mocked(isPublishedAnalyticsTarget).mockResolvedValue(true);
     vi.mocked(recordClientAnalyticsEvent).mockResolvedValue(true);
     vi.mocked(auth).mockResolvedValue({ user: { id: 'user-1' } } as never);
   });
 
-  it('returns 204 without target lookup or identity work when analytics is disabled', async () => {
-    vi.mocked(isAnalyticsEnabled).mockResolvedValue(false);
+  it('returns 204 without target lookup or identity work when the event is disabled', async () => {
+    vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(false);
 
     const response = await post(validEvent);
 
     expect(response.status).toBe(204);
+    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('course_viewed');
     expect(isPublishedAnalyticsTarget).not.toHaveBeenCalled();
     expect(auth).not.toHaveBeenCalled();
     expect(recordClientAnalyticsEvent).not.toHaveBeenCalled();
   });
 
   it('rejects unknown events and arbitrary personal metadata', async () => {
-    const response = await post({ ...validEvent, eventName: 'purchase_completed', email: 'person@example.com' });
+    const response = await post({
+      ...validEvent,
+      eventName: 'purchase_completed',
+      email: 'person@example.com',
+    });
 
     expect(response.status).toBe(400);
     expect(recordClientAnalyticsEvent).not.toHaveBeenCalled();
@@ -99,6 +104,6 @@ describe('POST /api/analytics/events', () => {
     const response = await post(validEvent);
 
     expect(response.status).toBe(429);
-    expect(isAnalyticsEnabled).not.toHaveBeenCalled();
+    expect(isAnalyticsEventEnabled).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/analytics-control-revision.test.ts
+++ b/tests/lib/analytics-control-revision.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAnalyticsControlService,
+  type AnalyticsControlSnapshot,
+  type AnalyticsControlStore,
+  type AnalyticsControlWrite,
+  type AnalyticsGovernanceDecisionInput,
+} from '@/lib/analytics-control';
+
+class RevisionStore implements AnalyticsControlStore {
+  snapshot: AnalyticsControlSnapshot = { operational: null, governance: null };
+
+  async read() {
+    return structuredClone(this.snapshot);
+  }
+
+  async write(input: AnalyticsControlWrite) {
+    const record = { value: input.value, updatedAt: input.now };
+    if (input.key === 'analytics_enabled') this.snapshot.operational = record;
+    else this.snapshot.governance = record;
+  }
+}
+
+function decision(purpose: string): AnalyticsGovernanceDecisionInput {
+  return {
+    ownerRole: 'privacy_owner',
+    purpose,
+    lawfulBasisOrConsent: 'Consent required.',
+    collectionNotice: 'Privacy notice.',
+    rawEventRetentionDays: 30,
+    aggregateRetentionDays: 365,
+    accessPolicy: 'Named owners only.',
+    deletionPolicy: 'Delete expired raw analytics only.',
+    withdrawalPolicy: 'Disable optional collection.',
+    approvedEventClasses: ['product_interaction'],
+  };
+}
+
+describe('analytics control revision', () => {
+  it('changes when policy content changes at the same timestamp', async () => {
+    const store = new RevisionStore();
+    const fixedNow = new Date('2026-08-31T00:00:00.000Z');
+    const service = createAnalyticsControlService(store, { now: () => fixedNow });
+    const requestContext = {
+      actorId: 'admin-1',
+      auditContext: { ipAddress: null, userAgent: 'vitest' },
+    };
+
+    const first = await service.recordGovernanceDecision({
+      decision: decision('Measure product discovery.'),
+      ...requestContext,
+    });
+    const second = await service.recordGovernanceDecision({
+      decision: decision('Measure checkout readiness.'),
+      ...requestContext,
+    });
+
+    expect(second.revision).not.toBe(first.revision);
+  });
+});

--- a/tests/lib/analytics-control-service.test.ts
+++ b/tests/lib/analytics-control-service.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ANALYTICS_CONTROL_CACHE_MAX_AGE_MS,
+  AnalyticsControlError,
+  createAnalyticsControlService,
+  type AnalyticsControlSnapshot,
+  type AnalyticsControlStore,
+  type AnalyticsControlWrite,
+  type AnalyticsGovernanceDecisionInput,
+} from '@/lib/analytics-control';
+
+const auditContext = { ipAddress: '127.0.0.1', userAgent: 'vitest' };
+
+const governanceDecision: AnalyticsGovernanceDecisionInput = {
+  ownerRole: 'privacy_owner',
+  purpose: 'Measure whether published product journeys help visitors make informed choices.',
+  lawfulBasisOrConsent: 'Consent is required before optional collection.',
+  collectionNotice: 'The privacy notice describes optional product analytics.',
+  rawEventRetentionDays: 30,
+  aggregateRetentionDays: 365,
+  accessPolicy: 'Named product and privacy owners only.',
+  deletionPolicy: 'Delete expired raw events without deleting business records.',
+  withdrawalPolicy: 'Disable collection immediately and honor the published withdrawal path.',
+  approvedEventClasses: ['product_interaction'],
+};
+
+class MemoryAnalyticsControlStore implements AnalyticsControlStore {
+  snapshot: AnalyticsControlSnapshot = { operational: null, governance: null };
+  reads = 0;
+  writes: AnalyticsControlWrite[] = [];
+
+  async read(): Promise<AnalyticsControlSnapshot> {
+    this.reads += 1;
+    return structuredClone(this.snapshot);
+  }
+
+  async write(input: AnalyticsControlWrite): Promise<void> {
+    this.writes.push(structuredClone(input));
+    const record = { value: input.value, updatedAt: input.now };
+    if (input.key === 'analytics_enabled') this.snapshot.operational = record;
+    else this.snapshot.governance = record;
+  }
+}
+
+describe('analytics control service', () => {
+  it('defaults to disabled and refreshes cached state within the declared bound', async () => {
+    const store = new MemoryAnalyticsControlStore();
+    let now = new Date('2026-08-31T00:00:00.000Z');
+    const service = createAnalyticsControlService(store, { now: () => now });
+
+    const first = await service.getState();
+    await service.getState();
+
+    expect(first).toMatchObject({
+      operationalEnabled: false,
+      effectiveEnabled: false,
+      governanceApproved: false,
+      cacheMaxAgeMs: ANALYTICS_CONTROL_CACHE_MAX_AGE_MS,
+    });
+    expect(store.reads).toBe(1);
+
+    now = new Date(now.getTime() + ANALYTICS_CONTROL_CACHE_MAX_AGE_MS + 1);
+    await service.getState();
+    expect(store.reads).toBe(2);
+  });
+
+  it('rejects enabling before an owner records a complete governance decision', async () => {
+    const store = new MemoryAnalyticsControlStore();
+    const service = createAnalyticsControlService(store);
+
+    await expect(service.setOperationalEnabled({
+      enabled: true,
+      actorId: 'admin-1',
+      auditContext,
+    })).rejects.toMatchObject({ code: 'GOVERNANCE_REQUIRED' });
+
+    expect(store.writes).toHaveLength(0);
+  });
+
+  it('audits governance and switch changes, invalidates cache, and reads effective state back', async () => {
+    const store = new MemoryAnalyticsControlStore();
+    let now = new Date('2026-08-31T01:00:00.000Z');
+    const service = createAnalyticsControlService(store, { now: () => now });
+
+    const disabled = await service.getState();
+    await service.recordGovernanceDecision({
+      decision: governanceDecision,
+      actorId: 'admin-1',
+      auditContext,
+    });
+    now = new Date('2026-08-31T01:00:01.000Z');
+    const enabled = await service.setOperationalEnabled({
+      enabled: true,
+      actorId: 'admin-1',
+      auditContext,
+    });
+
+    expect(enabled).toMatchObject({
+      operationalEnabled: true,
+      governanceApproved: true,
+      effectiveEnabled: true,
+      effectiveEventClasses: ['product_interaction'],
+    });
+    expect(enabled.revision).not.toBe(disabled.revision);
+    expect(store.writes).toEqual([
+      expect.objectContaining({
+        key: 'analytics_governance_decision',
+        type: 'json',
+        actorId: 'admin-1',
+        auditContext,
+      }),
+      expect.objectContaining({
+        key: 'analytics_enabled',
+        value: 'true',
+        type: 'boolean',
+        actorId: 'admin-1',
+        auditContext,
+      }),
+    ]);
+    expect(store.reads).toBeGreaterThanOrEqual(4);
+
+    now = new Date('2026-08-31T01:00:02.000Z');
+    const stopped = await service.setOperationalEnabled({
+      enabled: false,
+      actorId: 'admin-1',
+      auditContext,
+    });
+    expect(stopped).toMatchObject({ operationalEnabled: false, effectiveEnabled: false });
+  });
+
+  it('applies independent governance gates per event class', async () => {
+    const store = new MemoryAnalyticsControlStore();
+    const service = createAnalyticsControlService(store);
+
+    await service.recordGovernanceDecision({
+      decision: governanceDecision,
+      actorId: 'admin-1',
+      auditContext,
+    });
+    await service.setOperationalEnabled({ enabled: true, actorId: 'admin-1', auditContext });
+
+    await expect(service.isEventEnabled('course_viewed')).resolves.toBe(true);
+    await expect(service.isEventEnabled('purchase_completed')).resolves.toBe(false);
+  });
+
+  it('rejects incomplete or extensible governance records', async () => {
+    const store = new MemoryAnalyticsControlStore();
+    const service = createAnalyticsControlService(store);
+
+    await expect(service.recordGovernanceDecision({
+      decision: { ...governanceDecision, arbitraryApproval: true } as AnalyticsGovernanceDecisionInput,
+      actorId: 'admin-1',
+      auditContext,
+    })).rejects.toBeInstanceOf(AnalyticsControlError);
+    expect(store.writes).toHaveLength(0);
+  });
+});

--- a/tests/lib/analytics-event-privacy-contract.test.ts
+++ b/tests/lib/analytics-event-privacy-contract.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clientAnalyticsEventSchema,
+  serverAnalyticsEventSchema,
+} from '@/lib/analytics-contract';
+
+describe('analytics privacy contracts', () => {
+  it('rejects prohibited client fields even when the base event is valid', () => {
+    for (const prohibited of [
+      { metadata: { campaign: 'anything' } },
+      { name: 'Person' },
+      { email: 'person@example.com' },
+      { ipAddress: '127.0.0.1' },
+      { userAgent: 'browser fingerprint' },
+      { url: 'https://example.com/course?email=person@example.com' },
+      { paymentPayload: { provider: 'secret' } },
+      { slipContent: 'base64-slip' },
+      { videoUrl: 'https://video.example/private' },
+    ]) {
+      expect(clientAnalyticsEventSchema.safeParse({
+        eventName: 'course_viewed',
+        courseId: 'course-1',
+        placement: 'course_detail',
+        ...prohibited,
+      }).success).toBe(false);
+    }
+  });
+
+  it('accepts only server event-specific identifiers', () => {
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'registration_completed',
+      userId: 'user-1',
+    }).success).toBe(true);
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'purchase_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+      paymentId: 'payment-1',
+    }).success).toBe(true);
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'free_enrollment_completed',
+      userId: 'user-1',
+      bundleId: 'bundle-1',
+    }).success).toBe(true);
+  });
+
+  it('rejects missing, conflicting, arbitrary, and prohibited server data', () => {
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'purchase_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+    }).success).toBe(false);
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'free_enrollment_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+      bundleId: 'bundle-1',
+    }).success).toBe(false);
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'registration_completed',
+      userId: 'user-1',
+      metadata: { anything: true },
+    }).success).toBe(false);
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'purchase_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+      paymentId: 'payment-1',
+      email: 'person@example.com',
+    }).success).toBe(false);
+  });
+});

--- a/tests/lib/analytics-retention.test.ts
+++ b/tests/lib/analytics-retention.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AnalyticsRetentionError,
+  createAnalyticsRetentionPolicy,
+  type AnalyticsRetentionStore,
+} from '@/lib/analytics-retention';
+
+class MemoryAnalyticsRetentionStore implements AnalyticsRetentionStore {
+  calls: Array<{ cutoff: Date; batchSize: number }> = [];
+
+  async deleteRawEventsBefore(cutoff: Date, batchSize: number): Promise<number> {
+    this.calls.push({ cutoff, batchSize });
+    return 7;
+  }
+}
+
+describe('analytics raw-event retention policy', () => {
+  it('deletes only through the raw analytics boundary using the approved cutoff', async () => {
+    const store = new MemoryAnalyticsRetentionStore();
+    const policy = createAnalyticsRetentionPolicy(store);
+
+    const result = await policy.deleteExpiredRawEvents({
+      now: new Date('2026-08-31T12:00:00.000Z'),
+      rawEventRetentionDays: 30,
+      batchSize: 500,
+    });
+
+    expect(result).toEqual({
+      cutoff: new Date('2026-08-01T12:00:00.000Z'),
+      deletedCount: 7,
+      batchSize: 500,
+    });
+    expect(store.calls).toEqual([{
+      cutoff: new Date('2026-08-01T12:00:00.000Z'),
+      batchSize: 500,
+    }]);
+  });
+
+  it('rejects unsafe retention windows and batch sizes before deletion', async () => {
+    const store = new MemoryAnalyticsRetentionStore();
+    const policy = createAnalyticsRetentionPolicy(store);
+
+    await expect(policy.deleteExpiredRawEvents({
+      now: new Date('2026-08-31T12:00:00.000Z'),
+      rawEventRetentionDays: 0,
+    })).rejects.toBeInstanceOf(AnalyticsRetentionError);
+    await expect(policy.deleteExpiredRawEvents({
+      now: new Date('2026-08-31T12:00:00.000Z'),
+      rawEventRetentionDays: 30,
+      batchSize: 50_000,
+    })).rejects.toBeInstanceOf(AnalyticsRetentionError);
+    expect(store.calls).toHaveLength(0);
+  });
+});

--- a/tests/lib/analytics-writer.test.ts
+++ b/tests/lib/analytics-writer.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { insert, insertValues } = vi.hoisted(() => {
+  const values = vi.fn();
+  return {
+    insertValues: values,
+    insert: vi.fn(() => ({ values })),
+  };
+});
+
+vi.mock('@/lib/analytics-control', () => ({
+  getAnalyticsControlState: vi.fn(),
+  isAnalyticsEventEnabled: vi.fn(),
+  resetAnalyticsControlCache: vi.fn(),
+}));
+vi.mock('@/lib/db', () => ({ db: { insert, select: vi.fn() } }));
+vi.mock('@/lib/db/safe-insert', () => ({ isDuplicateKeyError: vi.fn().mockReturnValue(false) }));
+vi.mock('@/lib/error-handler', () => ({ logEvent: vi.fn() }));
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import {
+  recordClientAnalyticsEvent,
+  recordServerAnalyticsEvent,
+} from '@/lib/analytics';
+
+describe('analytics writer boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(true);
+    insertValues.mockResolvedValue(undefined);
+  });
+
+  it('does not write when the operational or event-class gate is disabled', async () => {
+    vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(false);
+
+    await expect(recordClientAnalyticsEvent({
+      eventName: 'course_viewed',
+      courseId: 'course-1',
+      placement: 'course_detail',
+    }, 'user-1')).resolves.toBe(false);
+
+    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('course_viewed');
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('rejects runtime server payload extensions before checking the gate or writing', async () => {
+    await expect(recordServerAnalyticsEvent({
+      eventName: 'purchase_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+      paymentId: 'payment-1',
+      paymentPayload: { secret: true },
+    } as never)).resolves.toBe(false);
+
+    expect(isAnalyticsEventEnabled).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('stores only allow-listed fields with null network identifiers', async () => {
+    await expect(recordClientAnalyticsEvent({
+      eventName: 'course_viewed',
+      courseId: 'course-1',
+      placement: 'course_detail',
+    }, 'user-1')).resolves.toBe(true);
+
+    expect(insertValues).toHaveBeenCalledWith({
+      eventName: 'course_viewed',
+      source: 'client',
+      userId: 'user-1',
+      courseId: 'course-1',
+      bundleId: null,
+      paymentId: null,
+      metadata: JSON.stringify({ placement: 'course_detail' }),
+      ipAddress: null,
+      userAgent: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an audited analytics operational kill switch with a five-second cache bound, versioned read-back, and governance approval gate
- enforce strict client and server event contracts that reject arbitrary metadata and prohibited payload fields
- add a testable raw-event retention boundary that deletes only analytics events in bounded batches
- keep analytics disabled in application defaults, seed data, and production until an owner decision is recorded

## Verification

- npm run test -- --run (616 passed)
- npm run lint
- npx tsc --noEmit
- npm run check:admin-text
- npm run build
- npm run test:e2e:required (1 passed, local MySQL without Docker)
- git diff --check

## Deployment notes

- no database migration
- no UI changes
- no production data was read or changed
- the retention runner is available as an application boundary but is not scheduled by this PR

Closes #27
