### PR TITLE
feat: add authoritative acquisition facts

### DIFF
--- a/docs/adr/0010-key-authoritative-acquisition-facts-by-domain-identity.md
+++ b/docs/adr/0010-key-authoritative-acquisition-facts-by-domain-identity.md
@@ -1,0 +1,3 @@
+# Key authoritative acquisition facts by domain identity
+
+MilerDev will reuse one transactional measurement outbox while keying paid acquisition facts by `paymentId` and free or 100%-coupon acquisition facts by each first-created `enrollmentId`; an outbox entry carries exactly one of those identities so retries remain idempotent without treating free access as a paid purchase.

--- a/drizzle/0017_authoritative_acquisition_facts.sql
+++ b/drizzle/0017_authoritative_acquisition_facts.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `measurement_outbox` MODIFY COLUMN `payment_id` varchar(36);--> statement-breakpoint
+ALTER TABLE `analytics_events` ADD `enrollment_id` varchar(36);--> statement-breakpoint
+ALTER TABLE `measurement_outbox` ADD `enrollment_id` varchar(36);--> statement-breakpoint
+ALTER TABLE `analytics_events` ADD CONSTRAINT `uq_analytics_event_enrollment` UNIQUE(`event_name`,`enrollment_id`);--> statement-breakpoint
+ALTER TABLE `measurement_outbox` ADD CONSTRAINT `uq_measurement_outbox_event_enrollment` UNIQUE(`event_name`,`enrollment_id`);--> statement-breakpoint
+ALTER TABLE `measurement_outbox` ADD CONSTRAINT `chk_measurement_outbox_acquisition_identity` CHECK (
+        (`measurement_outbox`.`event_name` = 'purchase_completed' AND `measurement_outbox`.`payment_id` IS NOT NULL AND `measurement_outbox`.`enrollment_id` IS NULL)
+        OR (`measurement_outbox`.`event_name` = 'free_enrollment_completed' AND `measurement_outbox`.`payment_id` IS NULL AND `measurement_outbox`.`enrollment_id` IS NOT NULL)
+    );--> statement-breakpoint
+ALTER TABLE `analytics_events` ADD CONSTRAINT `analytics_events_enrollment_id_enrollments_id_fk` FOREIGN KEY (`enrollment_id`) REFERENCES `enrollments`(`id`) ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `measurement_outbox` ADD CONSTRAINT `measurement_outbox_enrollment_id_enrollments_id_fk` FOREIGN KEY (`enrollment_id`) REFERENCES `enrollments`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `idx_analytics_enrollment_id` ON `analytics_events` (`enrollment_id`);--> statement-breakpoint
+CREATE INDEX `idx_measurement_outbox_enrollment_id` ON `measurement_outbox` (`enrollment_id`);

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,3065 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "97f578b4-13c3-4324-9fcf-90c7e4c0ff5c",
+  "prevId": "5a8e0cbb-c792-4235-99eb-a09288ae2ba6",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_accounts_provider_identity": {
+          "name": "uq_accounts_provider_identity",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_id": {
+          "name": "accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "affiliate_banners": {
+      "name": "affiliate_banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "affiliate_banners_id": {
+          "name": "affiliate_banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exposure_id": {
+          "name": "exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_exposure_id": {
+          "name": "attributed_exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_analytics_exposure_id": {
+          "name": "uq_analytics_exposure_id",
+          "columns": [
+            "exposure_id"
+          ],
+          "isUnique": true
+        },
+        "idx_analytics_attributed_exposure_id": {
+          "name": "idx_analytics_attributed_exposure_id",
+          "columns": [
+            "attributed_exposure_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_event_name": {
+          "name": "idx_analytics_event_name",
+          "columns": [
+            "event_name"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_created_at": {
+          "name": "idx_analytics_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_course_id": {
+          "name": "idx_analytics_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_bundle_id": {
+          "name": "idx_analytics_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_payment_id": {
+          "name": "idx_analytics_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_enrollment_id": {
+          "name": "idx_analytics_enrollment_id",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        },
+        "uq_analytics_event_payment": {
+          "name": "uq_analytics_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        },
+        "uq_analytics_event_enrollment": {
+          "name": "uq_analytics_event_enrollment",
+          "columns": [
+            "event_name",
+            "enrollment_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_course_id_courses_id_fk": {
+          "name": "analytics_events_course_id_courses_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_bundle_id_bundles_id_fk": {
+          "name": "analytics_events_bundle_id_bundles_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_payment_id_payments_id_fk": {
+          "name": "analytics_events_payment_id_payments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_enrollment_id_enrollments_id_fk": {
+          "name": "analytics_events_enrollment_id_enrollments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "enrollments",
+          "columnsFrom": [
+            "enrollment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analytics_events_id": {
+          "name": "analytics_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "target_role": {
+          "name": "target_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "announcements_id": {
+          "name": "announcements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_post_tags": {
+      "name": "blog_post_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_post_tags_post_id_blog_posts_id_fk": {
+          "name": "blog_post_tags_post_id_blog_posts_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "blog_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blog_post_tags_tag_id_tags_id_fk": {
+          "name": "blog_post_tags_tag_id_tags_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_post_tags_id": {
+          "name": "blog_post_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_posts": {
+      "name": "blog_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_blog_posts_status": {
+          "name": "idx_blog_posts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_blog_posts_published_at": {
+          "name": "idx_blog_posts_published_at",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_posts_author_id_users_id_fk": {
+          "name": "blog_posts_author_id_users_id_fk",
+          "tableFrom": "blog_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_posts_id": {
+          "name": "blog_posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "blog_posts_slug_unique": {
+          "name": "blog_posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "bundle_courses": {
+      "name": "bundle_courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_bundle_courses_bundle_id": {
+          "name": "idx_bundle_courses_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bundle_courses_bundle_id_bundles_id_fk": {
+          "name": "bundle_courses_bundle_id_bundles_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_courses_course_id_courses_id_fk": {
+          "name": "bundle_courses_course_id_courses_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_courses_id": {
+          "name": "bundle_courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "bundles": {
+      "name": "bundles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "bundles_id": {
+          "name": "bundles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "bundles_slug_unique": {
+          "name": "bundles_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "certificate_code": {
+          "name": "certificate_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_name": {
+          "name": "recipient_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_title": {
+          "name": "course_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_theme": {
+          "name": "certificate_theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_certificates_user_id": {
+          "name": "idx_certificates_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificates_course_id_courses_id_fk": {
+          "name": "certificates_course_id_courses_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "certificates_certificate_code_unique": {
+          "name": "certificates_certificate_code_unique",
+          "columns": [
+            "certificate_code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "coupon_usages": {
+      "name": "coupon_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_coupon_user_course": {
+          "name": "uq_coupon_user_course",
+          "columns": [
+            "coupon_id",
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coupon_usages_coupon_id_coupons_id_fk": {
+          "name": "coupon_usages_coupon_id_coupons_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_user_id_users_id_fk": {
+          "name": "coupon_usages_user_id_users_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_course_id_courses_id_fk": {
+          "name": "coupon_usages_course_id_courses_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupon_usages_id": {
+          "name": "coupon_usages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coupons": {
+      "name": "coupons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_purchase": {
+          "name": "min_purchase",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "max_discount": {
+          "name": "max_discount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "per_user_limit": {
+          "name": "per_user_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_course_id_courses_id_fk": {
+          "name": "coupons_course_id_courses_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupons_id": {
+          "name": "coupons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "coupons_code_unique": {
+          "name": "coupons_code_unique",
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "course_tags": {
+      "name": "course_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_tags_course_id_courses_id_fk": {
+          "name": "course_tags_course_id_courses_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_tags_tag_id_tags_id_fk": {
+          "name": "course_tags_tag_id_tags_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_tags_id": {
+          "name": "course_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "courses": {
+      "name": "courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_color": {
+          "name": "certificate_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#2563eb'"
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_badge": {
+          "name": "certificate_badge",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_video_url": {
+          "name": "preview_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_price": {
+          "name": "promo_price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_starts_at": {
+          "name": "promo_starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_ends_at": {
+          "name": "promo_ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "courses_instructor_id_users_id_fk": {
+          "name": "courses_instructor_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "courses_id": {
+          "name": "courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "courses_slug_unique": {
+          "name": "courses_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "enrollments": {
+      "name": "enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_enrollment_user_course": {
+          "name": "uq_enrollment_user_course",
+          "columns": [
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "enrollments_user_id_users_id_fk": {
+          "name": "enrollments_user_id_users_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollments_course_id_courses_id_fk": {
+          "name": "enrollments_course_id_courses_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "enrollments_id": {
+          "name": "enrollments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lesson_progress": {
+      "name": "lesson_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "watch_time_seconds": {
+          "name": "watch_time_seconds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_watched_at": {
+          "name": "last_watched_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lesson_progress_user_id": {
+          "name": "idx_lesson_progress_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lesson_progress_lesson_id": {
+          "name": "idx_lesson_progress_lesson_id",
+          "columns": [
+            "lesson_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lesson_progress_user_id_users_id_fk": {
+          "name": "lesson_progress_user_id_users_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lesson_progress_id": {
+          "name": "lesson_progress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lessons": {
+      "name": "lessons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_duration": {
+          "name": "video_duration",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_free_preview": {
+          "name": "is_free_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lessons_course_id": {
+          "name": "idx_lessons_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lessons_course_id_courses_id_fk": {
+          "name": "lessons_course_id_courses_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lessons_id": {
+          "name": "lessons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "measurement_outbox": {
+      "name": "measurement_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_measurement_outbox_event_payment": {
+          "name": "uq_measurement_outbox_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        },
+        "uq_measurement_outbox_event_enrollment": {
+          "name": "uq_measurement_outbox_event_enrollment",
+          "columns": [
+            "event_name",
+            "enrollment_id"
+          ],
+          "isUnique": true
+        },
+        "idx_measurement_outbox_projected_at": {
+          "name": "idx_measurement_outbox_projected_at",
+          "columns": [
+            "projected_at"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_payment_id": {
+          "name": "idx_measurement_outbox_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_enrollment_id": {
+          "name": "idx_measurement_outbox_enrollment_id",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "measurement_outbox_payment_id_payments_id_fk": {
+          "name": "measurement_outbox_payment_id_payments_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "measurement_outbox_enrollment_id_enrollments_id_fk": {
+          "name": "measurement_outbox_enrollment_id_enrollments_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "enrollments",
+          "columnsFrom": [
+            "enrollment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "measurement_outbox_id": {
+          "name": "measurement_outbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {
+        "chk_measurement_outbox_acquisition_identity": {
+          "name": "chk_measurement_outbox_acquisition_identity",
+          "value": "\n        (`measurement_outbox`.`event_name` = 'purchase_completed' AND `measurement_outbox`.`payment_id` IS NOT NULL AND `measurement_outbox`.`enrollment_id` IS NULL)\n        OR (`measurement_outbox`.`event_name` = 'free_enrollment_completed' AND `measurement_outbox`.`payment_id` IS NULL AND `measurement_outbox`.`enrollment_id` IS NOT NULL)\n    "
+        }
+      }
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_users_id_fk": {
+          "name": "media_uploaded_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_id": {
+          "name": "media_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notifications_id": {
+          "name": "notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "payments": {
+      "name": "payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_exposure_id": {
+          "name": "attributed_exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'THB'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slip_url": {
+          "name": "slip_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promptpay_trans_ref": {
+          "name": "promptpay_trans_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_title": {
+          "name": "item_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_payments_user_id": {
+          "name": "idx_payments_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_created_at": {
+          "name": "idx_payments_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_status": {
+          "name": "idx_payments_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_coupon_id": {
+          "name": "idx_payments_coupon_id",
+          "columns": [
+            "coupon_id"
+          ],
+          "isUnique": false
+        },
+        "uq_payments_promptpay_trans_ref": {
+          "name": "uq_payments_promptpay_trans_ref",
+          "columns": [
+            "promptpay_trans_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_course_id_courses_id_fk": {
+          "name": "payments_course_id_courses_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_bundle_id_bundles_id_fk": {
+          "name": "payments_bundle_id_bundles_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "payments_id": {
+          "name": "payments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_buckets_reset_at": {
+          "name": "idx_rate_limit_buckets_reset_at",
+          "columns": [
+            "reset_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_hash": {
+          "name": "rate_limit_buckets_key_hash",
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reviews_course_hidden": {
+          "name": "idx_reviews_course_hidden",
+          "columns": [
+            "course_id",
+            "is_hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_course_id_courses_id_fk": {
+          "name": "reviews_course_id_courses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reviews_id": {
+          "name": "reviews_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'string'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id": {
+          "name": "settings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "stripe_events": {
+      "name": "stripe_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_stripe_events_payment_id": {
+          "name": "idx_stripe_events_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_events_type": {
+          "name": "idx_stripe_events_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_payment_id_payments_id_fk": {
+          "name": "stripe_events_payment_id_payments_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_id": {
+          "name": "stripe_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tags_id": {
+          "name": "tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'student'"
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_expires": {
+          "name": "reset_expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_users_deactivated_at": {
+          "name": "idx_users_deactivated_at",
+          "columns": [
+            "deactivated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1788166660977,
       "tag": "0016_luxuriant_gorgon",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "5",
+      "when": 1788173185887,
+      "tag": "0017_authoritative_acquisition_facts",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/bundles/enroll/route.ts
+++ b/src/app/api/bundles/enroll/route.ts
@@ -7,6 +7,7 @@ import { sendEnrollmentEmail } from '@/lib/email';
 import { checkRateLimit, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
 import { safeInsertEnrollment } from '@/lib/db/safe-insert';
 import { requirePublishedBundleCourses, requireReadyBundleCourses } from '@/lib/bundle-commerce';
+import { fulfillFreeEnrollment } from '@/lib/free-enrollment-fulfillment';
 
 // POST /api/bundles/enroll - Enroll in all courses of a bundle
 export async function POST(request: Request) {
@@ -112,12 +113,27 @@ export async function POST(request: Request) {
         const enrolled: string[] = [];
         const skipped: string[] = [];
 
-        for (const course of bCourses) {
-            const { created } = await safeInsertEnrollment(session.user.id, course.courseId);
-            if (created) {
-                enrolled.push(course.courseTitle);
-            } else {
-                skipped.push(course.courseTitle);
+        if (hasAcceptedPayment) {
+            for (const course of bCourses) {
+                const { created } = await safeInsertEnrollment(session.user.id, course.courseId);
+                if (created) {
+                    enrolled.push(course.courseTitle);
+                } else {
+                    skipped.push(course.courseTitle);
+                }
+            }
+        } else {
+            const fulfillment = await fulfillFreeEnrollment({
+                userId: session.user.id,
+                courseIds: bCourses.map((course) => course.courseId),
+            });
+            const createdCourseIds = new Set(fulfillment.created.map((entry) => entry.courseId));
+            for (const course of bCourses) {
+                if (createdCourseIds.has(course.courseId)) {
+                    enrolled.push(course.courseTitle);
+                } else {
+                    skipped.push(course.courseTitle);
+                }
             }
         }
 

--- a/src/app/api/enroll/route.ts
+++ b/src/app/api/enroll/route.ts
@@ -3,14 +3,14 @@ import { logError } from '@/lib/error-handler';
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { enrollments, courses, payments, coupons, couponUsages } from "@/lib/db/schema";
-import { eq, and, sql, count } from "drizzle-orm";
+import { eq, and, count } from "drizzle-orm";
 import { sendEnrollmentEmail } from "@/lib/email";
 import { z } from "zod";
-import { createId } from "@paralleldrive/cuid2";
 import { checkRateLimit, rateLimits, rateLimitResponse } from "@/lib/rate-limit";
 import { calculateDiscount, validateCouponEligibility } from "@/lib/coupon";
 import { safeInsertEnrollment } from "@/lib/db/safe-insert";
 import { COURSE_NOT_READY, requireCourseHasLessons } from "@/lib/course-availability";
+import { fulfillFreeEnrollment } from '@/lib/free-enrollment-fulfillment';
 
 // Validation schema
 const enrollSchema = z.object({
@@ -132,33 +132,20 @@ export async function POST(request: Request) {
             if (discount < coursePrice) {
                 return NextResponse.json({ error: 'คูปองนี้ไม่ได้ลด 100% กรุณาชำระเงินส่วนที่เหลือ' }, { status: 402 });
             }
-            // Record coupon usage + enrollment in a transaction to prevent race conditions
-            // Conditional update guards against TOCTOU: only increments if still under limit
-            const enrollmentId = createId();
-            await db.transaction(async (tx) => {
-                const updateResult = await tx.update(coupons)
-                    .set({ usageCount: sql`${coupons.usageCount} + 1` })
-                    .where(and(
-                        eq(coupons.id, coupon.id),
-                        sql`(${coupons.usageLimit} IS NULL OR ${coupons.usageCount} < ${coupons.usageLimit})`
-                    ));
-                if (updateResult[0].affectedRows === 0) {
-                    throw new Error('COUPON_LIMIT_EXCEEDED');
-                }
-                await tx.insert(couponUsages).values({
-                    couponId: coupon.id,
-                    userId: session.user.id,
-                    courseId,
+            const fulfillment = await fulfillFreeEnrollment({
+                userId: session.user.id,
+                courseIds: [courseId],
+                coupon: {
+                    id: coupon.id,
                     discountAmount: String(Math.min(discount, coursePrice)),
-                });
-                await tx.insert(enrollments).values({
-                    id: enrollmentId,
-                    userId: session.user.id,
-                    courseId,
-                });
+                },
             });
+            const createdEnrollment = fulfillment.created[0];
+            if (!createdEnrollment) {
+                return NextResponse.json({ error: 'Already enrolled in this course' }, { status: 400 });
+            }
 
-            const enrollment = { id: enrollmentId, userId: session.user.id, courseId };
+            const enrollment = { id: createdEnrollment.id, userId: session.user.id, courseId };
 
             // Send enrollment email (non-blocking)
             if (session.user.email && session.user.name) {
@@ -179,8 +166,16 @@ export async function POST(request: Request) {
         }
 
         // Create enrollment (free course or paid with payment verification)
-        // Uses safe insert to handle concurrent duplicate attempts via unique constraint
-        const { created, enrollment } = await safeInsertEnrollment(session.user.id, courseId);
+        const freeFulfillment = coursePrice <= 0
+            ? await fulfillFreeEnrollment({ userId: session.user.id, courseIds: [courseId] })
+            : null;
+        const paidEnrollment = freeFulfillment
+            ? null
+            : await safeInsertEnrollment(session.user.id, courseId);
+        const created = freeFulfillment
+            ? freeFulfillment.created.length > 0
+            : Boolean(paidEnrollment?.created);
+        const enrollment = freeFulfillment?.created[0] ?? paidEnrollment?.enrollment;
         if (!created) {
             return NextResponse.json(
                 { error: "Already enrolled in this course" },

--- a/src/app/api/enrollments/route.ts
+++ b/src/app/api/enrollments/route.ts
@@ -5,7 +5,7 @@ import { enrollments, courses, lessons } from '@/lib/db/schema';
 import { eq, and, count, desc } from 'drizzle-orm';
 import { sendEnrollmentEmail } from '@/lib/email';
 import { checkRateLimit, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
-import { safeInsertEnrollment } from '@/lib/db/safe-insert';
+import { fulfillFreeEnrollment } from '@/lib/free-enrollment-fulfillment';
 import { COURSE_NOT_READY, requireCourseHasLessons } from '@/lib/course-availability';
 
 // GET /api/enrollments - Get user's enrollments
@@ -111,9 +111,11 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create enrollment (safe insert handles race conditions)
-    const { created } = await safeInsertEnrollment(session.user.id, courseId);
-    if (!created) {
+    const fulfillment = await fulfillFreeEnrollment({
+      userId: session.user.id,
+      courseIds: [courseId],
+    });
+    if (fulfillment.status === 'already_fulfilled') {
       return NextResponse.json(
         { error: 'คุณลงทะเบียนคอร์สนี้แล้ว' },
         { status: 400 }

--- a/src/lib/analytics-contract.ts
+++ b/src/lib/analytics-contract.ts
@@ -72,26 +72,33 @@ export const serverAnalyticsEventSchema = z.object({
   courseId: analyticsIdSchema.optional(),
   bundleId: analyticsIdSchema.optional(),
   paymentId: analyticsIdSchema.optional(),
+  enrollmentId: analyticsIdSchema.optional(),
 }).strict().superRefine((value, context) => {
   const hasCourse = Boolean(value.courseId);
   const hasBundle = Boolean(value.bundleId);
   const hasOneProduct = hasCourse !== hasBundle;
 
   if (value.eventName === 'registration_completed') {
-    if (!value.userId || hasCourse || hasBundle || value.paymentId) {
+    if (!value.userId || hasCourse || hasBundle || value.paymentId || value.enrollmentId) {
       context.addIssue({ code: 'custom', message: 'Invalid Registration event' });
     }
     return;
   }
 
   if (value.eventName === 'free_enrollment_completed') {
-    if (!value.userId || !hasOneProduct || value.paymentId) {
+    if (
+      !value.userId
+      || !value.enrollmentId
+      || !hasCourse
+      || hasBundle
+      || value.paymentId
+    ) {
       context.addIssue({ code: 'custom', message: 'Invalid Free enrollment event' });
     }
     return;
   }
 
-  if (!value.userId || !value.paymentId || !hasOneProduct) {
+  if (!value.userId || !value.paymentId || value.enrollmentId || !hasOneProduct) {
     context.addIssue({ code: 'custom', message: 'Paid events require a user, payment, and one product' });
   }
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -33,6 +33,7 @@ async function insertAnalyticsEvent(input: {
   courseId?: string | null;
   bundleId?: string | null;
   paymentId?: string | null;
+  enrollmentId?: string | null;
   placement?: AnalyticsPlacement;
 }): Promise<boolean> {
   try {
@@ -45,6 +46,7 @@ async function insertAnalyticsEvent(input: {
       courseId: input.courseId ?? null,
       bundleId: input.bundleId ?? null,
       paymentId: input.paymentId ?? null,
+      enrollmentId: input.enrollmentId ?? null,
       metadata: input.placement ? JSON.stringify({ placement: input.placement }) : null,
       ipAddress: null,
       userAgent: null,
@@ -77,7 +79,10 @@ export async function recordClientAnalyticsEvent(
 export async function recordServerAnalyticsEvent(input: ServerAnalyticsEvent): Promise<boolean> {
   const parsed = serverAnalyticsEventSchema.safeParse(input);
   if (!parsed.success) return false;
-  if (parsed.data.eventName === 'purchase_completed') return false;
+  if (
+    parsed.data.eventName === 'purchase_completed'
+    || parsed.data.eventName === 'free_enrollment_completed'
+  ) return false;
   return insertAnalyticsEvent({ ...parsed.data, source: 'server' });
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,5 @@
-import { mysqlTable, varchar, char, text, int, decimal, datetime, boolean, uniqueIndex, index } from 'drizzle-orm/mysql-core';
-import { relations } from 'drizzle-orm';
+import { mysqlTable, varchar, char, text, int, decimal, datetime, boolean, uniqueIndex, index, check } from 'drizzle-orm/mysql-core';
+import { relations, sql } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 
 // =====================
@@ -601,6 +601,7 @@ export const analyticsEvents = mysqlTable('analytics_events', {
     courseId: varchar('course_id', { length: 36 }).references(() => courses.id, { onDelete: 'set null' }),
     bundleId: varchar('bundle_id', { length: 36 }).references(() => bundles.id, { onDelete: 'set null' }),
     paymentId: varchar('payment_id', { length: 36 }).references(() => payments.id, { onDelete: 'set null' }),
+    enrollmentId: varchar('enrollment_id', { length: 36 }).references(() => enrollments.id, { onDelete: 'set null' }),
     source: varchar('source', { length: 20, enum: ['client', 'server'] }).default('server').notNull(),
     metadata: text('metadata'),
     ipAddress: varchar('ip_address', { length: 45 }),
@@ -614,7 +615,9 @@ export const analyticsEvents = mysqlTable('analytics_events', {
     index('idx_analytics_course_id').on(table.courseId),
     index('idx_analytics_bundle_id').on(table.bundleId),
     index('idx_analytics_payment_id').on(table.paymentId),
+    index('idx_analytics_enrollment_id').on(table.enrollmentId),
     uniqueIndex('uq_analytics_event_payment').on(table.eventName, table.paymentId),
+    uniqueIndex('uq_analytics_event_enrollment').on(table.eventName, table.enrollmentId),
 ]);
 
 export const analyticsEventsRelations = relations(analyticsEvents, ({ one }) => ({
@@ -634,6 +637,10 @@ export const analyticsEventsRelations = relations(analyticsEvents, ({ one }) => 
         fields: [analyticsEvents.paymentId],
         references: [payments.id],
     }),
+    enrollment: one(enrollments, {
+        fields: [analyticsEvents.enrollmentId],
+        references: [enrollments.id],
+    }),
 }));
 
 // =====================
@@ -641,8 +648,9 @@ export const analyticsEventsRelations = relations(analyticsEvents, ({ one }) => 
 // =====================
 export const measurementOutbox = mysqlTable('measurement_outbox', {
     id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => createId()),
-    eventName: varchar('event_name', { length: 100, enum: ['purchase_completed'] }).notNull(),
-    paymentId: varchar('payment_id', { length: 36 }).references(() => payments.id).notNull(),
+    eventName: varchar('event_name', { length: 100, enum: ['purchase_completed', 'free_enrollment_completed'] }).notNull(),
+    paymentId: varchar('payment_id', { length: 36 }).references(() => payments.id),
+    enrollmentId: varchar('enrollment_id', { length: 36 }).references(() => enrollments.id),
     attemptCount: int('attempt_count').default(0).notNull(),
     lastAttemptAt: datetime('last_attempt_at'),
     lastErrorCode: varchar('last_error_code', { length: 64 }),
@@ -650,14 +658,24 @@ export const measurementOutbox = mysqlTable('measurement_outbox', {
     createdAt: datetime('created_at').$defaultFn(() => new Date()).notNull(),
 }, (table) => [
     uniqueIndex('uq_measurement_outbox_event_payment').on(table.eventName, table.paymentId),
+    uniqueIndex('uq_measurement_outbox_event_enrollment').on(table.eventName, table.enrollmentId),
     index('idx_measurement_outbox_projected_at').on(table.projectedAt),
     index('idx_measurement_outbox_payment_id').on(table.paymentId),
+    index('idx_measurement_outbox_enrollment_id').on(table.enrollmentId),
+    check('chk_measurement_outbox_acquisition_identity', sql`
+        (${table.eventName} = 'purchase_completed' AND ${table.paymentId} IS NOT NULL AND ${table.enrollmentId} IS NULL)
+        OR (${table.eventName} = 'free_enrollment_completed' AND ${table.paymentId} IS NULL AND ${table.enrollmentId} IS NOT NULL)
+    `),
 ]);
 
 export const measurementOutboxRelations = relations(measurementOutbox, ({ one }) => ({
     payment: one(payments, {
         fields: [measurementOutbox.paymentId],
         references: [payments.id],
+    }),
+    enrollment: one(enrollments, {
+        fields: [measurementOutbox.enrollmentId],
+        references: [enrollments.id],
     }),
 }));
 

--- a/src/lib/enrollment-measurement-projector.ts
+++ b/src/lib/enrollment-measurement-projector.ts
@@ -1,0 +1,129 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import { db } from '@/lib/db';
+import { analyticsEvents, enrollments, measurementOutbox } from '@/lib/db/schema';
+import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+
+export type FreeEnrollmentProjection = {
+  enrollmentId: string;
+  userId: string;
+  courseId: string;
+};
+
+export interface EnrollmentMeasurementStore {
+  readEnrollment(enrollmentId: string): Promise<FreeEnrollmentProjection | null>;
+  projectPendingEnrollment(
+    enrollment: FreeEnrollmentProjection,
+  ): Promise<'projected' | 'duplicate' | 'already_projected'>;
+  recordProjectionFailure(enrollmentId: string): Promise<void>;
+}
+
+export interface EnrollmentMeasurementProjector {
+  projectEnrollment(
+    enrollmentId: string,
+  ): Promise<{ status: 'projected' | 'duplicate' | 'already_projected' | 'disabled' | 'ineligible' | 'failed' }>;
+}
+
+export function createEnrollmentMeasurementProjector(input: {
+  store: EnrollmentMeasurementStore;
+  isEventEnabled(eventName: 'free_enrollment_completed'): Promise<boolean>;
+}): EnrollmentMeasurementProjector {
+  return {
+    async projectEnrollment(enrollmentId) {
+      if (!enrollmentId.trim() || enrollmentId.length > 36) return { status: 'ineligible' };
+
+      try {
+        if (!(await input.isEventEnabled('free_enrollment_completed'))) return { status: 'disabled' };
+        const enrollment = await input.store.readEnrollment(enrollmentId);
+        if (!enrollment) return { status: 'ineligible' };
+        return { status: await input.store.projectPendingEnrollment(enrollment) };
+      } catch {
+        try {
+          await input.store.recordProjectionFailure(enrollmentId);
+        } catch {
+          // Optional measurement failure never becomes enrollment authority.
+        }
+        return { status: 'failed' };
+      }
+    },
+  };
+}
+
+const drizzleEnrollmentMeasurementStore: EnrollmentMeasurementStore = {
+  async readEnrollment(enrollmentId) {
+    const [enrollment] = await db
+      .select({
+        enrollmentId: enrollments.id,
+        userId: enrollments.userId,
+        courseId: enrollments.courseId,
+      })
+      .from(enrollments)
+      .where(eq(enrollments.id, enrollmentId))
+      .limit(1);
+    return enrollment ?? null;
+  },
+
+  async projectPendingEnrollment(enrollment) {
+    return db.transaction(async (tx) => {
+      const [outbox] = await tx
+        .select({ id: measurementOutbox.id, createdAt: measurementOutbox.createdAt })
+        .from(measurementOutbox)
+        .where(and(
+          eq(measurementOutbox.eventName, 'free_enrollment_completed'),
+          eq(measurementOutbox.enrollmentId, enrollment.enrollmentId),
+          isNull(measurementOutbox.projectedAt),
+        ))
+        .limit(1);
+      if (!outbox) return 'already_projected';
+
+      let duplicate = false;
+      try {
+        await tx.insert(analyticsEvents).values({
+          eventName: 'free_enrollment_completed',
+          source: 'server',
+          userId: enrollment.userId,
+          courseId: enrollment.courseId,
+          bundleId: null,
+          paymentId: null,
+          enrollmentId: enrollment.enrollmentId,
+          metadata: null,
+          ipAddress: null,
+          userAgent: null,
+          createdAt: outbox.createdAt,
+        });
+      } catch (error) {
+        if (!isDuplicateKeyError(error)) throw error;
+        duplicate = true;
+      }
+
+      await tx.update(measurementOutbox).set({
+        attemptCount: sql`${measurementOutbox.attemptCount} + 1`,
+        lastAttemptAt: new Date(),
+        lastErrorCode: null,
+        projectedAt: new Date(),
+      }).where(and(
+        eq(measurementOutbox.id, outbox.id),
+        isNull(measurementOutbox.projectedAt),
+      ));
+      return duplicate ? 'duplicate' : 'projected';
+    });
+  },
+
+  async recordProjectionFailure(enrollmentId) {
+    await db.update(measurementOutbox).set({
+      attemptCount: sql`${measurementOutbox.attemptCount} + 1`,
+      lastAttemptAt: new Date(),
+      lastErrorCode: 'projection_failed',
+    }).where(and(
+      eq(measurementOutbox.eventName, 'free_enrollment_completed'),
+      eq(measurementOutbox.enrollmentId, enrollmentId),
+      isNull(measurementOutbox.projectedAt),
+    ));
+  },
+};
+
+export const enrollmentMeasurementProjector = createEnrollmentMeasurementProjector({
+  store: drizzleEnrollmentMeasurementStore,
+  isEventEnabled: isAnalyticsEventEnabled,
+});

--- a/src/lib/free-enrollment-fulfillment.ts
+++ b/src/lib/free-enrollment-fulfillment.ts
@@ -1,0 +1,111 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { createId } from '@paralleldrive/cuid2';
+
+import { db } from '@/lib/db';
+import { couponUsages, coupons, enrollments, measurementOutbox } from '@/lib/db/schema';
+import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+import { enrollmentMeasurementProjector } from '@/lib/enrollment-measurement-projector';
+
+type DatabaseTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export class FreeEnrollmentFulfillmentError extends Error {
+  constructor(readonly code: 'INVALID_FREE_ENROLLMENT' | 'COUPON_LIMIT_EXCEEDED') {
+    super(code);
+    this.name = 'FreeEnrollmentFulfillmentError';
+  }
+}
+
+type EnrollmentOutcome = { id: string; courseId: string; created: boolean };
+
+function getAffectedRows(result: unknown): number {
+  const candidate = Array.isArray(result) ? result[0] : result;
+  if (!candidate || typeof candidate !== 'object' || !('affectedRows' in candidate)) return 0;
+  return Number((candidate as { affectedRows: unknown }).affectedRows) || 0;
+}
+
+async function insertEnrollment(
+  tx: DatabaseTransaction,
+  userId: string,
+  courseId: string,
+): Promise<EnrollmentOutcome> {
+  const id = createId();
+  try {
+    await tx.insert(enrollments).values({ id, userId, courseId });
+  } catch (error) {
+    if (!isDuplicateKeyError(error)) throw error;
+    const [existing] = await tx.select({ id: enrollments.id }).from(enrollments)
+      .where(and(eq(enrollments.userId, userId), eq(enrollments.courseId, courseId)))
+      .limit(1);
+    if (!existing) throw error;
+    return { id: existing.id, courseId, created: false };
+  }
+
+  await tx.insert(measurementOutbox).values({
+    eventName: 'free_enrollment_completed',
+    paymentId: null,
+    enrollmentId: id,
+  });
+  return { id, courseId, created: true };
+}
+
+export async function fulfillFreeEnrollment({
+  userId,
+  courseIds,
+  coupon,
+}: {
+  userId: string;
+  courseIds: string[];
+  coupon?: { id: string; discountAmount: string };
+}): Promise<{
+  status: 'fulfilled' | 'already_fulfilled';
+  created: EnrollmentOutcome[];
+  existing: EnrollmentOutcome[];
+}> {
+  const uniqueCourseIds = [...new Set(courseIds.map((id) => id.trim()).filter(Boolean))];
+  if (
+    !userId.trim()
+    || userId.length > 36
+    || uniqueCourseIds.length === 0
+    || uniqueCourseIds.some((id) => id.length > 36)
+    || (coupon && uniqueCourseIds.length !== 1)
+  ) {
+    throw new FreeEnrollmentFulfillmentError('INVALID_FREE_ENROLLMENT');
+  }
+
+  const outcomes = await db.transaction(async (tx) => {
+    const entries: EnrollmentOutcome[] = [];
+    for (const courseId of uniqueCourseIds) {
+      entries.push(await insertEnrollment(tx, userId, courseId));
+    }
+
+    const created = entries.filter((entry) => entry.created);
+    if (coupon && created.length > 0) {
+      const updateResult = await tx.update(coupons)
+        .set({ usageCount: sql`${coupons.usageCount} + 1` })
+        .where(and(
+          eq(coupons.id, coupon.id),
+          sql`(${coupons.usageLimit} IS NULL OR ${coupons.usageCount} < ${coupons.usageLimit})`,
+        ));
+      if (getAffectedRows(updateResult) !== 1) {
+        throw new FreeEnrollmentFulfillmentError('COUPON_LIMIT_EXCEEDED');
+      }
+      await tx.insert(couponUsages).values({
+        couponId: coupon.id,
+        userId,
+        courseId: uniqueCourseIds[0],
+        discountAmount: coupon.discountAmount,
+      });
+    }
+    return entries;
+  });
+
+  for (const enrollment of outcomes) {
+    await enrollmentMeasurementProjector.projectEnrollment(enrollment.id);
+  }
+  const created = outcomes.filter((entry) => entry.created);
+  return {
+    status: created.length > 0 ? 'fulfilled' : 'already_fulfilled',
+    created,
+    existing: outcomes.filter((entry) => !entry.created),
+  };
+}

--- a/src/lib/payment-fulfillment.ts
+++ b/src/lib/payment-fulfillment.ts
@@ -299,8 +299,7 @@ export async function fulfillStripeCheckoutSession({
         payment: { ...payment, status: 'completed', stripePaymentId: paymentIntentId },
         emailDetails,
       };
-      },
-    );
+    });
 
     await purchaseMeasurementProjector.projectPurchase(result.payment.id);
     return result;
@@ -337,7 +336,7 @@ export async function fulfillManualPayment({
   }
 
   try {
-    return await db.transaction(async (tx) => {
+    const result: Extract<ManualPaymentFulfillmentResult, { payment: Payment }> = await db.transaction(async (tx) => {
       const [payment] = await tx
         .select()
         .from(payments)
@@ -391,12 +390,20 @@ export async function fulfillManualPayment({
         newValue: `status: completed; manual approval; reason: ${reason.trim()}`,
       });
 
+      await tx.insert(measurementOutbox).values({
+        eventName: 'purchase_completed',
+        paymentId: payment.id,
+      });
+
       return {
         status: 'fulfilled',
         payment: { ...payment, status: 'completed' },
         enrolledCount,
       };
     });
+
+    await purchaseMeasurementProjector.projectPurchase(result.payment.id);
+    return result;
   } catch (error) {
     if (error instanceof FulfillmentRejection) {
       return { status: 'rejected', code: error.code, retryable: error.retryable };

--- a/src/lib/promptpay-fulfillment.ts
+++ b/src/lib/promptpay-fulfillment.ts
@@ -8,10 +8,12 @@ import {
   couponUsages,
   courses,
   enrollments,
+  measurementOutbox,
   payments,
   type Payment,
 } from '@/lib/db/schema';
 import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+import { purchaseMeasurementProjector } from '@/lib/purchase-measurement-projector';
 import {
   assertPromptPayIntentClaim,
   PromptPayIntentError,
@@ -97,7 +99,7 @@ export async function fulfillPromptPayIntent({
     throw new Error('PROMPTPAY_REFERENCE_INVALID');
   }
 
-  return db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     const [payment] = await tx.select().from(payments)
       .where(eq(payments.id, paymentId))
       .for('update');
@@ -176,11 +178,19 @@ export async function fulfillPromptPayIntent({
       }
     }
 
+    await tx.insert(measurementOutbox).values({
+      eventName: 'purchase_completed',
+      paymentId: payment.id,
+    });
+
     return {
       status: 'fulfilled' as const,
-      payment: { ...payment, status: 'completed', promptpayTransRef, slipUrl: promptpayTransRef },
+      payment: { ...payment, status: 'completed' as const, promptpayTransRef, slipUrl: promptpayTransRef },
       enrolledCount,
       emailDetails,
     };
   });
+
+  await purchaseMeasurementProjector.projectPurchase(result.payment.id);
+  return result;
 }

--- a/src/lib/purchase-measurement-projector.ts
+++ b/src/lib/purchase-measurement-projector.ts
@@ -12,11 +12,12 @@ export type PurchaseProjection = {
   bundleId: string | null;
   method: 'stripe' | 'promptpay' | 'bank_transfer';
   status: 'pending' | 'completed' | 'failed' | 'refunded' | 'verifying';
+  amount: string;
   attributedExposureId: string | null;
 };
 
 export interface PurchaseMeasurementStore {
-  readCompletedStripePayment(paymentId: string): Promise<PurchaseProjection | null>;
+  readCompletedPayment(paymentId: string): Promise<PurchaseProjection | null>;
   ensurePurchaseOutbox(paymentId: string): Promise<void>;
   projectPendingPurchase(
     payment: PurchaseProjection,
@@ -30,13 +31,15 @@ export interface PurchaseMeasurementProjector {
   ): Promise<{ status: 'projected' | 'duplicate' | 'already_projected' | 'disabled' | 'ineligible' | 'failed' }>;
 }
 
-function isEligibleStripePurchase(payment: PurchaseProjection | null): payment is PurchaseProjection {
+function isEligiblePaidPurchase(payment: PurchaseProjection | null): payment is PurchaseProjection {
+  const amount = Number(payment?.amount);
   return Boolean(
     payment
     && payment.status === 'completed'
-    && payment.method === 'stripe'
     && payment.userId
-    && Boolean(payment.courseId) !== Boolean(payment.bundleId),
+    && Boolean(payment.courseId) !== Boolean(payment.bundleId)
+    && Number.isFinite(amount)
+    && amount > 0
   );
 }
 
@@ -51,8 +54,8 @@ export function createPurchaseMeasurementProjector(input: {
       try {
         if (!(await input.isEventEnabled('purchase_completed'))) return { status: 'disabled' };
 
-        const payment = await input.store.readCompletedStripePayment(paymentId);
-        if (!isEligibleStripePurchase(payment)) return { status: 'ineligible' };
+        const payment = await input.store.readCompletedPayment(paymentId);
+        if (!isEligiblePaidPurchase(payment)) return { status: 'ineligible' };
 
         await input.store.ensurePurchaseOutbox(paymentId);
         const status = await input.store.projectPendingPurchase(payment);
@@ -70,7 +73,7 @@ export function createPurchaseMeasurementProjector(input: {
 }
 
 const drizzlePurchaseMeasurementStore: PurchaseMeasurementStore = {
-  async readCompletedStripePayment(paymentId) {
+  async readCompletedPayment(paymentId) {
     const [payment] = await db
       .select({
         paymentId: payments.id,
@@ -79,6 +82,7 @@ const drizzlePurchaseMeasurementStore: PurchaseMeasurementStore = {
         bundleId: payments.bundleId,
         method: payments.method,
         status: payments.status,
+        amount: payments.amount,
         attributedExposureId: payments.attributedExposureId,
       })
       .from(payments)

--- a/tests/lib/acquisition-outbox-schema.test.ts
+++ b/tests/lib/acquisition-outbox-schema.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/mysql-core';
+
+import { analyticsEvents, measurementOutbox } from '@/lib/db/schema';
+
+function indexColumns(config: ReturnType<typeof getTableConfig>, name: string) {
+  const candidate = config.indexes.find((entry) => entry.config.name === name);
+  return {
+    unique: candidate?.config.unique,
+    columns: candidate?.config.columns.map((column) => (
+      'name' in column ? column.name : null
+    )),
+  };
+}
+
+describe('authoritative acquisition outbox schema', () => {
+  it('keys paid purchases by payment and free enrollments by enrollment', () => {
+    const outbox = getTableConfig(measurementOutbox);
+    const paymentId = outbox.columns.find((column) => column.name === 'payment_id');
+    const enrollmentId = outbox.columns.find((column) => column.name === 'enrollment_id');
+
+    expect(paymentId?.notNull).toBe(false);
+    expect(enrollmentId?.notNull).toBe(false);
+    expect(indexColumns(outbox, 'uq_measurement_outbox_event_payment')).toEqual({
+      unique: true,
+      columns: ['event_name', 'payment_id'],
+    });
+    expect(indexColumns(outbox, 'uq_measurement_outbox_event_enrollment')).toEqual({
+      unique: true,
+      columns: ['event_name', 'enrollment_id'],
+    });
+    expect(outbox.checks.map((candidate) => candidate.name)).toContain(
+      'chk_measurement_outbox_acquisition_identity',
+    );
+  });
+
+  it('deduplicates projected facts using the same domain identities', () => {
+    const analytics = getTableConfig(analyticsEvents);
+    const enrollmentId = analytics.columns.find((column) => column.name === 'enrollment_id');
+
+    expect(enrollmentId?.notNull).toBe(false);
+    expect(indexColumns(analytics, 'uq_analytics_event_payment')).toEqual({
+      unique: true,
+      columns: ['event_name', 'payment_id'],
+    });
+    expect(indexColumns(analytics, 'uq_analytics_event_enrollment')).toEqual({
+      unique: true,
+      columns: ['event_name', 'enrollment_id'],
+    });
+  });
+  it('keeps migration 0017 additive and identity-safe', () => {
+    const migration = readFileSync(
+      resolve(process.cwd(), 'drizzle/0017_authoritative_acquisition_facts.sql'),
+      'utf8',
+    );
+
+    expect(migration).toMatch(/MODIFY COLUMN .payment_id. varchar\(36\);/);
+    expect(migration.match(/ADD .enrollment_id. varchar\(36\)/g)).toHaveLength(2);
+    expect(migration).toMatch(/ADD CONSTRAINT .chk_measurement_outbox_acquisition_identity. CHECK/);
+    expect(migration).not.toMatch(/chk_analytics_acquisition_identity/);
+    expect(migration).not.toMatch(/^\s*(DROP|DELETE|UPDATE|RENAME|TRUNCATE)\b/im);
+  });
+});

--- a/tests/lib/analytics-event-privacy-contract.test.ts
+++ b/tests/lib/analytics-event-privacy-contract.test.ts
@@ -42,7 +42,8 @@ describe('analytics privacy contracts', () => {
     expect(serverAnalyticsEventSchema.safeParse({
       eventName: 'free_enrollment_completed',
       userId: 'user-1',
-      bundleId: 'bundle-1',
+      courseId: 'course-1',
+      enrollmentId: 'enrollment-1',
     }).success).toBe(true);
   });
 
@@ -57,6 +58,11 @@ describe('analytics privacy contracts', () => {
       userId: 'user-1',
       courseId: 'course-1',
       bundleId: 'bundle-1',
+    }).success).toBe(false);
+    expect(serverAnalyticsEventSchema.safeParse({
+      eventName: 'free_enrollment_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
     }).success).toBe(false);
     expect(serverAnalyticsEventSchema.safeParse({
       eventName: 'registration_completed',

--- a/tests/lib/analytics-writer.test.ts
+++ b/tests/lib/analytics-writer.test.ts
@@ -82,6 +82,18 @@ describe('analytics writer boundary', () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it('routes free enrollment completion through the transactional outbox', async () => {
+    await expect(recordServerAnalyticsEvent({
+      eventName: 'free_enrollment_completed',
+      userId: 'user-1',
+      courseId: 'course-1',
+      enrollmentId: 'enrollment-1',
+    })).resolves.toBe(false);
+
+    expect(isAnalyticsEventEnabled).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it('stores only allow-listed fields with null network identifiers', async () => {
     await expect(recordClientAnalyticsEvent(checkoutEvent, 'user-1')).resolves.toBe(true);
 
@@ -92,6 +104,7 @@ describe('analytics writer boundary', () => {
       courseId: 'course-1',
       bundleId: null,
       paymentId: null,
+      enrollmentId: null,
       metadata: JSON.stringify({ placement: 'course_detail' }),
       ipAddress: null,
       userAgent: null,

--- a/tests/lib/enrollment-measurement-projector.test.ts
+++ b/tests/lib/enrollment-measurement-projector.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createEnrollmentMeasurementProjector,
+  type EnrollmentMeasurementStore,
+  type FreeEnrollmentProjection,
+} from '@/lib/enrollment-measurement-projector';
+
+class MemoryEnrollmentMeasurementStore implements EnrollmentMeasurementStore {
+  enrollment: FreeEnrollmentProjection | null = {
+    enrollmentId: 'enrollment-1',
+    userId: 'student-1',
+    courseId: 'course-1',
+  };
+  hasOutbox = true;
+  projected = false;
+  facts = new Set<string>();
+  failures = 0;
+  failProjection = false;
+
+  async readEnrollment(enrollmentId: string) {
+    return this.enrollment?.enrollmentId === enrollmentId ? this.enrollment : null;
+  }
+
+  async projectPendingEnrollment(enrollment: FreeEnrollmentProjection) {
+    if (this.failProjection) throw new Error('projector unavailable');
+    if (!this.hasOutbox || this.projected) return 'already_projected' as const;
+    const duplicate = this.facts.has(enrollment.enrollmentId);
+    this.facts.add(enrollment.enrollmentId);
+    this.projected = true;
+    return duplicate ? 'duplicate' as const : 'projected' as const;
+  }
+
+  async recordProjectionFailure() {
+    this.failures += 1;
+  }
+}
+
+describe('free enrollment measurement projector', () => {
+  it('projects one fact from the committed outbox identity', async () => {
+    const store = new MemoryEnrollmentMeasurementStore();
+    const projector = createEnrollmentMeasurementProjector({
+      store,
+      isEventEnabled: async () => true,
+    });
+
+    await expect(projector.projectEnrollment('enrollment-1')).resolves.toEqual({ status: 'projected' });
+    expect(store.facts).toEqual(new Set(['enrollment-1']));
+  });
+
+  it('does not infer a free fact from an enrollment that has no free outbox', async () => {
+    const store = new MemoryEnrollmentMeasurementStore();
+    store.hasOutbox = false;
+    const projector = createEnrollmentMeasurementProjector({ store, isEventEnabled: async () => true });
+
+    await expect(projector.projectEnrollment('enrollment-1')).resolves.toEqual({ status: 'already_projected' });
+    expect(store.facts.size).toBe(0);
+  });
+
+  it('keeps the outbox recoverable through a projection outage and retry', async () => {
+    const store = new MemoryEnrollmentMeasurementStore();
+    const projector = createEnrollmentMeasurementProjector({ store, isEventEnabled: async () => true });
+    store.failProjection = true;
+
+    await expect(projector.projectEnrollment('enrollment-1')).resolves.toEqual({ status: 'failed' });
+    expect(store.failures).toBe(1);
+    expect(store.enrollment).not.toBeNull();
+
+    store.failProjection = false;
+    await expect(projector.projectEnrollment('enrollment-1')).resolves.toEqual({ status: 'projected' });
+    expect(store.facts).toEqual(new Set(['enrollment-1']));
+  });
+});

--- a/tests/lib/free-enrollment-fulfillment.test.ts
+++ b/tests/lib/free-enrollment-fulfillment.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  dbTransaction,
+  insertedRows,
+  projectEnrollment,
+  duplicateCourses,
+  enrollmentIds,
+} = vi.hoisted(() => ({
+  dbTransaction: vi.fn(),
+  insertedRows: [] as Array<Record<string, unknown>>,
+  projectEnrollment: vi.fn(),
+  duplicateCourses: new Set<string>(),
+  enrollmentIds: new Map<string, string>(),
+}));
+
+vi.mock('@/lib/db', () => ({ db: { transaction: dbTransaction } }));
+vi.mock('@/lib/db/safe-insert', () => ({
+  isDuplicateKeyError: vi.fn((error: unknown) => error instanceof Error && error.message === 'duplicate'),
+}));
+vi.mock('@/lib/enrollment-measurement-projector', () => ({
+  enrollmentMeasurementProjector: { projectEnrollment },
+}));
+
+import { fulfillFreeEnrollment } from '@/lib/free-enrollment-fulfillment';
+
+function transactionAdapter() {
+  return {
+    insert: vi.fn(() => ({
+      values: vi.fn(async (row: Record<string, unknown>) => {
+        const isEnrollment = Boolean(row.id && row.userId && row.courseId && !row.eventName && !row.couponId);
+        if (isEnrollment && duplicateCourses.has(String(row.courseId))) {
+          throw new Error('duplicate');
+        }
+        insertedRows.push(row);
+        if (isEnrollment) {
+          enrollmentIds.set(String(row.courseId), String(row.id));
+        }
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [{ id: 'existing-enrollment' }]),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ affectedRows: 1 }]) })),
+    })),
+  };
+}
+
+describe('free enrollment fulfillment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRows.length = 0;
+    duplicateCourses.clear();
+    enrollmentIds.clear();
+    projectEnrollment.mockResolvedValue({ status: 'projected' });
+    dbTransaction.mockImplementation(async (work) => work(transactionAdapter()));
+  });
+
+  it('creates one enrollment fact for a first-created free course enrollment', async () => {
+    const result = await fulfillFreeEnrollment({
+      userId: 'student-1',
+      courseIds: ['course-1'],
+    });
+
+    expect(result.status).toBe('fulfilled');
+    const enrollmentId = enrollmentIds.get('course-1');
+    expect(enrollmentId).toBeTruthy();
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'free_enrollment_completed',
+      enrollmentId,
+      paymentId: null,
+    }));
+    expect(projectEnrollment).toHaveBeenCalledWith(enrollmentId);
+  });
+
+  it('creates one fact per newly-created course enrollment in a free Bundle', async () => {
+    const result = await fulfillFreeEnrollment({
+      userId: 'student-1',
+      courseIds: ['course-1', 'course-2'],
+    });
+
+    expect(result.created).toHaveLength(2);
+    expect(insertedRows.filter((row) => row.eventName === 'free_enrollment_completed')).toHaveLength(2);
+    expect(projectEnrollment).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not enqueue a second fact when the enrollment already exists', async () => {
+    duplicateCourses.add('course-1');
+
+    const result = await fulfillFreeEnrollment({
+      userId: 'student-1',
+      courseIds: ['course-1'],
+    });
+
+    expect(result.status).toBe('already_fulfilled');
+    expect(insertedRows).not.toContainEqual(expect.objectContaining({
+      eventName: 'free_enrollment_completed',
+    }));
+    expect(projectEnrollment).toHaveBeenCalledWith('existing-enrollment');
+  });
+
+  it('keeps a 100%-coupon usage, enrollment, and outbox in the same transaction', async () => {
+    const result = await fulfillFreeEnrollment({
+      userId: 'student-1',
+      courseIds: ['course-1'],
+      coupon: { id: 'coupon-1', discountAmount: '990' },
+    });
+
+    expect(result.status).toBe('fulfilled');
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      couponId: 'coupon-1',
+      userId: 'student-1',
+      courseId: 'course-1',
+      discountAmount: '990',
+    }));
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'free_enrollment_completed',
+      enrollmentId: enrollmentIds.get('course-1'),
+    }));
+  });
+
+  it('does not reverse a committed free enrollment when projection is unavailable', async () => {
+    projectEnrollment.mockResolvedValue({ status: 'failed' });
+
+    const result = await fulfillFreeEnrollment({
+      userId: 'student-1',
+      courseIds: ['course-1'],
+    });
+
+    expect(result.status).toBe('fulfilled');
+    expect(result.created).toHaveLength(1);
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'free_enrollment_completed',
+      enrollmentId: result.created[0].id,
+    }));
+  });
+});

--- a/tests/lib/manual-purchase-outbox.test.ts
+++ b/tests/lib/manual-purchase-outbox.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbTransaction, insertedRows, paymentState, projectPurchase } = vi.hoisted(() => ({
+  dbTransaction: vi.fn(),
+  insertedRows: [] as Array<Record<string, unknown>>,
+  paymentState: { status: 'verifying' as 'verifying' | 'completed' },
+  projectPurchase: vi.fn(),
+}));
+
+vi.mock('@/lib/db/safe-insert', () => ({
+  isDuplicateKeyError: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/db', () => ({ db: { transaction: dbTransaction } }));
+vi.mock('@/lib/purchase-measurement-projector', () => ({
+  purchaseMeasurementProjector: { projectPurchase },
+}));
+
+import { fulfillManualPayment } from '@/lib/payment-fulfillment';
+
+const payment = () => ({
+  id: 'payment-1',
+  userId: 'student-1',
+  courseId: 'course-1',
+  bundleId: null,
+  couponId: null,
+  attributedExposureId: null,
+  amount: '990.00',
+  currency: 'THB',
+  method: 'promptpay',
+  stripePaymentId: null,
+  slipUrl: null,
+  promptpayTransRef: null,
+  itemTitle: 'Course One',
+  status: paymentState.status,
+  retryCount: 0,
+  lastRetryAt: null,
+  createdAt: new Date('2026-08-31T09:00:00.000Z'),
+});
+
+function transactionAdapter() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([payment()]) })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ affectedRows: 1 }]) })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (row: Record<string, unknown>) => {
+        insertedRows.push(row);
+      }),
+    })),
+  };
+}
+
+describe('audited manual purchase outbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRows.length = 0;
+    paymentState.status = 'verifying';
+    projectPurchase.mockResolvedValue({ status: 'projected' });
+    dbTransaction.mockImplementation(async (work) => work(transactionAdapter()));
+  });
+
+  it('audits and enqueues only the first authorized completion before projecting it', async () => {
+    const result = await fulfillManualPayment({
+      paymentId: 'payment-1',
+      allowedMethod: 'promptpay',
+      actorId: 'admin-1',
+      reason: 'ตรวจสอบหลักฐานกับธนาคารแล้ว',
+    });
+
+    expect(result.status).toBe('fulfilled');
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      userId: 'admin-1',
+      entityType: 'payment',
+      entityId: 'payment-1',
+    }));
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed',
+      paymentId: 'payment-1',
+    }));
+    expect(projectPurchase).toHaveBeenCalledWith('payment-1');
+  });
+
+  it('uses an already-completed retry only to reconcile the original fact', async () => {
+    paymentState.status = 'completed';
+
+    const result = await fulfillManualPayment({
+      paymentId: 'payment-1',
+      allowedMethod: 'promptpay',
+      actorId: 'admin-1',
+      reason: 'ตรวจสอบซ้ำตามคำขอผู้เรียน',
+    });
+
+    expect(result.status).toBe('already_fulfilled');
+    expect(insertedRows).toHaveLength(0);
+    expect(projectPurchase).toHaveBeenCalledWith('payment-1');
+  });
+
+  it('does not reverse audited completion when projection is unavailable after commit', async () => {
+    projectPurchase.mockResolvedValue({ status: 'failed' });
+
+    const result = await fulfillManualPayment({
+      paymentId: 'payment-1',
+      allowedMethod: 'promptpay',
+      actorId: 'admin-1',
+      reason: 'ตรวจสอบหลักฐานกับธนาคารแล้ว',
+    });
+
+    expect(result.status).toBe('fulfilled');
+    expect(insertedRows).toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed',
+      paymentId: 'payment-1',
+    }));
+  });
+
+  it('rejects missing audit context before touching payment authority or measurement', async () => {
+    const result = await fulfillManualPayment({
+      paymentId: 'payment-1',
+      actorId: '',
+      reason: 'no',
+    });
+
+    expect(result).toEqual({
+      status: 'rejected', code: 'INVALID_AUDIT_CONTEXT', retryable: false,
+    });
+    expect(dbTransaction).not.toHaveBeenCalled();
+    expect(projectPurchase).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/promptpay-fulfillment.test.ts
+++ b/tests/lib/promptpay-fulfillment.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { projectPurchase } = vi.hoisted(() => ({
+  projectPurchase: vi.fn(),
+}));
+
 const selectQueue: unknown[][] = [];
 const inserted: unknown[] = [];
 const updates: unknown[] = [];
@@ -35,6 +39,9 @@ vi.mock('@/lib/db', () => ({
   },
 }));
 
+vi.mock('@/lib/purchase-measurement-projector', () => ({
+  purchaseMeasurementProjector: { projectPurchase },
+}));
 import { fulfillPromptPayIntent } from '@/lib/promptpay-fulfillment';
 
 const payment = {
@@ -62,6 +69,7 @@ describe('PromptPay fulfillment after course retirement', () => {
     selectQueue.length = 0;
     inserted.length = 0;
     updates.length = 0;
+    projectPurchase.mockResolvedValue({ status: 'projected' });
   });
 
   it('fulfills a previously accepted intent without rechecking publication status', async () => {
@@ -85,6 +93,11 @@ describe('PromptPay fulfillment after course retirement', () => {
       userId: 'student-1',
       courseId: 'course-archived',
     }));
+    expect(inserted).toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed',
+      paymentId: 'payment-1',
+    }));
+    expect(projectPurchase).toHaveBeenCalledWith('payment-1');
   });
 
   it('returns an idempotent result for an already-completed owner retry', async () => {
@@ -99,5 +112,27 @@ describe('PromptPay fulfillment after course retirement', () => {
     expect(result.status).toBe('already_fulfilled');
     expect(updates).toHaveLength(0);
     expect(inserted).toHaveLength(0);
+    expect(projectPurchase).toHaveBeenCalledWith('payment-1');
+  });
+
+  it('does not reverse fulfillment when purchase projection is unavailable after commit', async () => {
+    projectPurchase.mockResolvedValue({ status: 'failed' });
+    selectQueue.push(
+      [payment],
+      [{ title: 'Archived Course', slug: 'archived-course', status: 'archived' }],
+    );
+
+    const result = await fulfillPromptPayIntent({
+      paymentId: 'payment-1',
+      userId: 'student-1',
+      promptpayTransRef: 'provider-ref-1',
+    });
+
+    expect(result.status).toBe('fulfilled');
+    expect(inserted).toContainEqual(expect.objectContaining({
+      eventName: 'purchase_completed',
+      paymentId: 'payment-1',
+    }));
+    expect(projectPurchase).toHaveBeenCalledWith('payment-1');
   });
 });

--- a/tests/lib/purchase-measurement-projector.test.ts
+++ b/tests/lib/purchase-measurement-projector.test.ts
@@ -14,6 +14,7 @@ class MemoryPurchaseMeasurementStore implements PurchaseMeasurementStore {
     bundleId: null,
     method: 'stripe',
     status: 'completed',
+    amount: '990.00',
     attributedExposureId: '11111111-1111-4111-8111-111111111111',
   };
   outbox = new Map<string, { id: string; paymentId: string; createdAt: Date; projected: boolean }>();
@@ -21,7 +22,7 @@ class MemoryPurchaseMeasurementStore implements PurchaseMeasurementStore {
   failures = 0;
   failProjection = false;
 
-  async readCompletedStripePayment(paymentId: string) {
+  async readCompletedPayment(paymentId: string) {
     return this.payment?.paymentId === paymentId ? this.payment : null;
   }
 
@@ -53,7 +54,7 @@ class MemoryPurchaseMeasurementStore implements PurchaseMeasurementStore {
 describe('purchase measurement projector', () => {
   it('does not inspect or mutate payment data while purchase measurement is disabled', async () => {
     const store = new MemoryPurchaseMeasurementStore();
-    const readPayment = vi.spyOn(store, 'readCompletedStripePayment');
+    const readPayment = vi.spyOn(store, 'readCompletedPayment');
     const projector = createPurchaseMeasurementProjector({
       store,
       isEventEnabled: async () => false,
@@ -76,6 +77,32 @@ describe('purchase measurement projector', () => {
 
     await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'failed' });
     expect(store.payment?.status).toBe('completed');
+  });
+
+  it.each(['promptpay', 'bank_transfer'] as const)(
+    'projects an authoritative completed %s payment as a paid purchase',
+    async (method) => {
+      const store = new MemoryPurchaseMeasurementStore();
+      if (!store.payment) throw new Error('missing fixture');
+      store.payment = { ...store.payment, method };
+      const projector = createPurchaseMeasurementProjector({
+        store,
+        isEventEnabled: async () => true,
+      });
+
+      await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'projected' });
+      expect(store.facts).toEqual(new Set(['pay-1']));
+    },
+  );
+
+  it('does not classify a zero-value payment as a paid purchase', async () => {
+    const store = new MemoryPurchaseMeasurementStore();
+    if (!store.payment) throw new Error('missing fixture');
+    store.payment = { ...store.payment, method: 'promptpay', amount: '0.00' };
+    const projector = createPurchaseMeasurementProjector({ store, isEventEnabled: async () => true });
+
+    await expect(projector.projectPurchase('pay-1')).resolves.toEqual({ status: 'ineligible' });
+    expect(store.facts.size).toBe(0);
   });
 
   it('treats an existing payment fact as a successful idempotent projection', async () => {


### PR DESCRIPTION
## Summary
- project verified PromptPay and audited manual completions through the transactional purchase outbox
- record free course, free bundle, and 100%-coupon acquisition facts by first-created enrollment identity
- preserve enrollment/payment authority when measurement projection fails and deduplicate retries
- add ADR 0010 and additive Drizzle migration 0017

## Verification
- npm run test -- --run (669 tests)
- npm run lint
- npx tsc --noEmit
- npm run build
- git diff --check

## Database
- migration 0017 is generated and reviewed but was not applied locally
- no data rewrite or destructive SQL statements

Closes #30