### PR TITLE
feat(analytics): record eligible product exposures idempotently

### DIFF
--- a/docs/adr/0008-project-measurement-facts-with-idempotent-identities.md
+++ b/docs/adr/0008-project-measurement-facts-with-idempotent-identities.md
@@ -1,0 +1,5 @@
+# Project optional measurement facts with idempotent identities
+
+MilerDev will keep optional analytics as a projection that cannot change payment, enrollment, learning progress, or certificate truth. Product-exposure identities are random, short-lived, generated only after an eligible detail page commits in the browser, validated against server-side published and purchasable state, and persisted through an additive nullable idempotency identity; later authoritative domain milestones use a transactional outbox so domain commits never depend on analytics delivery.
+
+This keeps migrations backward-compatible with existing writers, makes browser retry and duplicate delivery safe, and allows analytics collection or projection to be disabled and rolled back without reversing business records.

--- a/drizzle/0015_bumpy_absorbing_man.sql
+++ b/drizzle/0015_bumpy_absorbing_man.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `analytics_events` ADD `exposure_id` varchar(36);--> statement-breakpoint
+ALTER TABLE `analytics_events` ADD CONSTRAINT `uq_analytics_exposure_id` UNIQUE(`exposure_id`);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2858 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "22e458f6-197f-4fdc-b281-801462745c43",
+  "prevId": "53df23b7-6618-4b02-a3d8-1303f42c517d",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_accounts_provider_identity": {
+          "name": "uq_accounts_provider_identity",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_id": {
+          "name": "accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "affiliate_banners": {
+      "name": "affiliate_banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "affiliate_banners_id": {
+          "name": "affiliate_banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exposure_id": {
+          "name": "exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_analytics_exposure_id": {
+          "name": "uq_analytics_exposure_id",
+          "columns": [
+            "exposure_id"
+          ],
+          "isUnique": true
+        },
+        "idx_analytics_event_name": {
+          "name": "idx_analytics_event_name",
+          "columns": [
+            "event_name"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_created_at": {
+          "name": "idx_analytics_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_course_id": {
+          "name": "idx_analytics_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_bundle_id": {
+          "name": "idx_analytics_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_payment_id": {
+          "name": "idx_analytics_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "uq_analytics_event_payment": {
+          "name": "uq_analytics_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_course_id_courses_id_fk": {
+          "name": "analytics_events_course_id_courses_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_bundle_id_bundles_id_fk": {
+          "name": "analytics_events_bundle_id_bundles_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_payment_id_payments_id_fk": {
+          "name": "analytics_events_payment_id_payments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analytics_events_id": {
+          "name": "analytics_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "target_role": {
+          "name": "target_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "announcements_id": {
+          "name": "announcements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_post_tags": {
+      "name": "blog_post_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_post_tags_post_id_blog_posts_id_fk": {
+          "name": "blog_post_tags_post_id_blog_posts_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "blog_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blog_post_tags_tag_id_tags_id_fk": {
+          "name": "blog_post_tags_tag_id_tags_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_post_tags_id": {
+          "name": "blog_post_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_posts": {
+      "name": "blog_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_blog_posts_status": {
+          "name": "idx_blog_posts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_blog_posts_published_at": {
+          "name": "idx_blog_posts_published_at",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_posts_author_id_users_id_fk": {
+          "name": "blog_posts_author_id_users_id_fk",
+          "tableFrom": "blog_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_posts_id": {
+          "name": "blog_posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "blog_posts_slug_unique": {
+          "name": "blog_posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "bundle_courses": {
+      "name": "bundle_courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_bundle_courses_bundle_id": {
+          "name": "idx_bundle_courses_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bundle_courses_bundle_id_bundles_id_fk": {
+          "name": "bundle_courses_bundle_id_bundles_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_courses_course_id_courses_id_fk": {
+          "name": "bundle_courses_course_id_courses_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_courses_id": {
+          "name": "bundle_courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "bundles": {
+      "name": "bundles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "bundles_id": {
+          "name": "bundles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "bundles_slug_unique": {
+          "name": "bundles_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "certificate_code": {
+          "name": "certificate_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_name": {
+          "name": "recipient_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_title": {
+          "name": "course_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_theme": {
+          "name": "certificate_theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_certificates_user_id": {
+          "name": "idx_certificates_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificates_course_id_courses_id_fk": {
+          "name": "certificates_course_id_courses_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "certificates_certificate_code_unique": {
+          "name": "certificates_certificate_code_unique",
+          "columns": [
+            "certificate_code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "coupon_usages": {
+      "name": "coupon_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_coupon_user_course": {
+          "name": "uq_coupon_user_course",
+          "columns": [
+            "coupon_id",
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coupon_usages_coupon_id_coupons_id_fk": {
+          "name": "coupon_usages_coupon_id_coupons_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_user_id_users_id_fk": {
+          "name": "coupon_usages_user_id_users_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_course_id_courses_id_fk": {
+          "name": "coupon_usages_course_id_courses_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupon_usages_id": {
+          "name": "coupon_usages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coupons": {
+      "name": "coupons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_purchase": {
+          "name": "min_purchase",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "max_discount": {
+          "name": "max_discount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "per_user_limit": {
+          "name": "per_user_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_course_id_courses_id_fk": {
+          "name": "coupons_course_id_courses_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupons_id": {
+          "name": "coupons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "coupons_code_unique": {
+          "name": "coupons_code_unique",
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "course_tags": {
+      "name": "course_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_tags_course_id_courses_id_fk": {
+          "name": "course_tags_course_id_courses_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_tags_tag_id_tags_id_fk": {
+          "name": "course_tags_tag_id_tags_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_tags_id": {
+          "name": "course_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "courses": {
+      "name": "courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_color": {
+          "name": "certificate_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#2563eb'"
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_badge": {
+          "name": "certificate_badge",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_video_url": {
+          "name": "preview_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_price": {
+          "name": "promo_price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_starts_at": {
+          "name": "promo_starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_ends_at": {
+          "name": "promo_ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "courses_instructor_id_users_id_fk": {
+          "name": "courses_instructor_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "courses_id": {
+          "name": "courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "courses_slug_unique": {
+          "name": "courses_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "enrollments": {
+      "name": "enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_enrollment_user_course": {
+          "name": "uq_enrollment_user_course",
+          "columns": [
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "enrollments_user_id_users_id_fk": {
+          "name": "enrollments_user_id_users_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollments_course_id_courses_id_fk": {
+          "name": "enrollments_course_id_courses_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "enrollments_id": {
+          "name": "enrollments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lesson_progress": {
+      "name": "lesson_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "watch_time_seconds": {
+          "name": "watch_time_seconds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_watched_at": {
+          "name": "last_watched_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lesson_progress_user_id": {
+          "name": "idx_lesson_progress_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lesson_progress_lesson_id": {
+          "name": "idx_lesson_progress_lesson_id",
+          "columns": [
+            "lesson_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lesson_progress_user_id_users_id_fk": {
+          "name": "lesson_progress_user_id_users_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lesson_progress_id": {
+          "name": "lesson_progress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lessons": {
+      "name": "lessons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_duration": {
+          "name": "video_duration",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_free_preview": {
+          "name": "is_free_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lessons_course_id": {
+          "name": "idx_lessons_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lessons_course_id_courses_id_fk": {
+          "name": "lessons_course_id_courses_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lessons_id": {
+          "name": "lessons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_users_id_fk": {
+          "name": "media_uploaded_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_id": {
+          "name": "media_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notifications_id": {
+          "name": "notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "payments": {
+      "name": "payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'THB'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slip_url": {
+          "name": "slip_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promptpay_trans_ref": {
+          "name": "promptpay_trans_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_title": {
+          "name": "item_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_payments_user_id": {
+          "name": "idx_payments_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_created_at": {
+          "name": "idx_payments_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_status": {
+          "name": "idx_payments_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_coupon_id": {
+          "name": "idx_payments_coupon_id",
+          "columns": [
+            "coupon_id"
+          ],
+          "isUnique": false
+        },
+        "uq_payments_promptpay_trans_ref": {
+          "name": "uq_payments_promptpay_trans_ref",
+          "columns": [
+            "promptpay_trans_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_course_id_courses_id_fk": {
+          "name": "payments_course_id_courses_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_bundle_id_bundles_id_fk": {
+          "name": "payments_bundle_id_bundles_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "payments_id": {
+          "name": "payments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_buckets_reset_at": {
+          "name": "idx_rate_limit_buckets_reset_at",
+          "columns": [
+            "reset_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_hash": {
+          "name": "rate_limit_buckets_key_hash",
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reviews_course_hidden": {
+          "name": "idx_reviews_course_hidden",
+          "columns": [
+            "course_id",
+            "is_hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_course_id_courses_id_fk": {
+          "name": "reviews_course_id_courses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reviews_id": {
+          "name": "reviews_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'string'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id": {
+          "name": "settings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "stripe_events": {
+      "name": "stripe_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_stripe_events_payment_id": {
+          "name": "idx_stripe_events_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_events_type": {
+          "name": "idx_stripe_events_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_payment_id_payments_id_fk": {
+          "name": "stripe_events_payment_id_payments_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_id": {
+          "name": "stripe_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tags_id": {
+          "name": "tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'student'"
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_expires": {
+          "name": "reset_expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_users_deactivated_at": {
+          "name": "idx_users_deactivated_at",
+          "columns": [
+            "deactivated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1787496456812,
       "tag": "0014_green_epoch",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "5",
+      "when": 1788156667147,
+      "tag": "0015_bumpy_absorbing_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/analytics/events/route.ts
+++ b/src/app/api/analytics/events/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from 'next/server';
 
-import { clientAnalyticsEventSchema } from '@/lib/analytics-contract';
 import {
   isAnalyticsEventEnabled,
   isPublishedAnalyticsTarget,
   recordClientAnalyticsEvent,
 } from '@/lib/analytics';
+import { clientAnalyticsEventSchema } from '@/lib/analytics-contract';
 import { auth } from '@/lib/auth';
 import { logEvent } from '@/lib/error-handler';
+import { measurementRecorder } from '@/lib/measurement-recorder';
 import { checkRateLimit, getClientIP, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
 
 export async function POST(request: Request) {
@@ -28,6 +29,24 @@ export async function POST(request: Request) {
   }
 
   try {
+    if (parsed.data.eventName === 'course_viewed' || parsed.data.eventName === 'bundle_viewed') {
+      const productType = parsed.data.eventName === 'course_viewed' ? 'course' : 'bundle';
+      const productId = productType === 'course' ? parsed.data.courseId : parsed.data.bundleId;
+      if (!parsed.data.exposureId || !productId) {
+        return NextResponse.json({ error: 'Invalid analytics event' }, { status: 400 });
+      }
+
+      const result = await measurementRecorder.recordProductExposure({
+        exposureId: parsed.data.exposureId,
+        productType,
+        productId,
+      });
+      if (result.status === 'ineligible') {
+        return NextResponse.json({ error: 'Analytics target not found' }, { status: 404 });
+      }
+      return new NextResponse(null, { status: 204 });
+    }
+
     if (!(await isAnalyticsEventEnabled(parsed.data.eventName))) {
       return new NextResponse(null, { status: 204 });
     }

--- a/src/app/bundles/[slug]/page.tsx
+++ b/src/app/bundles/[slug]/page.tsx
@@ -192,7 +192,7 @@ export default async function BundleDetailPage({ params }: Props) {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }} />
       <Navbar />
       <main className="min-h-screen bg-background text-foreground">
-        <AnalyticsViewEvent event={{ eventName: 'bundle_viewed', bundleId: bundle.id, placement: 'bundle_detail' }} />
+        <AnalyticsViewEvent productType="bundle" productId={bundle.id} />
         <header className="border-b bg-muted/30">
           <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
             <nav className="mb-10 flex flex-wrap items-center gap-2 text-sm text-muted-foreground [&_a:hover]:text-foreground" aria-label={'เส้นทางนำทาง'}>

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -227,7 +227,7 @@ export default async function CourseDetailPage({ params }: Props) {
 
       <CourseDetailProvider>
         <main className="min-h-screen bg-background text-foreground">
-          <AnalyticsViewEvent event={{ eventName: 'course_viewed', courseId: course.id, placement: 'course_detail' }} />
+          <AnalyticsViewEvent productType="course" productId={course.id} />
 
           <header className="bg-[radial-gradient(circle_at_12%_8%,var(--color-accent-soft),transparent_36%),linear-gradient(180deg,var(--academy-canvas),var(--background))]">
             <div className="mx-auto grid max-w-7xl gap-10 px-4 py-12 sm:px-6 lg:grid-cols-[minmax(0,1fr)_25rem] lg:gap-14 lg:px-8 lg:py-20">

--- a/src/components/analytics/AnalyticsViewEvent.tsx
+++ b/src/components/analytics/AnalyticsViewEvent.tsx
@@ -1,14 +1,50 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
+import {
+  createProductExposureId,
+  trackClientAnalyticsEvent,
+} from '@/components/analytics/analytics-client';
 import type { ClientAnalyticsEvent } from '@/lib/analytics-contract';
-import { trackClientAnalyticsEvent } from '@/components/analytics/analytics-client';
 
-export default function AnalyticsViewEvent({ event }: { event: ClientAnalyticsEvent }) {
+type AnalyticsViewEventProps = {
+  productType: 'course' | 'bundle';
+  productId: string;
+};
+
+export default function AnalyticsViewEvent({
+  productType,
+  productId,
+}: AnalyticsViewEventProps) {
+  const exposureRef = useRef<{ key: string; id: string } | null>(null);
+  const deliveredKeyRef = useRef<string | null>(null);
+
   useEffect(() => {
-    trackClientAnalyticsEvent(event, { dedupeInSession: true });
-  }, [event]);
+    const key = `${productType}:${productId}`;
+    if (deliveredKeyRef.current === key) return;
+
+    if (exposureRef.current?.key !== key) {
+      exposureRef.current = { key, id: createProductExposureId() };
+    }
+
+    const event: ClientAnalyticsEvent = productType === 'course'
+      ? {
+          eventName: 'course_viewed',
+          exposureId: exposureRef.current.id,
+          courseId: productId,
+          placement: 'course_detail',
+        }
+      : {
+          eventName: 'bundle_viewed',
+          exposureId: exposureRef.current.id,
+          bundleId: productId,
+          placement: 'bundle_detail',
+        };
+
+    deliveredKeyRef.current = key;
+    trackClientAnalyticsEvent(event);
+  }, [productId, productType]);
 
   return null;
 }

--- a/src/components/analytics/analytics-client.ts
+++ b/src/components/analytics/analytics-client.ts
@@ -2,35 +2,23 @@
 
 import type { ClientAnalyticsEvent } from '@/lib/analytics-contract';
 
-function eventDedupeKey(event: ClientAnalyticsEvent): string {
-  return [
-    'milerdev-analytics',
-    event.eventName,
-    event.courseId ?? '',
-    event.bundleId ?? '',
-    event.placement,
-  ].join(':');
+export function createProductExposureId(
+  randomUUID: () => string = () => crypto.randomUUID(),
+): string {
+  return randomUUID();
 }
 
-export function trackClientAnalyticsEvent(
-  event: ClientAnalyticsEvent,
-  options: { dedupeInSession?: boolean } = {},
-): void {
+export function trackClientAnalyticsEvent(event: ClientAnalyticsEvent): void {
   if (typeof window === 'undefined') return;
 
-  if (options.dedupeInSession) {
-    const key = eventDedupeKey(event);
-    try {
-      if (window.sessionStorage.getItem(key)) return;
-      window.sessionStorage.setItem(key, '1');
-    } catch {
-      // Analytics remains best-effort when browser storage is unavailable.
-    }
-  }
-
   const body = JSON.stringify(event);
-  if (typeof navigator.sendBeacon === 'function') {
-    navigator.sendBeacon('/api/analytics/events', new Blob([body], { type: 'application/json' }));
+  if (
+    typeof navigator.sendBeacon === 'function'
+    && navigator.sendBeacon(
+      '/api/analytics/events',
+      new Blob([body], { type: 'application/json' }),
+    )
+  ) {
     return;
   }
 

--- a/src/lib/analytics-contract.ts
+++ b/src/lib/analytics-contract.ts
@@ -22,9 +22,13 @@ export const analyticsPlacementSchema = z.enum([
 ]);
 
 const analyticsIdSchema = z.string().trim().min(1).max(36);
+export const analyticsExposureIdSchema = z.string().uuid().regex(
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+);
 
 export const clientAnalyticsEventSchema = z.object({
   eventName: z.enum(CLIENT_ANALYTICS_EVENT_NAMES),
+  exposureId: analyticsExposureIdSchema.optional(),
   courseId: analyticsIdSchema.optional(),
   bundleId: analyticsIdSchema.optional(),
   placement: analyticsPlacementSchema,
@@ -33,27 +37,31 @@ export const clientAnalyticsEventSchema = z.object({
   const hasBundle = Boolean(value.bundleId);
 
   if (value.eventName === 'home_primary_cta_clicked') {
-    if (value.placement !== 'hero' || hasCourse || hasBundle) {
+    if (value.placement !== 'hero' || value.exposureId || hasCourse || hasBundle) {
       context.addIssue({ code: 'custom', message: 'Invalid Home CTA event' });
     }
     return;
   }
 
   if (value.eventName === 'course_viewed') {
-    if (!hasCourse || hasBundle || value.placement !== 'course_detail') {
+    if (!value.exposureId || !hasCourse || hasBundle || value.placement !== 'course_detail') {
       context.addIssue({ code: 'custom', message: 'Invalid Course view event' });
     }
     return;
   }
 
   if (value.eventName === 'bundle_viewed') {
-    if (!hasBundle || hasCourse || value.placement !== 'bundle_detail') {
+    if (!value.exposureId || !hasBundle || hasCourse || value.placement !== 'bundle_detail') {
       context.addIssue({ code: 'custom', message: 'Invalid Bundle view event' });
     }
     return;
   }
 
-  if (hasCourse === hasBundle || !['course_detail', 'bundle_detail'].includes(value.placement)) {
+  if (
+    value.exposureId
+    || hasCourse === hasBundle
+    || !['course_detail', 'bundle_detail'].includes(value.placement)
+  ) {
     context.addIssue({ code: 'custom', message: 'Checkout events require exactly one product' });
   }
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -63,6 +63,9 @@ export async function recordClientAnalyticsEvent(
 ): Promise<boolean> {
   const parsed = clientAnalyticsEventSchema.safeParse(input);
   if (!parsed.success) return false;
+  if (parsed.data.eventName === 'course_viewed' || parsed.data.eventName === 'bundle_viewed') {
+    return false;
+  }
 
   return insertAnalyticsEvent({
     ...parsed.data,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -594,6 +594,7 @@ export const certificatesRelations = relations(certificates, ({ one }) => ({
 export const analyticsEvents = mysqlTable('analytics_events', {
     id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => createId()),
     eventName: varchar('event_name', { length: 100 }).notNull(),
+    exposureId: varchar('exposure_id', { length: 36 }),
     userId: varchar('user_id', { length: 36 }).references(() => users.id, { onDelete: 'set null' }),
     courseId: varchar('course_id', { length: 36 }).references(() => courses.id, { onDelete: 'set null' }),
     bundleId: varchar('bundle_id', { length: 36 }).references(() => bundles.id, { onDelete: 'set null' }),
@@ -604,6 +605,7 @@ export const analyticsEvents = mysqlTable('analytics_events', {
     userAgent: text('user_agent'),
     createdAt: datetime('created_at').$defaultFn(() => new Date()),
 }, (table) => [
+    uniqueIndex('uq_analytics_exposure_id').on(table.exposureId),
     index('idx_analytics_event_name').on(table.eventName),
     index('idx_analytics_created_at').on(table.createdAt),
     index('idx_analytics_course_id').on(table.courseId),

--- a/src/lib/measurement-recorder.ts
+++ b/src/lib/measurement-recorder.ts
@@ -1,0 +1,186 @@
+import { count, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import { requireReadyBundleCourses } from '@/lib/bundle-commerce';
+import { requireCourseHasLessons } from '@/lib/course-availability';
+import { db } from '@/lib/db';
+import {
+  analyticsEvents,
+  bundleCourses,
+  bundles,
+  courses,
+  lessons,
+} from '@/lib/db/schema';
+import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+
+export type ProductType = 'course' | 'bundle';
+type ProductStatus = 'draft' | 'published' | 'archived';
+
+const productExposureFactSchema = z.object({
+  exposureId: z.string().uuid().regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  ),
+  productType: z.enum(['course', 'bundle']),
+  productId: z.string().trim().min(1).max(36),
+}).strict();
+
+export type ProductEligibility =
+  | {
+    productType: 'course';
+    productId: string;
+    status: ProductStatus;
+    lessonCount: number;
+  }
+  | {
+    productType: 'bundle';
+    productId: string;
+    status: ProductStatus;
+    courses: Array<{
+      id: string;
+      status: ProductStatus;
+      lessonCount: number;
+    }>;
+  };
+
+export type ProductExposureRow = {
+  exposureId: string;
+  eventName: 'course_viewed' | 'bundle_viewed';
+  courseId: string | null;
+  bundleId: string | null;
+  placement: 'course_detail' | 'bundle_detail';
+};
+
+export interface MeasurementStore {
+  readProductEligibility(
+    productType: ProductType,
+    productId: string,
+  ): Promise<ProductEligibility | null>;
+  insertProductExposure(row: ProductExposureRow): Promise<'inserted' | 'duplicate'>;
+}
+
+export interface MeasurementRecorder {
+  recordProductExposure(fact: {
+    exposureId: string;
+    productType: ProductType;
+    productId: string;
+  }): Promise<{ status: 'recorded' | 'duplicate' | 'disabled' | 'ineligible' }>;
+}
+
+export class MeasurementRecorderError extends Error {
+  constructor(readonly code: 'INVALID_FACT') {
+    super(code);
+    this.name = 'MeasurementRecorderError';
+  }
+}
+
+function isEligibleProduct(eligibility: ProductEligibility | null): boolean {
+  if (!eligibility || eligibility.status !== 'published') return false;
+
+  try {
+    if (eligibility.productType === 'course') {
+      requireCourseHasLessons(eligibility.lessonCount);
+    } else {
+      requireReadyBundleCourses(eligibility.courses);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createMeasurementRecorder(input: {
+  store: MeasurementStore;
+  isEventEnabled(eventName: ProductExposureRow['eventName']): Promise<boolean>;
+}): MeasurementRecorder {
+  return {
+    async recordProductExposure(fact) {
+      const parsed = productExposureFactSchema.safeParse(fact);
+      if (!parsed.success) throw new MeasurementRecorderError('INVALID_FACT');
+
+      const eventName = parsed.data.productType === 'course' ? 'course_viewed' : 'bundle_viewed';
+      if (!(await input.isEventEnabled(eventName))) return { status: 'disabled' };
+
+      const eligibility = await input.store.readProductEligibility(
+        parsed.data.productType,
+        parsed.data.productId,
+      );
+      if (!isEligibleProduct(eligibility)) return { status: 'ineligible' };
+
+      const inserted = await input.store.insertProductExposure({
+        exposureId: parsed.data.exposureId,
+        eventName,
+        courseId: parsed.data.productType === 'course' ? parsed.data.productId : null,
+        bundleId: parsed.data.productType === 'bundle' ? parsed.data.productId : null,
+        placement: parsed.data.productType === 'course' ? 'course_detail' : 'bundle_detail',
+      });
+      return { status: inserted === 'inserted' ? 'recorded' : 'duplicate' };
+    },
+  };
+}
+
+const drizzleMeasurementStore: MeasurementStore = {
+  async readProductEligibility(productType, productId) {
+    if (productType === 'course') {
+      const [row] = await db
+        .select({
+          productId: courses.id,
+          status: courses.status,
+          lessonCount: count(lessons.id),
+        })
+        .from(courses)
+        .leftJoin(lessons, eq(lessons.courseId, courses.id))
+        .where(eq(courses.id, productId))
+        .groupBy(courses.id, courses.status)
+        .limit(1);
+      return row ? { productType: 'course', ...row } : null;
+    }
+
+    const [bundleRows, courseRows] = await Promise.all([
+      db
+        .select({ productId: bundles.id, status: bundles.status })
+        .from(bundles)
+        .where(eq(bundles.id, productId))
+        .limit(1),
+      db
+        .select({
+          id: courses.id,
+          status: courses.status,
+          lessonCount: count(lessons.id),
+        })
+        .from(bundleCourses)
+        .innerJoin(courses, eq(bundleCourses.courseId, courses.id))
+        .leftJoin(lessons, eq(lessons.courseId, courses.id))
+        .where(eq(bundleCourses.bundleId, productId))
+        .groupBy(courses.id, courses.status),
+    ]);
+    const bundle = bundleRows[0];
+    return bundle ? { productType: 'bundle', ...bundle, courses: courseRows } : null;
+  },
+
+  async insertProductExposure(row) {
+    try {
+      await db.insert(analyticsEvents).values({
+        exposureId: row.exposureId,
+        eventName: row.eventName,
+        source: 'client',
+        userId: null,
+        courseId: row.courseId,
+        bundleId: row.bundleId,
+        paymentId: null,
+        metadata: JSON.stringify({ placement: row.placement }),
+        ipAddress: null,
+        userAgent: null,
+      });
+      return 'inserted';
+    } catch (error) {
+      if (isDuplicateKeyError(error)) return 'duplicate';
+      throw error;
+    }
+  },
+};
+
+export const measurementRecorder = createMeasurementRecorder({
+  store: drizzleMeasurementStore,
+  isEventEnabled: isAnalyticsEventEnabled,
+});

--- a/tests/api/analytics.test.ts
+++ b/tests/api/analytics.test.ts
@@ -6,6 +6,9 @@ vi.mock('@/lib/analytics', () => ({
   isPublishedAnalyticsTarget: vi.fn(),
   recordClientAnalyticsEvent: vi.fn(),
 }));
+vi.mock('@/lib/measurement-recorder', () => ({
+  measurementRecorder: { recordProductExposure: vi.fn() },
+}));
 vi.mock('@/lib/error-handler', () => ({ logEvent: vi.fn() }));
 vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
@@ -23,7 +26,7 @@ import { auth } from '@/lib/auth';
 import { checkRateLimit } from '@/lib/rate-limit';
 
 const validEvent = {
-  eventName: 'course_viewed',
+  eventName: 'checkout_opened',
   courseId: 'course-1',
   placement: 'course_detail',
 };
@@ -61,7 +64,7 @@ describe('POST /api/analytics/events', () => {
     const response = await post(validEvent);
 
     expect(response.status).toBe(204);
-    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('course_viewed');
+    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('checkout_opened');
     expect(isPublishedAnalyticsTarget).not.toHaveBeenCalled();
     expect(auth).not.toHaveBeenCalled();
     expect(recordClientAnalyticsEvent).not.toHaveBeenCalled();

--- a/tests/api/product-exposure.test.ts
+++ b/tests/api/product-exposure.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/analytics', () => ({
+  isAnalyticsEventEnabled: vi.fn().mockResolvedValue(true),
+  isPublishedAnalyticsTarget: vi.fn().mockResolvedValue(true),
+  recordClientAnalyticsEvent: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@/lib/measurement-recorder', () => ({
+  measurementRecorder: { recordProductExposure: vi.fn() },
+}));
+vi.mock('@/lib/error-handler', () => ({ logEvent: vi.fn() }));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockReturnValue({
+    success: true,
+    remaining: 99,
+    resetTime: Date.now() + 60_000,
+  }),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  rateLimits: { general: { maxRequests: 100, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(),
+}));
+
+import { recordClientAnalyticsEvent } from '@/lib/analytics';
+import { auth } from '@/lib/auth';
+import { measurementRecorder } from '@/lib/measurement-recorder';
+
+const exposure = {
+  eventName: 'course_viewed',
+  exposureId: '11111111-1111-4111-8111-111111111111',
+  courseId: 'course-1',
+  placement: 'course_detail',
+};
+
+async function post(body: unknown) {
+  const { POST } = await import('@/app/api/analytics/events/route');
+  return POST(new Request('http://localhost/api/analytics/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('eligible product exposure API contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(measurementRecorder.recordProductExposure).mockResolvedValue({ status: 'recorded' });
+  });
+
+  it('records a Course exposure without optional user identity lookup or the legacy writer', async () => {
+    const response = await post(exposure);
+
+    expect(response.status).toBe(204);
+    expect(measurementRecorder.recordProductExposure).toHaveBeenCalledWith({
+      exposureId: exposure.exposureId,
+      productType: 'course',
+      productId: 'course-1',
+    });
+    expect(auth).not.toHaveBeenCalled();
+    expect(recordClientAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not count an ineligible, missing, or invalid product target', async () => {
+    vi.mocked(measurementRecorder.recordProductExposure).mockResolvedValue({ status: 'ineligible' });
+
+    const response = await post(exposure);
+
+    expect(response.status).toBe(404);
+    expect(auth).not.toHaveBeenCalled();
+    expect(recordClientAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  it('accepts delivery without identity or target work when analytics is disabled', async () => {
+    vi.mocked(measurementRecorder.recordProductExposure).mockResolvedValue({ status: 'disabled' });
+
+    const response = await post(exposure);
+
+    expect(response.status).toBe(204);
+    expect(auth).not.toHaveBeenCalled();
+    expect(recordClientAnalyticsEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/analytics-view-event.test.tsx
+++ b/tests/components/analytics-view-event.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createProductExposureId, trackClientAnalyticsEvent } = vi.hoisted(() => ({
+  createProductExposureId: vi.fn(),
+  trackClientAnalyticsEvent: vi.fn(),
+}));
+
+vi.mock('@/components/analytics/analytics-client', () => ({
+  createProductExposureId,
+  trackClientAnalyticsEvent,
+}));
+
+import AnalyticsViewEvent from '@/components/analytics/AnalyticsViewEvent';
+
+describe('AnalyticsViewEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createProductExposureId
+      .mockReturnValueOnce('123e4567-e89b-42d3-a456-426614174000')
+      .mockReturnValueOnce('123e4567-e89b-42d3-b456-426614174001');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not create or deliver an exposure during server rendering', () => {
+    renderToString(<AnalyticsViewEvent productType="course" productId="course-1" />);
+
+    expect(createProductExposureId).not.toHaveBeenCalled();
+    expect(trackClientAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  it('creates one random identity after commit and reuses it across rerenders', async () => {
+    const view = render(<AnalyticsViewEvent productType="course" productId="course-1" />);
+
+    await waitFor(() => expect(trackClientAnalyticsEvent).toHaveBeenCalledWith({
+      eventName: 'course_viewed',
+      courseId: 'course-1',
+      placement: 'course_detail',
+      exposureId: '123e4567-e89b-42d3-a456-426614174000',
+    }));
+
+    view.rerender(<AnalyticsViewEvent productType="course" productId="course-1" />);
+
+    expect(createProductExposureId).toHaveBeenCalledTimes(1);
+    expect(trackClientAnalyticsEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/lib/analytics-client.test.ts
+++ b/tests/lib/analytics-client.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createProductExposureId,
+  trackClientAnalyticsEvent,
+} from '@/components/analytics/analytics-client';
+
+const event = {
+  eventName: 'course_viewed' as const,
+  courseId: 'course-1',
+  placement: 'course_detail' as const,
+  exposureId: '123e4567-e89b-42d3-a456-426614174000',
+};
+
+describe('analytics browser delivery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('creates the exposure identity from browser cryptographic randomness', () => {
+    const randomUUID = vi.fn(() => '123e4567-e89b-42d3-a456-426614174000');
+
+    expect(createProductExposureId(randomUUID)).toBe('123e4567-e89b-42d3-a456-426614174000');
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it('uses Beacon when the browser accepts the payload', () => {
+    const sendBeacon = vi.fn(() => true);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('navigator', { sendBeacon });
+    vi.stubGlobal('fetch', fetchMock);
+
+    trackClientAnalyticsEvent(event);
+
+    expect(sendBeacon).toHaveBeenCalledWith(
+      '/api/analytics/events',
+      expect.any(Blob),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to keepalive fetch when Beacon rejects the payload', () => {
+    const sendBeacon = vi.fn(() => false);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('navigator', { sendBeacon });
+    vi.stubGlobal('fetch', fetchMock);
+
+    trackClientAnalyticsEvent(event);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/analytics/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(event),
+      keepalive: true,
+    });
+  });
+});

--- a/tests/lib/analytics-contract.test.ts
+++ b/tests/lib/analytics-contract.test.ts
@@ -2,15 +2,19 @@ import { describe, expect, it } from 'vitest';
 
 import { clientAnalyticsEventSchema } from '@/lib/analytics-contract';
 
+const exposureId = '11111111-1111-4111-8111-111111111111';
+
 describe('client analytics event contract', () => {
   it('accepts only the allowed target shape for Course and Bundle events', () => {
     expect(clientAnalyticsEventSchema.safeParse({
       eventName: 'course_viewed',
+      exposureId,
       courseId: 'course-1',
       placement: 'course_detail',
     }).success).toBe(true);
     expect(clientAnalyticsEventSchema.safeParse({
       eventName: 'bundle_viewed',
+      exposureId,
       bundleId: 'bundle-1',
       placement: 'bundle_detail',
     }).success).toBe(true);
@@ -18,6 +22,26 @@ describe('client analytics event contract', () => {
       eventName: 'checkout_opened',
       courseId: 'course-1',
       bundleId: 'bundle-1',
+      placement: 'course_detail',
+    }).success).toBe(false);
+  });
+
+  it('requires a random UUIDv4 identity only for product views', () => {
+    expect(clientAnalyticsEventSchema.safeParse({
+      eventName: 'course_viewed',
+      courseId: 'course-1',
+      placement: 'course_detail',
+    }).success).toBe(false);
+    expect(clientAnalyticsEventSchema.safeParse({
+      eventName: 'bundle_viewed',
+      exposureId: 'user-1:bundle-1',
+      bundleId: 'bundle-1',
+      placement: 'bundle_detail',
+    }).success).toBe(false);
+    expect(clientAnalyticsEventSchema.safeParse({
+      eventName: 'checkout_opened',
+      exposureId,
+      courseId: 'course-1',
       placement: 'course_detail',
     }).success).toBe(false);
   });
@@ -30,6 +54,7 @@ describe('client analytics event contract', () => {
     }).success).toBe(false);
     expect(clientAnalyticsEventSchema.safeParse({
       eventName: 'course_viewed',
+      exposureId,
       courseId: 'course-1',
       placement: 'course_detail',
       email: 'learner@example.com',

--- a/tests/lib/analytics-event-privacy-contract.test.ts
+++ b/tests/lib/analytics-event-privacy-contract.test.ts
@@ -20,6 +20,7 @@ describe('analytics privacy contracts', () => {
     ]) {
       expect(clientAnalyticsEventSchema.safeParse({
         eventName: 'course_viewed',
+        exposureId: '11111111-1111-4111-8111-111111111111',
         courseId: 'course-1',
         placement: 'course_detail',
         ...prohibited,

--- a/tests/lib/analytics-writer.test.ts
+++ b/tests/lib/analytics-writer.test.ts
@@ -23,6 +23,12 @@ import {
   recordServerAnalyticsEvent,
 } from '@/lib/analytics';
 
+const checkoutEvent = {
+  eventName: 'checkout_opened' as const,
+  courseId: 'course-1',
+  placement: 'course_detail' as const,
+};
+
 describe('analytics writer boundary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -33,13 +39,21 @@ describe('analytics writer boundary', () => {
   it('does not write when the operational or event-class gate is disabled', async () => {
     vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(false);
 
+    await expect(recordClientAnalyticsEvent(checkoutEvent, 'user-1')).resolves.toBe(false);
+
+    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('checkout_opened');
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('keeps product views behind MeasurementRecorder eligibility and idempotency', async () => {
     await expect(recordClientAnalyticsEvent({
       eventName: 'course_viewed',
+      exposureId: '11111111-1111-4111-8111-111111111111',
       courseId: 'course-1',
       placement: 'course_detail',
     }, 'user-1')).resolves.toBe(false);
 
-    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('course_viewed');
+    expect(isAnalyticsEventEnabled).not.toHaveBeenCalled();
     expect(insert).not.toHaveBeenCalled();
   });
 
@@ -57,14 +71,10 @@ describe('analytics writer boundary', () => {
   });
 
   it('stores only allow-listed fields with null network identifiers', async () => {
-    await expect(recordClientAnalyticsEvent({
-      eventName: 'course_viewed',
-      courseId: 'course-1',
-      placement: 'course_detail',
-    }, 'user-1')).resolves.toBe(true);
+    await expect(recordClientAnalyticsEvent(checkoutEvent, 'user-1')).resolves.toBe(true);
 
     expect(insertValues).toHaveBeenCalledWith({
-      eventName: 'course_viewed',
+      eventName: 'checkout_opened',
       source: 'client',
       userId: 'user-1',
       courseId: 'course-1',

--- a/tests/lib/measurement-recorder.test.ts
+++ b/tests/lib/measurement-recorder.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MeasurementRecorderError,
+  createMeasurementRecorder,
+  type MeasurementStore,
+  type ProductEligibility,
+  type ProductExposureRow,
+} from '@/lib/measurement-recorder';
+
+class MemoryMeasurementStore implements MeasurementStore {
+  eligibility = new Map<string, ProductEligibility>();
+  exposureIds = new Set<string>();
+  eligibilityReads = 0;
+  inserts = 0;
+
+  async readProductEligibility(productType: 'course' | 'bundle', productId: string) {
+    this.eligibilityReads += 1;
+    return this.eligibility.get(`${productType}:${productId}`) ?? null;
+  }
+
+  async insertProductExposure(row: ProductExposureRow) {
+    this.inserts += 1;
+    if (this.exposureIds.has(row.exposureId)) return 'duplicate' as const;
+    this.exposureIds.add(row.exposureId);
+    return 'inserted' as const;
+  }
+}
+
+describe('MeasurementRecorder product exposure', () => {
+  it('persists one eligible Course fact for repeated delivery of the same exposure identity', async () => {
+    const store = new MemoryMeasurementStore();
+    store.eligibility.set('course:course-1', {
+      productType: 'course',
+      productId: 'course-1',
+      status: 'published',
+      lessonCount: 3,
+    });
+    const recorder = createMeasurementRecorder({
+      store,
+      isEventEnabled: async () => true,
+    });
+    const fact = {
+      exposureId: '11111111-1111-4111-8111-111111111111',
+      productType: 'course' as const,
+      productId: 'course-1',
+    };
+
+    await expect(recorder.recordProductExposure(fact)).resolves.toEqual({ status: 'recorded' });
+    await expect(recorder.recordProductExposure(fact)).resolves.toEqual({ status: 'duplicate' });
+    expect(store.exposureIds).toEqual(new Set([fact.exposureId]));
+  });
+
+  it('records a published Bundle only when every included Course is ready', async () => {
+    const store = new MemoryMeasurementStore();
+    store.eligibility.set('bundle:bundle-ready', {
+      productType: 'bundle',
+      productId: 'bundle-ready',
+      status: 'published',
+      courses: [
+        { id: 'course-1', status: 'published', lessonCount: 2 },
+        { id: 'course-2', status: 'published', lessonCount: 1 },
+      ],
+    });
+    store.eligibility.set('bundle:bundle-unready', {
+      productType: 'bundle',
+      productId: 'bundle-unready',
+      status: 'published',
+      courses: [
+        { id: 'course-1', status: 'published', lessonCount: 0 },
+      ],
+    });
+    const recorder = createMeasurementRecorder({ store, isEventEnabled: async () => true });
+
+    await expect(recorder.recordProductExposure({
+      exposureId: '22222222-2222-4222-8222-222222222222',
+      productType: 'bundle',
+      productId: 'bundle-ready',
+    })).resolves.toEqual({ status: 'recorded' });
+    await expect(recorder.recordProductExposure({
+      exposureId: '33333333-3333-4333-8333-333333333333',
+      productType: 'bundle',
+      productId: 'bundle-unready',
+    })).resolves.toEqual({ status: 'ineligible' });
+  });
+
+  it.each([
+    ['missing Course', 'course', null],
+    ['draft Course', 'course', {
+      productType: 'course', productId: 'target', status: 'draft', lessonCount: 1,
+    }],
+    ['archived Course', 'course', {
+      productType: 'course', productId: 'target', status: 'archived', lessonCount: 1,
+    }],
+    ['unready Course', 'course', {
+      productType: 'course', productId: 'target', status: 'published', lessonCount: 0,
+    }],
+    ['empty Bundle', 'bundle', {
+      productType: 'bundle', productId: 'target', status: 'published', courses: [],
+    }],
+    ['Bundle with an unpublished Course', 'bundle', {
+      productType: 'bundle',
+      productId: 'target',
+      status: 'published',
+      courses: [{ id: 'course-1', status: 'draft', lessonCount: 1 }],
+    }],
+  ] as const)('does not persist an ineligible %s', async (_label, productType, eligibility) => {
+    const store = new MemoryMeasurementStore();
+    if (eligibility) store.eligibility.set(`${productType}:target`, eligibility as ProductEligibility);
+    const recorder = createMeasurementRecorder({ store, isEventEnabled: async () => true });
+
+    await expect(recorder.recordProductExposure({
+      exposureId: '44444444-4444-4444-8444-444444444444',
+      productType,
+      productId: 'target',
+    })).resolves.toEqual({ status: 'ineligible' });
+    expect(store.inserts).toBe(0);
+  });
+
+  it('stops before eligibility and persistence when product exposure analytics is disabled', async () => {
+    const store = new MemoryMeasurementStore();
+    const recorder = createMeasurementRecorder({ store, isEventEnabled: async () => false });
+
+    await expect(recorder.recordProductExposure({
+      exposureId: '55555555-5555-4555-8555-555555555555',
+      productType: 'course',
+      productId: 'course-1',
+    })).resolves.toEqual({ status: 'disabled' });
+    expect(store.eligibilityReads).toBe(0);
+    expect(store.inserts).toBe(0);
+  });
+
+  it('rejects a non-random exposure identity before gate, eligibility, or persistence work', async () => {
+    const store = new MemoryMeasurementStore();
+    let gateChecks = 0;
+    const recorder = createMeasurementRecorder({
+      store,
+      isEventEnabled: async () => {
+        gateChecks += 1;
+        return true;
+      },
+    });
+
+    await expect(recorder.recordProductExposure({
+      exposureId: 'user-1:course-1',
+      productType: 'course',
+      productId: 'course-1',
+    })).rejects.toBeInstanceOf(MeasurementRecorderError);
+    expect(gateChecks).toBe(0);
+    expect(store.eligibilityReads).toBe(0);
+    expect(store.inserts).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #28

Summary:
- generate a random short-lived exposure identity only after a public Course or Bundle detail commits in the browser
- validate published and purchasable readiness on the server and persist each exposure identity once
- use Beacon with keepalive fetch fallback while keeping analytics optional and anonymous
- add an additive nullable unique exposure_id migration and document the measurement boundary in ADR 0008

Verification:
- npm run lint
- npx tsc --noEmit
- npm run test -- --run (636 tests)
- npm run build
- git diff --check

Database note:
- migration 0015 is generated and reviewed but was not applied to the owner-managed local MySQL database