### PR TITLE
[UI Rollout 04] Add Stripe purchase attribution outbox

### DIFF
--- a/docs/adr/0009-project-stripe-purchase-facts-through-a-transactional-outbox.md
+++ b/docs/adr/0009-project-stripe-purchase-facts-through-a-transactional-outbox.md
@@ -1,0 +1,3 @@
+# Project Stripe purchase facts through a transactional outbox
+
+MilerDev will copy an optional server-validated product exposure identity onto each immutable local Stripe payment attempt, then enqueue `purchase_completed` by payment identity in the same transaction as the first verified `pending` to `completed` transition and enrollment writes. A best-effort projector and targeted reconciliation may retry the additive outbox into `analytics_events`, but projection failure never reverses payment or access, replay and success-page fulfillment cannot create a second fact, and code rollback remains compatible with the nullable attribution columns and retained outbox table.

--- a/drizzle/0016_luxuriant_gorgon.sql
+++ b/drizzle/0016_luxuriant_gorgon.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `measurement_outbox` (
+	`id` varchar(36) NOT NULL,
+	`event_name` varchar(100) NOT NULL,
+	`payment_id` varchar(36) NOT NULL,
+	`attempt_count` int NOT NULL DEFAULT 0,
+	`last_attempt_at` datetime,
+	`last_error_code` varchar(64),
+	`projected_at` datetime,
+	`created_at` datetime NOT NULL,
+	CONSTRAINT `measurement_outbox_id` PRIMARY KEY(`id`),
+	CONSTRAINT `uq_measurement_outbox_event_payment` UNIQUE(`event_name`,`payment_id`)
+);
+--> statement-breakpoint
+ALTER TABLE `analytics_events` ADD `attributed_exposure_id` varchar(36);--> statement-breakpoint
+ALTER TABLE `payments` ADD `attributed_exposure_id` varchar(36);--> statement-breakpoint
+ALTER TABLE `measurement_outbox` ADD CONSTRAINT `measurement_outbox_payment_id_payments_id_fk` FOREIGN KEY (`payment_id`) REFERENCES `payments`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `idx_measurement_outbox_projected_at` ON `measurement_outbox` (`projected_at`);--> statement-breakpoint
+CREATE INDEX `idx_measurement_outbox_payment_id` ON `measurement_outbox` (`payment_id`);--> statement-breakpoint
+CREATE INDEX `idx_analytics_attributed_exposure_id` ON `analytics_events` (`attributed_exposure_id`);

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,2990 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "5a8e0cbb-c792-4235-99eb-a09288ae2ba6",
+  "prevId": "22e458f6-197f-4fdc-b281-801462745c43",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_accounts_provider_identity": {
+          "name": "uq_accounts_provider_identity",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_id": {
+          "name": "accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "affiliate_banners": {
+      "name": "affiliate_banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "affiliate_banners_id": {
+          "name": "affiliate_banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exposure_id": {
+          "name": "exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_exposure_id": {
+          "name": "attributed_exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_analytics_exposure_id": {
+          "name": "uq_analytics_exposure_id",
+          "columns": [
+            "exposure_id"
+          ],
+          "isUnique": true
+        },
+        "idx_analytics_attributed_exposure_id": {
+          "name": "idx_analytics_attributed_exposure_id",
+          "columns": [
+            "attributed_exposure_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_event_name": {
+          "name": "idx_analytics_event_name",
+          "columns": [
+            "event_name"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_created_at": {
+          "name": "idx_analytics_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_course_id": {
+          "name": "idx_analytics_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_bundle_id": {
+          "name": "idx_analytics_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_payment_id": {
+          "name": "idx_analytics_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "uq_analytics_event_payment": {
+          "name": "uq_analytics_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_course_id_courses_id_fk": {
+          "name": "analytics_events_course_id_courses_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_bundle_id_bundles_id_fk": {
+          "name": "analytics_events_bundle_id_bundles_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_payment_id_payments_id_fk": {
+          "name": "analytics_events_payment_id_payments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analytics_events_id": {
+          "name": "analytics_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "target_role": {
+          "name": "target_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "announcements_id": {
+          "name": "announcements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_post_tags": {
+      "name": "blog_post_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_post_tags_post_id_blog_posts_id_fk": {
+          "name": "blog_post_tags_post_id_blog_posts_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "blog_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blog_post_tags_tag_id_tags_id_fk": {
+          "name": "blog_post_tags_tag_id_tags_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_post_tags_id": {
+          "name": "blog_post_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_posts": {
+      "name": "blog_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_blog_posts_status": {
+          "name": "idx_blog_posts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_blog_posts_published_at": {
+          "name": "idx_blog_posts_published_at",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_posts_author_id_users_id_fk": {
+          "name": "blog_posts_author_id_users_id_fk",
+          "tableFrom": "blog_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_posts_id": {
+          "name": "blog_posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "blog_posts_slug_unique": {
+          "name": "blog_posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "bundle_courses": {
+      "name": "bundle_courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_bundle_courses_bundle_id": {
+          "name": "idx_bundle_courses_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bundle_courses_bundle_id_bundles_id_fk": {
+          "name": "bundle_courses_bundle_id_bundles_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_courses_course_id_courses_id_fk": {
+          "name": "bundle_courses_course_id_courses_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_courses_id": {
+          "name": "bundle_courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "bundles": {
+      "name": "bundles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "bundles_id": {
+          "name": "bundles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "bundles_slug_unique": {
+          "name": "bundles_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "certificate_code": {
+          "name": "certificate_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_name": {
+          "name": "recipient_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_title": {
+          "name": "course_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_theme": {
+          "name": "certificate_theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_certificates_user_id": {
+          "name": "idx_certificates_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificates_course_id_courses_id_fk": {
+          "name": "certificates_course_id_courses_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "certificates_certificate_code_unique": {
+          "name": "certificates_certificate_code_unique",
+          "columns": [
+            "certificate_code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "coupon_usages": {
+      "name": "coupon_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_coupon_user_course": {
+          "name": "uq_coupon_user_course",
+          "columns": [
+            "coupon_id",
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coupon_usages_coupon_id_coupons_id_fk": {
+          "name": "coupon_usages_coupon_id_coupons_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_user_id_users_id_fk": {
+          "name": "coupon_usages_user_id_users_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_course_id_courses_id_fk": {
+          "name": "coupon_usages_course_id_courses_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupon_usages_id": {
+          "name": "coupon_usages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coupons": {
+      "name": "coupons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_purchase": {
+          "name": "min_purchase",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "max_discount": {
+          "name": "max_discount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "per_user_limit": {
+          "name": "per_user_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_course_id_courses_id_fk": {
+          "name": "coupons_course_id_courses_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupons_id": {
+          "name": "coupons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "coupons_code_unique": {
+          "name": "coupons_code_unique",
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "course_tags": {
+      "name": "course_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_tags_course_id_courses_id_fk": {
+          "name": "course_tags_course_id_courses_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_tags_tag_id_tags_id_fk": {
+          "name": "course_tags_tag_id_tags_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_tags_id": {
+          "name": "course_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "courses": {
+      "name": "courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_color": {
+          "name": "certificate_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#2563eb'"
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_badge": {
+          "name": "certificate_badge",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_video_url": {
+          "name": "preview_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_price": {
+          "name": "promo_price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_starts_at": {
+          "name": "promo_starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_ends_at": {
+          "name": "promo_ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "courses_instructor_id_users_id_fk": {
+          "name": "courses_instructor_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "courses_id": {
+          "name": "courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "courses_slug_unique": {
+          "name": "courses_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "enrollments": {
+      "name": "enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_enrollment_user_course": {
+          "name": "uq_enrollment_user_course",
+          "columns": [
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "enrollments_user_id_users_id_fk": {
+          "name": "enrollments_user_id_users_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollments_course_id_courses_id_fk": {
+          "name": "enrollments_course_id_courses_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "enrollments_id": {
+          "name": "enrollments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lesson_progress": {
+      "name": "lesson_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "watch_time_seconds": {
+          "name": "watch_time_seconds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_watched_at": {
+          "name": "last_watched_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lesson_progress_user_id": {
+          "name": "idx_lesson_progress_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lesson_progress_lesson_id": {
+          "name": "idx_lesson_progress_lesson_id",
+          "columns": [
+            "lesson_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lesson_progress_user_id_users_id_fk": {
+          "name": "lesson_progress_user_id_users_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lesson_progress_id": {
+          "name": "lesson_progress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lessons": {
+      "name": "lessons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_duration": {
+          "name": "video_duration",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_free_preview": {
+          "name": "is_free_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lessons_course_id": {
+          "name": "idx_lessons_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lessons_course_id_courses_id_fk": {
+          "name": "lessons_course_id_courses_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lessons_id": {
+          "name": "lessons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "measurement_outbox": {
+      "name": "measurement_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_measurement_outbox_event_payment": {
+          "name": "uq_measurement_outbox_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        },
+        "idx_measurement_outbox_projected_at": {
+          "name": "idx_measurement_outbox_projected_at",
+          "columns": [
+            "projected_at"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_payment_id": {
+          "name": "idx_measurement_outbox_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "measurement_outbox_payment_id_payments_id_fk": {
+          "name": "measurement_outbox_payment_id_payments_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "measurement_outbox_id": {
+          "name": "measurement_outbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_users_id_fk": {
+          "name": "media_uploaded_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_id": {
+          "name": "media_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notifications_id": {
+          "name": "notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "payments": {
+      "name": "payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_exposure_id": {
+          "name": "attributed_exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'THB'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slip_url": {
+          "name": "slip_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promptpay_trans_ref": {
+          "name": "promptpay_trans_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_title": {
+          "name": "item_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_payments_user_id": {
+          "name": "idx_payments_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_created_at": {
+          "name": "idx_payments_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_status": {
+          "name": "idx_payments_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_coupon_id": {
+          "name": "idx_payments_coupon_id",
+          "columns": [
+            "coupon_id"
+          ],
+          "isUnique": false
+        },
+        "uq_payments_promptpay_trans_ref": {
+          "name": "uq_payments_promptpay_trans_ref",
+          "columns": [
+            "promptpay_trans_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_course_id_courses_id_fk": {
+          "name": "payments_course_id_courses_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_bundle_id_bundles_id_fk": {
+          "name": "payments_bundle_id_bundles_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "payments_id": {
+          "name": "payments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_buckets_reset_at": {
+          "name": "idx_rate_limit_buckets_reset_at",
+          "columns": [
+            "reset_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_hash": {
+          "name": "rate_limit_buckets_key_hash",
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reviews_course_hidden": {
+          "name": "idx_reviews_course_hidden",
+          "columns": [
+            "course_id",
+            "is_hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_course_id_courses_id_fk": {
+          "name": "reviews_course_id_courses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reviews_id": {
+          "name": "reviews_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'string'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id": {
+          "name": "settings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "stripe_events": {
+      "name": "stripe_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_stripe_events_payment_id": {
+          "name": "idx_stripe_events_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_events_type": {
+          "name": "idx_stripe_events_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_payment_id_payments_id_fk": {
+          "name": "stripe_events_payment_id_payments_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_id": {
+          "name": "stripe_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tags_id": {
+          "name": "tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'student'"
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_expires": {
+          "name": "reset_expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_users_deactivated_at": {
+          "name": "idx_users_deactivated_at",
+          "columns": [
+            "deactivated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1788156667147,
       "tag": "0015_bumpy_absorbing_man",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "5",
+      "when": 1788166660977,
+      "tag": "0016_luxuriant_gorgon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/stripe/bundle-checkout/route.ts
+++ b/src/app/api/stripe/bundle-checkout/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from 'zod';
 import { auth } from "@/lib/auth";
 import { stripe } from "@/lib/stripe";
 import { db } from "@/lib/db";
@@ -6,6 +7,15 @@ import { bundles, bundleCourses, courses, enrollments, lessons, payments } from 
 import { eq, asc, and, count, inArray } from "drizzle-orm";
 import { checkRateLimit, rateLimits, rateLimitResponse } from "@/lib/rate-limit";
 import { requirePublishedBundleCourses, requireReadyBundleCourses } from '@/lib/bundle-commerce';
+import { analyticsExposureIdSchema } from '@/lib/analytics-contract';
+import { logEvent } from '@/lib/error-handler';
+import { measurementRecorder } from '@/lib/measurement-recorder';
+
+const stripeBundleCheckoutRequestSchema = z.object({
+    bundleId: z.string().trim().min(1).max(36),
+    exposureId: analyticsExposureIdSchema.optional(),
+}).strict();
+
 
 // POST /api/stripe/bundle-checkout - Create Stripe checkout session for bundle
 export async function POST(request: Request) {
@@ -20,7 +30,11 @@ export async function POST(request: Request) {
             return rateLimitResponse(rateLimit.resetTime);
         }
 
-        const { bundleId } = await request.json();
+        const parsed = stripeBundleCheckoutRequestSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+            return NextResponse.json({ error: "Invalid checkout request" }, { status: 400 });
+        }
+        const { bundleId, exposureId } = parsed.data;
 
         // Get bundle details
         const [bundle] = await db
@@ -99,6 +113,20 @@ export async function POST(request: Request) {
         // A checkout session is an immutable payment attempt. Reusing and repricing
         // an older pending row would let multiple Stripe sessions point at mutable
         // local state and can strand a successfully paid session.
+
+        let attributedExposureId: string | null = null;
+        if (exposureId) {
+            try {
+                attributedExposureId = await measurementRecorder.resolveProductExposureAttribution({
+                    exposureId,
+                    productType: 'bundle',
+                    productId: bundle.id,
+                });
+            } catch {
+                logEvent('analytics.payment_attribution_failed', 'warn');
+            }
+        }
+
         const paymentId = crypto.randomUUID();
         await db.insert(payments).values({
             id: paymentId,
@@ -106,6 +134,7 @@ export async function POST(request: Request) {
             bundleId: bundle.id,
             amount: priceNumber.toFixed(2),
             currency: "THB",
+            attributedExposureId,
             method: "stripe",
             itemTitle: `📦 ${bundle.title}`,
             status: "pending",

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from 'zod';
 import { auth } from "@/lib/auth";
 import { stripe } from "@/lib/stripe";
 import { db } from "@/lib/db";
@@ -7,6 +8,16 @@ import { eq, and, count } from "drizzle-orm";
 import { calculateDiscount, validateCouponEligibility } from "@/lib/coupon";
 import { checkRateLimit, rateLimits, rateLimitResponse } from "@/lib/rate-limit";
 import { COURSE_NOT_READY, requireCourseHasLessons } from "@/lib/course-availability";
+import { analyticsExposureIdSchema } from '@/lib/analytics-contract';
+import { logEvent } from '@/lib/error-handler';
+import { measurementRecorder } from '@/lib/measurement-recorder';
+
+const stripeCheckoutRequestSchema = z.object({
+    courseId: z.string().trim().min(1).max(36),
+    couponId: z.string().trim().min(1).max(36).optional(),
+    exposureId: analyticsExposureIdSchema.optional(),
+}).strict();
+
 
 // POST /api/stripe/checkout - Create Stripe checkout session
 export async function POST(request: Request) {
@@ -21,7 +32,11 @@ export async function POST(request: Request) {
             return rateLimitResponse(rateLimit.resetTime);
         }
 
-        const { courseId, couponId } = await request.json();
+        const parsed = stripeCheckoutRequestSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+            return NextResponse.json({ error: "Invalid checkout request" }, { status: 400 });
+        }
+        const { courseId, couponId, exposureId } = parsed.data;
 
         // Get course details
         const course = await db.query.courses.findFirst({
@@ -100,6 +115,20 @@ export async function POST(request: Request) {
         // A checkout session is an immutable payment attempt. Reusing and repricing
         // an older pending row would let multiple Stripe sessions point at mutable
         // local state and can strand a successfully paid session.
+
+        let attributedExposureId: string | null = null;
+        if (exposureId) {
+            try {
+                attributedExposureId = await measurementRecorder.resolveProductExposureAttribution({
+                    exposureId,
+                    productType: 'course',
+                    productId: course.id,
+                });
+            } catch {
+                logEvent('analytics.payment_attribution_failed', 'warn');
+            }
+        }
+
         const paymentId = crypto.randomUUID();
         await db.insert(payments).values({
             id: paymentId,
@@ -108,6 +137,7 @@ export async function POST(request: Request) {
             couponId: appliedCouponId,
             amount: priceNumber.toFixed(2),
             currency: "THB",
+            attributedExposureId,
             method: "stripe",
             itemTitle: course.title,
             status: "pending",

--- a/src/app/bundles/[slug]/page.tsx
+++ b/src/app/bundles/[slug]/page.tsx
@@ -191,8 +191,8 @@ export default async function BundleDetailPage({ params }: Props) {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(productJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }} />
       <Navbar />
-      <main className="min-h-screen bg-background text-foreground">
-        <AnalyticsViewEvent productType="bundle" productId={bundle.id} />
+      <AnalyticsViewEvent productType="bundle" productId={bundle.id}>
+        <main className="min-h-screen bg-background text-foreground">
         <header className="border-b bg-muted/30">
           <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
             <nav className="mb-10 flex flex-wrap items-center gap-2 text-sm text-muted-foreground [&_a:hover]:text-foreground" aria-label={'เส้นทางนำทาง'}>
@@ -315,7 +315,8 @@ export default async function BundleDetailPage({ params }: Props) {
             </aside>
           </div>
         </section>
-      </main>
+        </main>
+      </AnalyticsViewEvent>
       <Footer />
     </>
   );

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -226,8 +226,8 @@ export default async function CourseDetailPage({ params }: Props) {
       <Navbar />
 
       <CourseDetailProvider>
-        <main className="min-h-screen bg-background text-foreground">
-          <AnalyticsViewEvent productType="course" productId={course.id} />
+        <AnalyticsViewEvent productType="course" productId={course.id}>
+          <main className="min-h-screen bg-background text-foreground">
 
           <header className="bg-[radial-gradient(circle_at_12%_8%,var(--color-accent-soft),transparent_36%),linear-gradient(180deg,var(--academy-canvas),var(--background))]">
             <div className="mx-auto grid max-w-7xl gap-10 px-4 py-12 sm:px-6 lg:grid-cols-[minmax(0,1fr)_25rem] lg:gap-14 lg:px-8 lg:py-20">
@@ -374,7 +374,8 @@ export default async function CourseDetailPage({ params }: Props) {
               </Card>
             )}
           </article>
-        </main>
+          </main>
+        </AnalyticsViewEvent>
       </CourseDetailProvider>
 
       <Footer />

--- a/src/components/analytics/AnalyticsViewEvent.tsx
+++ b/src/components/analytics/AnalyticsViewEvent.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 
 import {
   createProductExposureId,
@@ -8,43 +15,59 @@ import {
 } from '@/components/analytics/analytics-client';
 import type { ClientAnalyticsEvent } from '@/lib/analytics-contract';
 
+const ProductExposureContext = createContext<string | null>(null);
+
 type AnalyticsViewEventProps = {
   productType: 'course' | 'bundle';
   productId: string;
+  children?: ReactNode;
 };
+
+export function useProductExposureId(): string | null {
+  return useContext(ProductExposureContext);
+}
 
 export default function AnalyticsViewEvent({
   productType,
   productId,
+  children,
 }: AnalyticsViewEventProps) {
   const exposureRef = useRef<{ key: string; id: string } | null>(null);
   const deliveredKeyRef = useRef<string | null>(null);
+  const [attribution, setAttribution] = useState<{ key: string; id: string } | null>(null);
+  const key = `${productType}:${productId}`;
 
   useEffect(() => {
-    const key = `${productType}:${productId}`;
     if (deliveredKeyRef.current === key) return;
 
     if (exposureRef.current?.key !== key) {
       exposureRef.current = { key, id: createProductExposureId() };
     }
 
+    const exposureId = exposureRef.current.id;
     const event: ClientAnalyticsEvent = productType === 'course'
       ? {
           eventName: 'course_viewed',
-          exposureId: exposureRef.current.id,
+          exposureId,
           courseId: productId,
           placement: 'course_detail',
         }
       : {
           eventName: 'bundle_viewed',
-          exposureId: exposureRef.current.id,
+          exposureId,
           bundleId: productId,
           placement: 'bundle_detail',
         };
 
     deliveredKeyRef.current = key;
+    setAttribution({ key, id: exposureId });
     trackClientAnalyticsEvent(event);
-  }, [productId, productType]);
+  }, [key, productId, productType]);
 
-  return null;
+  const attributedExposureId = attribution?.key === key ? attribution.id : null;
+  return (
+    <ProductExposureContext.Provider value={attributedExposureId}>
+      {children}
+    </ProductExposureContext.Provider>
+  );
 }

--- a/src/components/bundle/BundleEnrollButton.tsx
+++ b/src/components/bundle/BundleEnrollButton.tsx
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { trackClientAnalyticsEvent } from '@/components/analytics/analytics-client';
+import { useProductExposureId } from '@/components/analytics/AnalyticsViewEvent';
 
 interface BundleEnrollButtonProps {
   bundleId: string;
@@ -50,6 +51,7 @@ export default function BundleEnrollButton({
 }: BundleEnrollButtonProps) {
   const router = useRouter();
   const session = useSession()?.data;
+  const exposureId = useProductExposureId();
   const [loading, setLoading] = useState(false);
   const [enrolled, setEnrolled] = useState(false);
   const [paymentStep, setPaymentStep] = useState<PaymentStep>('idle');
@@ -125,7 +127,7 @@ export default function BundleEnrollButton({
       const res = await fetch(BUNDLE_PAYMENT_CONTRACT.stripeEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundleId }),
+        body: JSON.stringify({ bundleId, ...(exposureId && { exposureId }) }),
       });
       const data = await res.json();
       if (res.ok && data.url) {

--- a/src/components/course/EnrollButton.tsx
+++ b/src/components/course/EnrollButton.tsx
@@ -30,6 +30,7 @@ import {
 import { Spinner } from '@/components/ui/spinner';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { trackClientAnalyticsEvent } from '@/components/analytics/analytics-client';
+import { useProductExposureId } from '@/components/analytics/AnalyticsViewEvent';
 
 interface EnrollButtonProps {
   courseId: string;
@@ -59,6 +60,7 @@ export default function EnrollButton({ courseId, courseSlug, price, onEnrollment
   const sessionResult = useSession();
   const session = sessionResult?.data;
   const status = sessionResult?.status ?? 'unauthenticated';
+  const exposureId = useProductExposureId();
   const [loading, setLoading] = useState(false);
   const [enrolled, setEnrolled] = useState(false);
   const [checking, setChecking] = useState(true);
@@ -255,7 +257,11 @@ export default function EnrollButton({ courseId, courseSlug, price, onEnrollment
       const res = await fetch(COURSE_PAYMENT_CONTRACT.stripeEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ courseId, ...(appliedCoupon && { couponId: appliedCoupon.couponId }) }),
+        body: JSON.stringify({
+          courseId,
+          ...(appliedCoupon && { couponId: appliedCoupon.couponId }),
+          ...(exposureId && { exposureId }),
+        }),
       });
 
       const data = await res.json();

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -77,6 +77,7 @@ export async function recordClientAnalyticsEvent(
 export async function recordServerAnalyticsEvent(input: ServerAnalyticsEvent): Promise<boolean> {
   const parsed = serverAnalyticsEventSchema.safeParse(input);
   if (!parsed.success) return false;
+  if (parsed.data.eventName === 'purchase_completed') return false;
   return insertAnalyticsEvent({ ...parsed.data, source: 'server' });
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -176,6 +176,7 @@ export const payments = mysqlTable('payments', {
     courseId: varchar('course_id', { length: 36 }).references(() => courses.id, { onDelete: 'set null' }),
     bundleId: varchar('bundle_id', { length: 36 }).references(() => bundles.id, { onDelete: 'set null' }),
     couponId: varchar('coupon_id', { length: 36 }),
+    attributedExposureId: varchar('attributed_exposure_id', { length: 36 }),
     amount: decimal('amount', { precision: 10, scale: 2 }).notNull(),
     currency: varchar('currency', { length: 10 }).default('THB').notNull(),
     method: varchar('method', { length: 20, enum: ['stripe', 'promptpay', 'bank_transfer'] }).notNull(),
@@ -595,6 +596,7 @@ export const analyticsEvents = mysqlTable('analytics_events', {
     id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => createId()),
     eventName: varchar('event_name', { length: 100 }).notNull(),
     exposureId: varchar('exposure_id', { length: 36 }),
+    attributedExposureId: varchar('attributed_exposure_id', { length: 36 }),
     userId: varchar('user_id', { length: 36 }).references(() => users.id, { onDelete: 'set null' }),
     courseId: varchar('course_id', { length: 36 }).references(() => courses.id, { onDelete: 'set null' }),
     bundleId: varchar('bundle_id', { length: 36 }).references(() => bundles.id, { onDelete: 'set null' }),
@@ -606,6 +608,7 @@ export const analyticsEvents = mysqlTable('analytics_events', {
     createdAt: datetime('created_at').$defaultFn(() => new Date()),
 }, (table) => [
     uniqueIndex('uq_analytics_exposure_id').on(table.exposureId),
+    index('idx_analytics_attributed_exposure_id').on(table.attributedExposureId),
     index('idx_analytics_event_name').on(table.eventName),
     index('idx_analytics_created_at').on(table.createdAt),
     index('idx_analytics_course_id').on(table.courseId),
@@ -629,6 +632,31 @@ export const analyticsEventsRelations = relations(analyticsEvents, ({ one }) => 
     }),
     payment: one(payments, {
         fields: [analyticsEvents.paymentId],
+        references: [payments.id],
+    }),
+}));
+
+// =====================
+// MEASUREMENT OUTBOX TABLE
+// =====================
+export const measurementOutbox = mysqlTable('measurement_outbox', {
+    id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => createId()),
+    eventName: varchar('event_name', { length: 100, enum: ['purchase_completed'] }).notNull(),
+    paymentId: varchar('payment_id', { length: 36 }).references(() => payments.id).notNull(),
+    attemptCount: int('attempt_count').default(0).notNull(),
+    lastAttemptAt: datetime('last_attempt_at'),
+    lastErrorCode: varchar('last_error_code', { length: 64 }),
+    projectedAt: datetime('projected_at'),
+    createdAt: datetime('created_at').$defaultFn(() => new Date()).notNull(),
+}, (table) => [
+    uniqueIndex('uq_measurement_outbox_event_payment').on(table.eventName, table.paymentId),
+    index('idx_measurement_outbox_projected_at').on(table.projectedAt),
+    index('idx_measurement_outbox_payment_id').on(table.paymentId),
+]);
+
+export const measurementOutboxRelations = relations(measurementOutbox, ({ one }) => ({
+    payment: one(payments, {
+        fields: [measurementOutbox.paymentId],
         references: [payments.id],
     }),
 }));
@@ -678,6 +706,8 @@ export type BundleCourse = typeof bundleCourses.$inferSelect;
 export type NewBundleCourse = typeof bundleCourses.$inferInsert;
 export type AnalyticsEvent = typeof analyticsEvents.$inferSelect;
 export type NewAnalyticsEvent = typeof analyticsEvents.$inferInsert;
+export type MeasurementOutboxEntry = typeof measurementOutbox.$inferSelect;
+export type NewMeasurementOutboxEntry = typeof measurementOutbox.$inferInsert;
 export type RateLimitBucket = typeof rateLimitBuckets.$inferSelect;
 
 // =====================

--- a/src/lib/measurement-recorder.ts
+++ b/src/lib/measurement-recorder.ts
@@ -51,12 +51,20 @@ export type ProductExposureRow = {
   placement: 'course_detail' | 'bundle_detail';
 };
 
+export type ProductExposureAttributionRow = {
+  exposureId: string | null;
+  eventName: string;
+  courseId: string | null;
+  bundleId: string | null;
+};
+
 export interface MeasurementStore {
   readProductEligibility(
     productType: ProductType,
     productId: string,
   ): Promise<ProductEligibility | null>;
   insertProductExposure(row: ProductExposureRow): Promise<'inserted' | 'duplicate'>;
+  readProductExposure(exposureId: string): Promise<ProductExposureAttributionRow | null>;
 }
 
 export interface MeasurementRecorder {
@@ -65,6 +73,11 @@ export interface MeasurementRecorder {
     productType: ProductType;
     productId: string;
   }): Promise<{ status: 'recorded' | 'duplicate' | 'disabled' | 'ineligible' }>;
+  resolveProductExposureAttribution(input: {
+    exposureId: string;
+    productType: ProductType;
+    productId: string;
+  }): Promise<string | null>;
 }
 
 export class MeasurementRecorderError extends Error {
@@ -115,6 +128,23 @@ export function createMeasurementRecorder(input: {
         placement: parsed.data.productType === 'course' ? 'course_detail' : 'bundle_detail',
       });
       return { status: inserted === 'inserted' ? 'recorded' : 'duplicate' };
+    },
+
+    async resolveProductExposureAttribution(attribution) {
+      const parsed = productExposureFactSchema.safeParse(attribution);
+      if (!parsed.success) return null;
+
+      const eventName = parsed.data.productType === 'course' ? 'course_viewed' : 'bundle_viewed';
+      if (!(await input.isEventEnabled(eventName))) return null;
+
+      const exposure = await input.store.readProductExposure(parsed.data.exposureId);
+      if (!exposure || exposure.exposureId !== parsed.data.exposureId) return null;
+      if (exposure.eventName !== eventName) return null;
+
+      const targetMatches = parsed.data.productType === 'course'
+        ? exposure.courseId === parsed.data.productId && exposure.bundleId === null
+        : exposure.bundleId === parsed.data.productId && exposure.courseId === null;
+      return targetMatches ? parsed.data.exposureId : null;
     },
   };
 }
@@ -177,6 +207,20 @@ const drizzleMeasurementStore: MeasurementStore = {
       if (isDuplicateKeyError(error)) return 'duplicate';
       throw error;
     }
+  },
+
+  async readProductExposure(exposureId) {
+    const [row] = await db
+      .select({
+        exposureId: analyticsEvents.exposureId,
+        eventName: analyticsEvents.eventName,
+        courseId: analyticsEvents.courseId,
+        bundleId: analyticsEvents.bundleId,
+      })
+      .from(analyticsEvents)
+      .where(eq(analyticsEvents.exposureId, exposureId))
+      .limit(1);
+    return row ?? null;
   },
 };
 

--- a/src/lib/payment-fulfillment.ts
+++ b/src/lib/payment-fulfillment.ts
@@ -10,10 +10,12 @@ import {
   courses,
   enrollments,
   payments,
+  measurementOutbox,
   stripeEvents,
   type Payment,
 } from '@/lib/db/schema';
 import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+import { purchaseMeasurementProjector } from '@/lib/purchase-measurement-projector';
 
 type PaymentTarget =
   | { type: 'course'; itemId: string }
@@ -164,7 +166,8 @@ export async function fulfillStripeCheckoutSession({
   }
 
   try {
-    return await db.transaction(async (tx) => {
+    const result: Extract<StripeFulfillmentResult, { payment: Payment }> = await db.transaction(
+      async (tx) => {
       if (event) {
         if (!event.id || !event.type) reject('INVALID_EVENT');
         await tx.insert(stripeEvents).values({
@@ -284,14 +287,28 @@ export async function fulfillStripeCheckoutSession({
         }
       }
 
+      if (!wasCompleted) {
+        await tx.insert(measurementOutbox).values({
+          eventName: 'purchase_completed',
+          paymentId: payment.id,
+        });
+      }
+
       return {
         status: wasCompleted ? 'already_fulfilled' : 'fulfilled',
         payment: { ...payment, status: 'completed', stripePaymentId: paymentIntentId },
         emailDetails,
       };
-    });
+      },
+    );
+
+    await purchaseMeasurementProjector.projectPurchase(result.payment.id);
+    return result;
   } catch (error) {
-    if (event && isDuplicateKeyError(error)) return { status: 'replayed' };
+    if (event && isDuplicateKeyError(error)) {
+      await purchaseMeasurementProjector.projectPurchase(identity.paymentId);
+      return { status: 'replayed' };
+    }
     if (error instanceof FulfillmentRejection) {
       return { status: 'rejected', code: error.code, retryable: error.retryable };
     }

--- a/src/lib/purchase-measurement-projector.ts
+++ b/src/lib/purchase-measurement-projector.ts
@@ -1,0 +1,171 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import { db } from '@/lib/db';
+import { analyticsEvents, measurementOutbox, payments } from '@/lib/db/schema';
+import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+
+export type PurchaseProjection = {
+  paymentId: string;
+  userId: string | null;
+  courseId: string | null;
+  bundleId: string | null;
+  method: 'stripe' | 'promptpay' | 'bank_transfer';
+  status: 'pending' | 'completed' | 'failed' | 'refunded' | 'verifying';
+  attributedExposureId: string | null;
+};
+
+export interface PurchaseMeasurementStore {
+  readCompletedStripePayment(paymentId: string): Promise<PurchaseProjection | null>;
+  ensurePurchaseOutbox(paymentId: string): Promise<void>;
+  projectPendingPurchase(
+    payment: PurchaseProjection,
+  ): Promise<'projected' | 'duplicate' | 'already_projected'>;
+  recordProjectionFailure(paymentId: string): Promise<void>;
+}
+
+export interface PurchaseMeasurementProjector {
+  projectPurchase(
+    paymentId: string,
+  ): Promise<{ status: 'projected' | 'duplicate' | 'already_projected' | 'disabled' | 'ineligible' | 'failed' }>;
+}
+
+function isEligibleStripePurchase(payment: PurchaseProjection | null): payment is PurchaseProjection {
+  return Boolean(
+    payment
+    && payment.status === 'completed'
+    && payment.method === 'stripe'
+    && payment.userId
+    && Boolean(payment.courseId) !== Boolean(payment.bundleId),
+  );
+}
+
+export function createPurchaseMeasurementProjector(input: {
+  store: PurchaseMeasurementStore;
+  isEventEnabled(eventName: 'purchase_completed'): Promise<boolean>;
+}): PurchaseMeasurementProjector {
+  return {
+    async projectPurchase(paymentId) {
+      if (!paymentId.trim() || paymentId.length > 36) return { status: 'ineligible' };
+
+      try {
+        if (!(await input.isEventEnabled('purchase_completed'))) return { status: 'disabled' };
+
+        const payment = await input.store.readCompletedStripePayment(paymentId);
+        if (!isEligibleStripePurchase(payment)) return { status: 'ineligible' };
+
+        await input.store.ensurePurchaseOutbox(paymentId);
+        const status = await input.store.projectPendingPurchase(payment);
+        return { status };
+      } catch {
+        try {
+          await input.store.recordProjectionFailure(paymentId);
+        } catch {
+          // Measurement recovery remains best-effort and never becomes payment authority.
+        }
+        return { status: 'failed' };
+      }
+    },
+  };
+}
+
+const drizzlePurchaseMeasurementStore: PurchaseMeasurementStore = {
+  async readCompletedStripePayment(paymentId) {
+    const [payment] = await db
+      .select({
+        paymentId: payments.id,
+        userId: payments.userId,
+        courseId: payments.courseId,
+        bundleId: payments.bundleId,
+        method: payments.method,
+        status: payments.status,
+        attributedExposureId: payments.attributedExposureId,
+      })
+      .from(payments)
+      .where(eq(payments.id, paymentId))
+      .limit(1);
+    return payment ?? null;
+  },
+
+  async ensurePurchaseOutbox(paymentId) {
+    try {
+      await db.insert(measurementOutbox).values({
+        eventName: 'purchase_completed',
+        paymentId,
+      });
+    } catch (error) {
+      if (!isDuplicateKeyError(error)) throw error;
+    }
+  },
+
+  async projectPendingPurchase(payment) {
+    return db.transaction(async (tx) => {
+      const [outbox] = await tx
+        .select({ id: measurementOutbox.id, createdAt: measurementOutbox.createdAt })
+        .from(measurementOutbox)
+        .where(and(
+          eq(measurementOutbox.eventName, 'purchase_completed'),
+          eq(measurementOutbox.paymentId, payment.paymentId),
+          isNull(measurementOutbox.projectedAt),
+        ))
+        .limit(1);
+
+      if (!outbox) return 'already_projected';
+
+      let duplicate = false;
+      try {
+        await tx.insert(analyticsEvents).values({
+          eventName: 'purchase_completed',
+          attributedExposureId: payment.attributedExposureId,
+          source: 'server',
+          userId: payment.userId,
+          courseId: payment.courseId,
+          bundleId: payment.bundleId,
+          paymentId: payment.paymentId,
+          metadata: JSON.stringify({ method: payment.method }),
+          ipAddress: null,
+          userAgent: null,
+          createdAt: outbox.createdAt,
+        });
+      } catch (error) {
+        if (!isDuplicateKeyError(error)) throw error;
+        duplicate = true;
+      }
+
+      await tx
+        .update(measurementOutbox)
+        .set({
+          attemptCount: sql`${measurementOutbox.attemptCount} + 1`,
+          lastAttemptAt: new Date(),
+          lastErrorCode: null,
+          projectedAt: new Date(),
+        })
+        .where(and(
+          eq(measurementOutbox.id, outbox.id),
+          isNull(measurementOutbox.projectedAt),
+        ));
+
+      return duplicate ? 'duplicate' : 'projected';
+    });
+  },
+
+  async recordProjectionFailure(paymentId) {
+    await db
+      .update(measurementOutbox)
+      .set({
+        attemptCount: sql`${measurementOutbox.attemptCount} + 1`,
+        lastAttemptAt: new Date(),
+        lastErrorCode: 'projection_failed',
+      })
+      .where(and(
+        eq(measurementOutbox.eventName, 'purchase_completed'),
+        eq(measurementOutbox.paymentId, paymentId),
+        isNull(measurementOutbox.projectedAt),
+      ));
+  },
+};
+
+export const purchaseMeasurementProjector = createPurchaseMeasurementProjector({
+  store: drizzlePurchaseMeasurementStore,
+  isEventEnabled: isAnalyticsEventEnabled,
+});

--- a/tests/api/stripe-attribution.test.ts
+++ b/tests/api/stripe-attribution.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { paymentInsert, resolveProductExposureAttribution } = vi.hoisted(() => ({
+  paymentInsert: vi.fn(),
+  resolveProductExposureAttribution: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ success: true, remaining: 9, resetTime: Date.now() + 60_000 }),
+  rateLimits: { sensitive: { maxRequests: 10, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(),
+}));
+vi.mock('@/lib/coupon', () => ({
+  calculateDiscount: vi.fn(),
+  validateCouponEligibility: vi.fn(),
+}));
+vi.mock('@/lib/measurement-recorder', () => ({
+  measurementRecorder: { resolveProductExposureAttribution },
+}));
+vi.mock('@/lib/stripe', () => ({
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi.fn().mockResolvedValue({
+          id: 'cs_test',
+          url: 'https://checkout.stripe.test/session',
+        }),
+      },
+    },
+  },
+}));
+vi.mock('@/lib/db', () => ({
+  db: {
+    query: {
+      courses: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'course-1',
+          slug: 'course-one',
+          title: 'Course One',
+          description: null,
+          thumbnailUrl: null,
+          price: '990.00',
+          promoPrice: null,
+          promoStartsAt: null,
+          promoEndsAt: null,
+          status: 'published',
+          lessons: [{ id: 'lesson-1' }],
+        }),
+      },
+      enrollments: { findFirst: vi.fn().mockResolvedValue(null) },
+    },
+    select: vi.fn(),
+    insert: vi.fn(() => ({ values: paymentInsert })),
+  },
+}));
+
+import { db } from '@/lib/db';
+
+const exposureId = '11111111-1111-4111-8111-111111111111';
+
+describe('Stripe payment-attempt attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    paymentInsert.mockResolvedValue(undefined);
+    resolveProductExposureAttribution.mockResolvedValue(exposureId);
+  });
+
+  it('stores only the server-validated Course exposure on the immutable payment attempt', async () => {
+    const { POST } = await import('@/app/api/stripe/checkout/route');
+    const response = await POST(new Request('http://localhost/api/stripe/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ courseId: 'course-1', exposureId }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(resolveProductExposureAttribution).toHaveBeenCalledWith({
+      exposureId,
+      productType: 'course',
+      productId: 'course-1',
+    });
+    expect(paymentInsert).toHaveBeenCalledWith(expect.objectContaining({
+      courseId: 'course-1',
+      attributedExposureId: exposureId,
+      status: 'pending',
+    }));
+  });
+
+  it('stores only the server-validated Bundle exposure on the immutable payment attempt', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'bundle-1',
+              slug: 'bundle-one',
+              title: 'Bundle One',
+              description: null,
+              thumbnailUrl: null,
+              price: '1990.00',
+              status: 'published',
+            }]),
+          })),
+        })),
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn(() => ({
+              orderBy: vi.fn().mockResolvedValue([{
+                courseId: 'course-1',
+                courseTitle: 'Course One',
+                courseStatus: 'published',
+              }]),
+            })),
+          })),
+        })),
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            groupBy: vi.fn().mockResolvedValue([{ courseId: 'course-1', lessonCount: 1 }]),
+          })),
+        })),
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([]) })),
+        })),
+      } as never);
+
+    const { POST } = await import('@/app/api/stripe/bundle-checkout/route');
+    const response = await POST(new Request('http://localhost/api/stripe/bundle-checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bundleId: 'bundle-1', exposureId }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(resolveProductExposureAttribution).toHaveBeenCalledWith({
+      exposureId,
+      productType: 'bundle',
+      productId: 'bundle-1',
+    });
+    expect(paymentInsert).toHaveBeenCalledWith(expect.objectContaining({
+      bundleId: 'bundle-1',
+      attributedExposureId: exposureId,
+      status: 'pending',
+    }));
+  });
+});

--- a/tests/components/product-exposure-attribution.test.tsx
+++ b/tests/components/product-exposure-attribution.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { createProductExposureId, trackClientAnalyticsEvent } = vi.hoisted(() => ({
+  createProductExposureId: vi.fn(() => '123e4567-e89b-42d3-a456-426614174000'),
+  trackClientAnalyticsEvent: vi.fn(),
+}));
+
+vi.mock('@/components/analytics/analytics-client', () => ({
+  createProductExposureId,
+  trackClientAnalyticsEvent,
+}));
+
+import AnalyticsViewEvent, {
+  useProductExposureId,
+} from '@/components/analytics/AnalyticsViewEvent';
+
+function AttributionConsumer() {
+  const exposureId = useProductExposureId();
+  return <output>{exposureId ?? 'unattributed'}</output>;
+}
+
+describe('product exposure attribution context', () => {
+  it('shares the same post-commit exposure identity with checkout consumers', async () => {
+    render(
+      <AnalyticsViewEvent productType="course" productId="course-1">
+        <AttributionConsumer />
+      </AnalyticsViewEvent>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('123e4567-e89b-42d3-a456-426614174000')).toBeTruthy();
+    });
+    expect(trackClientAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      exposureId: '123e4567-e89b-42d3-a456-426614174000',
+      courseId: 'course-1',
+    }));
+  });
+});

--- a/tests/lib/analytics-writer.test.ts
+++ b/tests/lib/analytics-writer.test.ts
@@ -70,6 +70,18 @@ describe('analytics writer boundary', () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it('routes purchase completion through the transactional outbox instead of the legacy writer', async () => {
+    await expect(recordServerAnalyticsEvent({
+      eventName: 'purchase_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+      paymentId: 'payment-1',
+    })).resolves.toBe(false);
+
+    expect(isAnalyticsEventEnabled).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it('stores only allow-listed fields with null network identifiers', async () => {
     await expect(recordClientAnalyticsEvent(checkoutEvent, 'user-1')).resolves.toBe(true);
 

--- a/tests/lib/measurement-attribution.test.ts
+++ b/tests/lib/measurement-attribution.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createMeasurementRecorder,
+  type MeasurementStore,
+  type ProductExposureRow,
+} from '@/lib/measurement-recorder';
+
+class AttributionStore implements MeasurementStore {
+  constructor(private readonly exposure: ProductExposureRow | null) {}
+
+  async readProductEligibility() {
+    return null;
+  }
+
+  async insertProductExposure() {
+    return 'inserted' as const;
+  }
+
+  async readProductExposure() {
+    return this.exposure;
+  }
+}
+
+describe('MeasurementRecorder payment attribution', () => {
+  it('returns a committed Course exposure only when its product identity matches', async () => {
+    const exposureId = '11111111-1111-4111-8111-111111111111';
+    const recorder = createMeasurementRecorder({
+      store: new AttributionStore({
+        exposureId,
+        eventName: 'course_viewed',
+        courseId: 'course-1',
+        bundleId: null,
+        placement: 'course_detail',
+      }),
+      isEventEnabled: async () => true,
+    });
+
+    await expect(recorder.resolveProductExposureAttribution({
+      exposureId,
+      productType: 'course',
+      productId: 'course-1',
+    })).resolves.toBe(exposureId);
+  });
+});

--- a/tests/lib/measurement-recorder.test.ts
+++ b/tests/lib/measurement-recorder.test.ts
@@ -19,6 +19,10 @@ class MemoryMeasurementStore implements MeasurementStore {
     return this.eligibility.get(`${productType}:${productId}`) ?? null;
   }
 
+  async readProductExposure() {
+    return null;
+  }
+
   async insertProductExposure(row: ProductExposureRow) {
     this.inserts += 1;
     if (this.exposureIds.has(row.exposureId)) return 'duplicate' as const;

--- a/tests/lib/purchase-measurement-projector.test.ts
+++ b/tests/lib/purchase-measurement-projector.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createPurchaseMeasurementProjector,
+  type PurchaseMeasurementStore,
+  type PurchaseProjection,
+} from '@/lib/purchase-measurement-projector';
+
+class MemoryPurchaseMeasurementStore implements PurchaseMeasurementStore {
+  payment: PurchaseProjection | null = {
+    paymentId: 'pay-1',
+    userId: 'user-1',
+    courseId: 'course-1',
+    bundleId: null,
+    method: 'stripe',
+    status: 'completed',
+    attributedExposureId: '11111111-1111-4111-8111-111111111111',
+  };
+  outbox = new Map<string, { id: string; paymentId: string; createdAt: Date; projected: boolean }>();
+  facts = new Set<string>();
+  failures = 0;
+  failProjection = false;
+
+  async readCompletedStripePayment(paymentId: string) {
+    return this.payment?.paymentId === paymentId ? this.payment : null;
+  }
+
+  async ensurePurchaseOutbox(paymentId: string) {
+    if (this.outbox.has(paymentId)) return;
+    this.outbox.set(paymentId, {
+      id: `outbox:${paymentId}`,
+      paymentId,
+      createdAt: new Date('2026-08-31T08:00:00.000Z'),
+      projected: false,
+    });
+  }
+
+  async projectPendingPurchase(payment: PurchaseProjection) {
+    if (this.failProjection) throw new Error('projector unavailable');
+    const outbox = this.outbox.get(payment.paymentId);
+    if (!outbox || outbox.projected) return 'already_projected' as const;
+    const duplicate = this.facts.has(payment.paymentId);
+    this.facts.add(payment.paymentId);
+    outbox.projected = true;
+    return duplicate ? 'duplicate' as const : 'projected' as const;
+  }
+
+  async recordProjectionFailure() {
+    this.failures += 1;
+  }
+}
+
+describe('purchase measurement projector', () => {
+  it('does not inspect or mutate payment data while purchase measurement is disabled', async () => {
+    const store = new MemoryPurchaseMeasurementStore();
+    const readPayment = vi.spyOn(store, 'readCompletedStripePayment');
+    const projector = createPurchaseMeasurementProjector({
+      store,
+      isEventEnabled: async () => false,
+    });
+
+    await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'disabled' });
+    expect(readPayment).not.toHaveBeenCalled();
+    expect(store.outbox.size).toBe(0);
+    expect(store.facts.size).toBe(0);
+  });
+
+  it('contains gate and lookup outages so analytics never becomes payment authority', async () => {
+    const store = new MemoryPurchaseMeasurementStore();
+    const projector = createPurchaseMeasurementProjector({
+      store,
+      isEventEnabled: async () => {
+        throw new Error('analytics control unavailable');
+      },
+    });
+
+    await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'failed' });
+    expect(store.payment?.status).toBe('completed');
+  });
+
+  it('treats an existing payment fact as a successful idempotent projection', async () => {
+    const store = new MemoryPurchaseMeasurementStore();
+    store.facts.add('pay-1');
+    const projector = createPurchaseMeasurementProjector({
+      store,
+      isEventEnabled: async () => true,
+    });
+
+    await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'duplicate' });
+    expect(store.facts).toEqual(new Set(['pay-1']));
+    expect(store.outbox.get('pay-1')?.projected).toBe(true);
+  });
+
+  it('keeps the committed payment recoverable when projection fails, then retries to one fact', async () => {
+    const store = new MemoryPurchaseMeasurementStore();
+    const projector = createPurchaseMeasurementProjector({
+      store,
+      isEventEnabled: async () => true,
+    });
+    store.failProjection = true;
+
+    await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'failed' });
+    expect(store.payment?.status).toBe('completed');
+    expect(store.facts.size).toBe(0);
+    expect(store.failures).toBe(1);
+
+    store.failProjection = false;
+    await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'projected' });
+    expect(store.facts).toEqual(new Set(['pay-1']));
+  });
+});

--- a/tests/lib/stripe-purchase-outbox.test.ts
+++ b/tests/lib/stripe-purchase-outbox.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbTransaction, insertedRows, paymentState, projectPurchase, isDuplicateKeyError } = vi.hoisted(() => ({
+  dbTransaction: vi.fn(),
+  insertedRows: [] as Array<Record<string, unknown>>,
+  paymentState: { status: 'pending' as 'pending' | 'completed' },
+  projectPurchase: vi.fn(),
+  isDuplicateKeyError: vi.fn(),
+}));
+
+vi.mock('@/lib/db/safe-insert', () => ({
+  isDuplicateKeyError,
+}));
+vi.mock('@/lib/db', () => ({ db: { transaction: dbTransaction } }));
+vi.mock('@/lib/purchase-measurement-projector', () => ({
+  purchaseMeasurementProjector: { projectPurchase },
+}));
+
+import { fulfillStripeCheckoutSession } from '@/lib/payment-fulfillment';
+
+const payment = () => ({
+  id: 'pay-1',
+  userId: 'user-1',
+  courseId: 'course-1',
+  bundleId: null,
+  couponId: null,
+  attributedExposureId: '11111111-1111-4111-8111-111111111111',
+  amount: '990.00',
+  currency: 'THB',
+  method: 'stripe',
+  stripePaymentId: paymentState.status === 'completed' ? 'pi_test' : null,
+  slipUrl: null,
+  promptpayTransRef: null,
+  itemTitle: 'Course One',
+  status: paymentState.status,
+  retryCount: 0,
+  lastRetryAt: null,
+  createdAt: new Date('2026-08-31T08:00:00.000Z'),
+});
+
+const session = {
+  metadata: {
+    paymentId: 'pay-1',
+    userId: 'user-1',
+    courseId: 'course-1',
+    type: 'course',
+  },
+  payment_intent: 'pi_test',
+  payment_status: 'paid',
+  amount_total: 99_000,
+  currency: 'thb',
+};
+
+function transactionAdapter() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([payment()]) })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ affectedRows: 1 }]) })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (row: Record<string, unknown>) => {
+        insertedRows.push(row);
+      }),
+    })),
+    query: {
+      courses: {
+        findFirst: vi.fn().mockResolvedValue({ title: 'Course One', slug: 'course-one' }),
+      },
+    },
+  };
+}
+
+describe('Stripe purchase transactional outbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRows.length = 0;
+    paymentState.status = 'pending';
+    projectPurchase.mockResolvedValue({ status: 'projected' });
+    isDuplicateKeyError.mockReturnValue(false);
+    dbTransaction.mockImplementation(async (work) => work(transactionAdapter()));
+  });
+
+  it('enqueues one purchase fact with the first committed pending-to-completed transition', async () => {
+    const result = await fulfillStripeCheckoutSession({ session: session as never });
+
+    expect(result.status).toBe('fulfilled');
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed',
+      paymentId: 'pay-1',
+    }));
+    expect(projectPurchase).toHaveBeenCalledWith('pay-1');
+  });
+
+  it('keeps fulfillment successful when projection fails after the domain commit', async () => {
+    projectPurchase.mockResolvedValue({ status: 'failed' });
+
+    const result = await fulfillStripeCheckoutSession({ session: session as never });
+
+    expect(result.status).toBe('fulfilled');
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed', paymentId: 'pay-1',
+    }));
+  });
+
+  it('does not enqueue a second purchase fact for an already-fulfilled success-page render', async () => {
+    paymentState.status = 'completed';
+
+    const result = await fulfillStripeCheckoutSession({ session: session as never });
+
+    expect(result.status).toBe('already_fulfilled');
+    expect(insertedRows).not.toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed',
+      paymentId: 'pay-1',
+    }));
+    expect(projectPurchase).toHaveBeenCalledWith('pay-1');
+  });
+
+  it('uses a duplicate webhook only to reconcile the original payment fact', async () => {
+    isDuplicateKeyError.mockReturnValue(true);
+    dbTransaction.mockRejectedValue(new Error('duplicate Stripe event'));
+
+    const result = await fulfillStripeCheckoutSession({
+      session: session as never,
+      event: { id: 'evt-1', type: 'checkout.session.completed' },
+    });
+
+    expect(result).toEqual({ status: 'replayed' });
+    expect(insertedRows).toHaveLength(0);
+    expect(projectPurchase).toHaveBeenCalledTimes(1);
+    expect(projectPurchase).toHaveBeenCalledWith('pay-1');
+  });
+});


### PR DESCRIPTION
Closes #29

Summary:
- carry server-validated product exposure attribution into immutable Stripe payment attempts
- enqueue purchase completion in the same transaction as payment completion and enrollment
- project purchase facts idempotently with replay and targeted reconciliation recovery
- add ADR 0009 and additive Drizzle migration 0016

Verification:
- npx tsc --noEmit
- npm run lint
- npm run test -- --run (649 tests)
- npm run build
- git diff --check

Migration note: 0016 only adds nullable columns, indexes, and measurement_outbox. It was generated and reviewed but not applied manually to any database.