### PR TITLE
feat: collect privacy-minimized Core Web Vitals

### DIFF
--- a/drizzle/0020_dapper_lenny_balinger.sql
+++ b/drizzle/0020_dapper_lenny_balinger.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `web_vitals` (
+	`id` varchar(36) NOT NULL,
+	`page_load_id` varchar(100) NOT NULL,
+	`metric_name` varchar(10) NOT NULL,
+	`route_family` varchar(40) NOT NULL,
+	`device_class` varchar(10) NOT NULL,
+	`release_identity` varchar(100) NOT NULL,
+	`value` decimal(16,4) NOT NULL,
+	`rating` varchar(20) NOT NULL,
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	CONSTRAINT `web_vitals_id` PRIMARY KEY(`id`),
+	CONSTRAINT `uq_web_vitals_page_metric` UNIQUE(`page_load_id`,`metric_name`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_web_vitals_updated_at` ON `web_vitals` (`updated_at`);--> statement-breakpoint
+CREATE INDEX `idx_web_vitals_release_route_metric_device` ON `web_vitals` (`release_identity`,`route_family`,`metric_name`,`device_class`);

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,3351 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "d49d5a48-58c3-40a7-90d0-03b9cbf58a0c",
+  "prevId": "2c9d43cb-4627-435a-9527-bf4a41ed4093",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_accounts_provider_identity": {
+          "name": "uq_accounts_provider_identity",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_id": {
+          "name": "accounts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "affiliate_banners": {
+      "name": "affiliate_banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "affiliate_banners_id": {
+          "name": "affiliate_banners_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exposure_id": {
+          "name": "exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_exposure_id": {
+          "name": "attributed_exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "learning_fact_id": {
+          "name": "learning_fact_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "learning_enrollment_id": {
+          "name": "learning_enrollment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'server'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_analytics_exposure_id": {
+          "name": "uq_analytics_exposure_id",
+          "columns": [
+            "exposure_id"
+          ],
+          "isUnique": true
+        },
+        "idx_analytics_attributed_exposure_id": {
+          "name": "idx_analytics_attributed_exposure_id",
+          "columns": [
+            "attributed_exposure_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_event_name": {
+          "name": "idx_analytics_event_name",
+          "columns": [
+            "event_name"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_created_at": {
+          "name": "idx_analytics_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_course_id": {
+          "name": "idx_analytics_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_bundle_id": {
+          "name": "idx_analytics_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_payment_id": {
+          "name": "idx_analytics_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_enrollment_id": {
+          "name": "idx_analytics_enrollment_id",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_learning_enrollment_id": {
+          "name": "idx_analytics_learning_enrollment_id",
+          "columns": [
+            "learning_enrollment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_lesson_id": {
+          "name": "idx_analytics_lesson_id",
+          "columns": [
+            "lesson_id"
+          ],
+          "isUnique": false
+        },
+        "uq_analytics_event_payment": {
+          "name": "uq_analytics_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        },
+        "uq_analytics_event_enrollment": {
+          "name": "uq_analytics_event_enrollment",
+          "columns": [
+            "event_name",
+            "enrollment_id"
+          ],
+          "isUnique": true
+        },
+        "uq_analytics_learning_fact": {
+          "name": "uq_analytics_learning_fact",
+          "columns": [
+            "event_name",
+            "learning_fact_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_course_id_courses_id_fk": {
+          "name": "analytics_events_course_id_courses_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_bundle_id_bundles_id_fk": {
+          "name": "analytics_events_bundle_id_bundles_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_payment_id_payments_id_fk": {
+          "name": "analytics_events_payment_id_payments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_enrollment_id_enrollments_id_fk": {
+          "name": "analytics_events_enrollment_id_enrollments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "enrollments",
+          "columnsFrom": [
+            "enrollment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_learning_enrollment_id_enrollments_id_fk": {
+          "name": "analytics_events_learning_enrollment_id_enrollments_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "enrollments",
+          "columnsFrom": [
+            "learning_enrollment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analytics_events_lesson_id_lessons_id_fk": {
+          "name": "analytics_events_lesson_id_lessons_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "analytics_events_id": {
+          "name": "analytics_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "announcements": {
+      "name": "announcements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "target_role": {
+          "name": "target_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcements_created_by_users_id_fk": {
+          "name": "announcements_created_by_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "announcements_id": {
+          "name": "announcements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_post_tags": {
+      "name": "blog_post_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_post_tags_post_id_blog_posts_id_fk": {
+          "name": "blog_post_tags_post_id_blog_posts_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "blog_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blog_post_tags_tag_id_tags_id_fk": {
+          "name": "blog_post_tags_tag_id_tags_id_fk",
+          "tableFrom": "blog_post_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_post_tags_id": {
+          "name": "blog_post_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "blog_posts": {
+      "name": "blog_posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_blog_posts_status": {
+          "name": "idx_blog_posts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_blog_posts_published_at": {
+          "name": "idx_blog_posts_published_at",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_posts_author_id_users_id_fk": {
+          "name": "blog_posts_author_id_users_id_fk",
+          "tableFrom": "blog_posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_posts_id": {
+          "name": "blog_posts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "blog_posts_slug_unique": {
+          "name": "blog_posts_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "bundle_courses": {
+      "name": "bundle_courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_bundle_courses_bundle_id": {
+          "name": "idx_bundle_courses_bundle_id",
+          "columns": [
+            "bundle_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bundle_courses_bundle_id_bundles_id_fk": {
+          "name": "bundle_courses_bundle_id_bundles_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bundle_courses_course_id_courses_id_fk": {
+          "name": "bundle_courses_course_id_courses_id_fk",
+          "tableFrom": "bundle_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bundle_courses_id": {
+          "name": "bundle_courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "bundles": {
+      "name": "bundles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "bundles_id": {
+          "name": "bundles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "bundles_slug_unique": {
+          "name": "bundles_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "certificate_code": {
+          "name": "certificate_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipient_name": {
+          "name": "recipient_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_title": {
+          "name": "course_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_theme": {
+          "name": "certificate_theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_certificates_user_id": {
+          "name": "idx_certificates_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_user_id_users_id_fk": {
+          "name": "certificates_user_id_users_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificates_course_id_courses_id_fk": {
+          "name": "certificates_course_id_courses_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "certificates_certificate_code_unique": {
+          "name": "certificates_certificate_code_unique",
+          "columns": [
+            "certificate_code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "coupon_usages": {
+      "name": "coupon_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_coupon_user_course": {
+          "name": "uq_coupon_user_course",
+          "columns": [
+            "coupon_id",
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coupon_usages_coupon_id_coupons_id_fk": {
+          "name": "coupon_usages_coupon_id_coupons_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "coupons",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_user_id_users_id_fk": {
+          "name": "coupon_usages_user_id_users_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coupon_usages_course_id_courses_id_fk": {
+          "name": "coupon_usages_course_id_courses_id_fk",
+          "tableFrom": "coupon_usages",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupon_usages_id": {
+          "name": "coupon_usages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coupons": {
+      "name": "coupons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_purchase": {
+          "name": "min_purchase",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "max_discount": {
+          "name": "max_discount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "per_user_limit": {
+          "name": "per_user_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "coupons_course_id_courses_id_fk": {
+          "name": "coupons_course_id_courses_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "coupons_id": {
+          "name": "coupons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "coupons_code_unique": {
+          "name": "coupons_code_unique",
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "course_tags": {
+      "name": "course_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_tags_course_id_courses_id_fk": {
+          "name": "course_tags_course_id_courses_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_tags_tag_id_tags_id_fk": {
+          "name": "course_tags_tag_id_tags_id_fk",
+          "tableFrom": "course_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course_tags_id": {
+          "name": "course_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "courses": {
+      "name": "courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_color": {
+          "name": "certificate_color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'#2563eb'"
+        },
+        "certificate_header_image": {
+          "name": "certificate_header_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "certificate_badge": {
+          "name": "certificate_badge",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_video_url": {
+          "name": "preview_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_price": {
+          "name": "promo_price",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_starts_at": {
+          "name": "promo_starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promo_ends_at": {
+          "name": "promo_ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "courses_instructor_id_users_id_fk": {
+          "name": "courses_instructor_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "courses_id": {
+          "name": "courses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "courses_slug_unique": {
+          "name": "courses_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "enrollments": {
+      "name": "enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_percent": {
+          "name": "progress_percent",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_enrollment_user_course": {
+          "name": "uq_enrollment_user_course",
+          "columns": [
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "enrollments_user_id_users_id_fk": {
+          "name": "enrollments_user_id_users_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "enrollments_course_id_courses_id_fk": {
+          "name": "enrollments_course_id_courses_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "enrollments_id": {
+          "name": "enrollments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lesson_progress": {
+      "name": "lesson_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "watch_time_seconds": {
+          "name": "watch_time_seconds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_watched_at": {
+          "name": "last_watched_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_lesson_progress_user_lesson": {
+          "name": "uq_lesson_progress_user_lesson",
+          "columns": [
+            "user_id",
+            "lesson_id"
+          ],
+          "isUnique": true
+        },
+        "idx_lesson_progress_user_id": {
+          "name": "idx_lesson_progress_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lesson_progress_lesson_id": {
+          "name": "idx_lesson_progress_lesson_id",
+          "columns": [
+            "lesson_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lesson_progress_user_id_users_id_fk": {
+          "name": "lesson_progress_user_id_users_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lesson_progress_id": {
+          "name": "lesson_progress_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "lessons": {
+      "name": "lessons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_duration": {
+          "name": "video_duration",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_free_preview": {
+          "name": "is_free_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lessons_course_id": {
+          "name": "idx_lessons_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lessons_course_id_courses_id_fk": {
+          "name": "lessons_course_id_courses_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lessons_id": {
+          "name": "lessons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "measurement_outbox": {
+      "name": "measurement_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrollment_id": {
+          "name": "enrollment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "learning_fact_id": {
+          "name": "learning_fact_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "learning_enrollment_id": {
+          "name": "learning_enrollment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projected_at": {
+          "name": "projected_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_measurement_outbox_event_payment": {
+          "name": "uq_measurement_outbox_event_payment",
+          "columns": [
+            "event_name",
+            "payment_id"
+          ],
+          "isUnique": true
+        },
+        "uq_measurement_outbox_event_enrollment": {
+          "name": "uq_measurement_outbox_event_enrollment",
+          "columns": [
+            "event_name",
+            "enrollment_id"
+          ],
+          "isUnique": true
+        },
+        "uq_measurement_outbox_learning_fact": {
+          "name": "uq_measurement_outbox_learning_fact",
+          "columns": [
+            "event_name",
+            "learning_fact_id"
+          ],
+          "isUnique": true
+        },
+        "idx_measurement_outbox_projected_at": {
+          "name": "idx_measurement_outbox_projected_at",
+          "columns": [
+            "projected_at"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_payment_id": {
+          "name": "idx_measurement_outbox_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_enrollment_id": {
+          "name": "idx_measurement_outbox_enrollment_id",
+          "columns": [
+            "enrollment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_learning_enrollment_id": {
+          "name": "idx_measurement_outbox_learning_enrollment_id",
+          "columns": [
+            "learning_enrollment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_course_id": {
+          "name": "idx_measurement_outbox_course_id",
+          "columns": [
+            "course_id"
+          ],
+          "isUnique": false
+        },
+        "idx_measurement_outbox_lesson_id": {
+          "name": "idx_measurement_outbox_lesson_id",
+          "columns": [
+            "lesson_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "measurement_outbox_payment_id_payments_id_fk": {
+          "name": "measurement_outbox_payment_id_payments_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "measurement_outbox_enrollment_id_enrollments_id_fk": {
+          "name": "measurement_outbox_enrollment_id_enrollments_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "enrollments",
+          "columnsFrom": [
+            "enrollment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "measurement_outbox_learning_enrollment_id_enrollments_id_fk": {
+          "name": "measurement_outbox_learning_enrollment_id_enrollments_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "enrollments",
+          "columnsFrom": [
+            "learning_enrollment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "measurement_outbox_course_id_courses_id_fk": {
+          "name": "measurement_outbox_course_id_courses_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "measurement_outbox_lesson_id_lessons_id_fk": {
+          "name": "measurement_outbox_lesson_id_lessons_id_fk",
+          "tableFrom": "measurement_outbox",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "measurement_outbox_id": {
+          "name": "measurement_outbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {
+        "chk_measurement_outbox_identity": {
+          "name": "chk_measurement_outbox_identity",
+          "value": "\n        (`measurement_outbox`.`event_name` = 'purchase_completed'\n            AND `measurement_outbox`.`payment_id` IS NOT NULL AND `measurement_outbox`.`enrollment_id` IS NULL\n            AND `measurement_outbox`.`learning_fact_id` IS NULL AND `measurement_outbox`.`learning_enrollment_id` IS NULL\n            AND `measurement_outbox`.`course_id` IS NULL AND `measurement_outbox`.`lesson_id` IS NULL)\n        OR (`measurement_outbox`.`event_name` = 'free_enrollment_completed'\n            AND `measurement_outbox`.`payment_id` IS NULL AND `measurement_outbox`.`enrollment_id` IS NOT NULL\n            AND `measurement_outbox`.`learning_fact_id` IS NULL AND `measurement_outbox`.`learning_enrollment_id` IS NULL\n            AND `measurement_outbox`.`course_id` IS NULL AND `measurement_outbox`.`lesson_id` IS NULL)\n        OR (`measurement_outbox`.`event_name` = 'lesson_completed'\n            AND `measurement_outbox`.`payment_id` IS NULL AND `measurement_outbox`.`enrollment_id` IS NULL\n            AND `measurement_outbox`.`learning_fact_id` IS NOT NULL AND `measurement_outbox`.`learning_enrollment_id` IS NOT NULL\n            AND `measurement_outbox`.`course_id` IS NOT NULL AND `measurement_outbox`.`lesson_id` IS NOT NULL)\n        OR (`measurement_outbox`.`event_name` = 'course_completed'\n            AND `measurement_outbox`.`payment_id` IS NULL AND `measurement_outbox`.`enrollment_id` IS NULL\n            AND `measurement_outbox`.`learning_fact_id` IS NOT NULL AND `measurement_outbox`.`learning_enrollment_id` IS NOT NULL\n            AND `measurement_outbox`.`course_id` IS NOT NULL AND `measurement_outbox`.`lesson_id` IS NULL)\n    "
+        }
+      }
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_users_id_fk": {
+          "name": "media_uploaded_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "media_id": {
+          "name": "media_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notifications_id": {
+          "name": "notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "payments": {
+      "name": "payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bundle_id": {
+          "name": "bundle_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributed_exposure_id": {
+          "name": "attributed_exposure_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'THB'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slip_url": {
+          "name": "slip_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "promptpay_trans_ref": {
+          "name": "promptpay_trans_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_title": {
+          "name": "item_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_payments_user_id": {
+          "name": "idx_payments_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_created_at": {
+          "name": "idx_payments_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_status": {
+          "name": "idx_payments_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_payments_coupon_id": {
+          "name": "idx_payments_coupon_id",
+          "columns": [
+            "coupon_id"
+          ],
+          "isUnique": false
+        },
+        "uq_payments_promptpay_trans_ref": {
+          "name": "uq_payments_promptpay_trans_ref",
+          "columns": [
+            "promptpay_trans_ref"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_course_id_courses_id_fk": {
+          "name": "payments_course_id_courses_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payments_bundle_id_bundles_id_fk": {
+          "name": "payments_bundle_id_bundles_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "bundles",
+          "columnsFrom": [
+            "bundle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "payments_id": {
+          "name": "payments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rate_limit_buckets_reset_at": {
+          "name": "idx_rate_limit_buckets_reset_at",
+          "columns": [
+            "reset_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_hash": {
+          "name": "rate_limit_buckets_key_hash",
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reviews_course_hidden": {
+          "name": "idx_reviews_course_hidden",
+          "columns": [
+            "course_id",
+            "is_hidden"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reviews_course_id_courses_id_fk": {
+          "name": "reviews_course_id_courses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reviews_id": {
+          "name": "reviews_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'string'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_updated_by_users_id_fk": {
+          "name": "settings_updated_by_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_id": {
+          "name": "settings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "stripe_events": {
+      "name": "stripe_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_stripe_events_payment_id": {
+          "name": "idx_stripe_events_payment_id",
+          "columns": [
+            "payment_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_events_type": {
+          "name": "idx_stripe_events_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_payment_id_payments_id_fk": {
+          "name": "stripe_events_payment_id_payments_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_id": {
+          "name": "stripe_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tags_id": {
+          "name": "tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ]
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'student'"
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_expires": {
+          "name": "reset_expires",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_users_deactivated_at": {
+          "name": "idx_users_deactivated_at",
+          "columns": [
+            "deactivated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "web_vitals": {
+      "name": "web_vitals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_load_id": {
+          "name": "page_load_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric_name": {
+          "name": "metric_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route_family": {
+          "name": "route_family",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_class": {
+          "name": "device_class",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_identity": {
+          "name": "release_identity",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "decimal(16,4)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_web_vitals_page_metric": {
+          "name": "uq_web_vitals_page_metric",
+          "columns": [
+            "page_load_id",
+            "metric_name"
+          ],
+          "isUnique": true
+        },
+        "idx_web_vitals_updated_at": {
+          "name": "idx_web_vitals_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_web_vitals_release_route_metric_device": {
+          "name": "idx_web_vitals_release_route_metric_device",
+          "columns": [
+            "release_identity",
+            "route_family",
+            "metric_name",
+            "device_class"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "web_vitals_id": {
+          "name": "web_vitals_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1788228913286,
       "tag": "0019_amusing_captain_midlands",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "5",
+      "when": 1788230689214,
+      "tag": "0020_dapper_lenny_balinger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/analytics/web-vitals/route.ts
+++ b/src/app/api/analytics/web-vitals/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import { logEvent } from '@/lib/error-handler';
+import { checkRateLimit, getClientIP, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
+import { webVitalReportSchema, webVitalsRecorder } from '@/lib/web-vitals';
+
+export async function POST(request: Request) {
+  const clientIP = getClientIP(request);
+  const rateLimit = checkRateLimit(`web-vitals:${clientIP}`, rateLimits.general);
+  if (!rateLimit.success) return rateLimitResponse(rateLimit.resetTime);
+
+  try {
+    if (!(await isAnalyticsEventEnabled('web_vitals'))) {
+      return new NextResponse(null, { status: 204 });
+    }
+  } catch {
+    logEvent('analytics.web_vitals_control_failed', 'warn');
+    return new NextResponse(null, { status: 204 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid Web Vitals report' }, { status: 400 });
+  }
+  const parsed = webVitalReportSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid Web Vitals report' }, { status: 400 });
+  }
+
+  const result = await webVitalsRecorder.record(parsed.data);
+  if (result.status === 'failed') {
+    logEvent('analytics.web_vitals_record_failed', 'warn');
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,8 @@ import { Toaster } from "@/components/ui/sonner";
 
 import { buildSiteJsonLd, serializeJsonLd, SITE_URL } from "@/lib/seo";
 
+import WebVitalsReporter from '@/components/analytics/WebVitalsReporter';
+
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
@@ -84,6 +86,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="antialiased">
+        <WebVitalsReporter />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
 import { Inter, Prompt } from "next/font/google";
 import "./globals.css";
+import WebVitalsReporter from "@/components/analytics/WebVitalsReporter";
 import SessionProvider from "@/components/providers/SessionProvider";
 import NotificationProvider from "@/components/notifications/NotificationProvider";
 import ThemeSurface from "@/components/theme/ThemeSurface";
 import { Toaster } from "@/components/ui/sonner";
 
 import { buildSiteJsonLd, serializeJsonLd, SITE_URL } from "@/lib/seo";
-
-import WebVitalsReporter from '@/components/analytics/WebVitalsReporter';
+import { getWebVitalsReleaseIdentity } from "@/lib/web-vitals-release";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -86,7 +86,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="antialiased">
-        <WebVitalsReporter />
+        <WebVitalsReporter releaseIdentity={getWebVitalsReleaseIdentity()} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -2,9 +2,13 @@
 
 import { useReportWebVitals } from 'next/web-vitals';
 
-import { reportWebVitalMetric } from '@/components/analytics/web-vitals-client';
+import {
+  initializeWebVitalsPageLoadContext,
+  reportWebVitalMetric,
+} from '@/components/analytics/web-vitals-client';
 
-export default function WebVitalsReporter() {
+export default function WebVitalsReporter({ releaseIdentity }: { releaseIdentity: string }) {
+  initializeWebVitalsPageLoadContext(releaseIdentity);
   useReportWebVitals(reportWebVitalMetric);
   return null;
 }

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useReportWebVitals } from 'next/web-vitals';
+
+import { reportWebVitalMetric } from '@/components/analytics/web-vitals-client';
+
+export default function WebVitalsReporter() {
+  useReportWebVitals(reportWebVitalMetric);
+  return null;
+}

--- a/src/components/analytics/web-vitals-client.ts
+++ b/src/components/analytics/web-vitals-client.ts
@@ -1,13 +1,22 @@
 'use client';
 
-import type {
-  WebVitalDeviceClass,
-  WebVitalName,
-  WebVitalRating,
-  WebVitalRouteFamily,
+import {
+  WEB_VITAL_NAMES,
+  type WebVitalDeviceClass,
+  type WebVitalName,
+  type WebVitalRating,
+  type WebVitalRouteFamily,
 } from '@/lib/web-vitals-contract';
 
-const CORE_WEB_VITAL_NAMES = new Set<string>(['LCP', 'INP', 'CLS']);
+const CORE_WEB_VITAL_NAMES = new Set<string>(WEB_VITAL_NAMES);
+
+type PageLoadContext = {
+  routeFamily: WebVitalRouteFamily;
+  deviceClass: WebVitalDeviceClass;
+  releaseIdentity: string;
+};
+
+let pageLoadContext: PageLoadContext | null | undefined;
 
 export type BrowserWebVitalMetric = {
   id: string;
@@ -49,6 +58,15 @@ function getDeviceClass(): WebVitalDeviceClass {
   return window.innerWidth < 768 ? 'mobile' : 'desktop';
 }
 
+export function initializeWebVitalsPageLoadContext(releaseIdentity: string): void {
+  if (typeof window === 'undefined' || pageLoadContext !== undefined) return;
+
+  const routeFamily = normalizeWebVitalRouteFamily(window.location.pathname);
+  pageLoadContext = routeFamily
+    ? { routeFamily, deviceClass: getDeviceClass(), releaseIdentity }
+    : null;
+}
+
 export function reportWebVitalMetric(metric: BrowserWebVitalMetric): void {
   if (
     typeof window === 'undefined'
@@ -56,14 +74,15 @@ export function reportWebVitalMetric(metric: BrowserWebVitalMetric): void {
     || !Number.isFinite(metric.value)
   ) return;
 
-  const routeFamily = normalizeWebVitalRouteFamily(window.location.pathname);
-  if (!routeFamily) return;
+  const context = pageLoadContext;
+  if (!context) return;
 
   const body = JSON.stringify({
     pageLoadId: metric.id,
     metricName: metric.name as WebVitalName,
-    routeFamily,
-    deviceClass: getDeviceClass(),
+    routeFamily: context.routeFamily,
+    deviceClass: context.deviceClass,
+    releaseIdentity: context.releaseIdentity,
     value: metric.value,
     rating: metric.rating as WebVitalRating,
   });

--- a/src/components/analytics/web-vitals-client.ts
+++ b/src/components/analytics/web-vitals-client.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import type {
+  WebVitalDeviceClass,
+  WebVitalName,
+  WebVitalRating,
+  WebVitalRouteFamily,
+} from '@/lib/web-vitals-contract';
+
+const CORE_WEB_VITAL_NAMES = new Set<string>(['LCP', 'INP', 'CLS']);
+
+export type BrowserWebVitalMetric = {
+  id: string;
+  name: string;
+  value: number;
+  rating: string;
+};
+
+export function normalizeWebVitalRouteFamily(
+  pathname: string,
+): WebVitalRouteFamily | null {
+  const segments = pathname.split('/').filter(Boolean);
+  const [first, second, third] = segments;
+
+  if (first === 'admin') return null;
+  if (!first) return 'home';
+  if (first === 'courses') {
+    if (!second) return 'catalog';
+    if (third === 'learn') return 'learning';
+    if (third === 'payment-success') return 'purchase';
+    return 'product_detail';
+  }
+  if (first === 'bundles') {
+    if (!second) return 'catalog';
+    if (third === 'payment-success') return 'purchase';
+    return 'product_detail';
+  }
+  if (['login', 'register', 'forgot-password', 'reset-password'].includes(first)) {
+    return 'authentication';
+  }
+  if (['dashboard', 'profile', 'settings'].includes(first)) return 'account';
+  if (first === 'certificate') return 'certificate';
+  if (['blog', 'announcements'].includes(first)) return 'content';
+  if (['about', 'contact', 'faq', 'privacy', 'terms'].includes(first)) return 'legal_support';
+  return 'other';
+}
+
+function getDeviceClass(): WebVitalDeviceClass {
+  return window.innerWidth < 768 ? 'mobile' : 'desktop';
+}
+
+export function reportWebVitalMetric(metric: BrowserWebVitalMetric): void {
+  if (
+    typeof window === 'undefined'
+    || !CORE_WEB_VITAL_NAMES.has(metric.name)
+    || !Number.isFinite(metric.value)
+  ) return;
+
+  const routeFamily = normalizeWebVitalRouteFamily(window.location.pathname);
+  if (!routeFamily) return;
+
+  const body = JSON.stringify({
+    pageLoadId: metric.id,
+    metricName: metric.name as WebVitalName,
+    routeFamily,
+    deviceClass: getDeviceClass(),
+    value: metric.value,
+    rating: metric.rating as WebVitalRating,
+  });
+  if (
+    typeof navigator.sendBeacon === 'function'
+    && navigator.sendBeacon(
+      '/api/analytics/web-vitals',
+      new Blob([body], { type: 'application/json' }),
+    )
+  ) return;
+
+  void fetch('/api/analytics/web-vitals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => undefined);
+}

--- a/src/lib/analytics-control.ts
+++ b/src/lib/analytics-control.ts
@@ -18,10 +18,11 @@ export const ANALYTICS_EVENT_CLASSES = [
   'commerce',
   'enrollment',
   'learning',
+  'performance',
 ] as const;
 
 export type AnalyticsEventClass = typeof ANALYTICS_EVENT_CLASSES[number];
-type AnalyticsEventName = ClientAnalyticsEvent['eventName'] | ServerAnalyticsEventName;
+type AnalyticsEventName = ClientAnalyticsEvent['eventName'] | ServerAnalyticsEventName | 'web_vitals';
 
 const ANALYTICS_ENABLED_KEY = 'analytics_enabled' as const;
 const ANALYTICS_GOVERNANCE_KEY = 'analytics_governance_decision' as const;
@@ -66,9 +67,10 @@ const eventClassByName: Record<AnalyticsEventName, AnalyticsEventClass> = {
   learning_workspace_started: 'learning',
   lesson_completed: 'learning',
   course_completed: 'learning',
+  web_vitals: 'performance',
 };
 
-for (const eventName of [...CLIENT_ANALYTICS_EVENT_NAMES, ...SERVER_ANALYTICS_EVENT_NAMES]) {
+for (const eventName of [...CLIENT_ANALYTICS_EVENT_NAMES, ...SERVER_ANALYTICS_EVENT_NAMES, 'web_vitals'] as const) {
   if (!eventClassByName[eventName]) throw new Error(`Missing analytics event class for ${eventName}`);
 }
 

--- a/src/lib/analytics-retention.ts
+++ b/src/lib/analytics-retention.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { getAnalyticsControlState } from '@/lib/analytics-control';
 import { db } from '@/lib/db';
-import { analyticsEvents } from '@/lib/db/schema';
+import { analyticsEvents, webVitals } from '@/lib/db/schema';
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_BATCH_SIZE = 1_000;
@@ -15,7 +15,10 @@ const retentionRequestSchema = z.object({
 }).strict();
 
 export interface AnalyticsRetentionStore {
-  deleteRawEventsBefore(cutoff: Date, batchSize: number): Promise<number>;
+  deleteRawMeasurementsBefore(cutoff: Date, batchSize: number): Promise<{
+    analyticsEvents: number;
+    webVitals: number;
+  }>;
 }
 
 export class AnalyticsRetentionError extends Error {
@@ -38,8 +41,14 @@ export function createAnalyticsRetentionPolicy(store: AnalyticsRetentionStore) {
       const cutoff = new Date(
         parsed.data.now.getTime() - parsed.data.rawEventRetentionDays * DAY_MS,
       );
-      const deletedCount = await store.deleteRawEventsBefore(cutoff, parsed.data.batchSize);
-      return { cutoff, deletedCount, batchSize: parsed.data.batchSize };
+      const deleted = await store.deleteRawMeasurementsBefore(cutoff, parsed.data.batchSize);
+      return {
+        cutoff,
+        deletedCount: deleted.analyticsEvents + deleted.webVitals,
+        deletedAnalyticsEventCount: deleted.analyticsEvents,
+        deletedWebVitalCount: deleted.webVitals,
+        batchSize: parsed.data.batchSize,
+      };
     },
   };
 }
@@ -52,12 +61,21 @@ function affectedRows(result: unknown): number {
 }
 
 const drizzleAnalyticsRetentionStore: AnalyticsRetentionStore = {
-  async deleteRawEventsBefore(cutoff, batchSize) {
-    const result = await db
-      .delete(analyticsEvents)
-      .where(lt(analyticsEvents.createdAt, cutoff))
-      .limit(batchSize);
-    return affectedRows(result);
+  async deleteRawMeasurementsBefore(cutoff, batchSize) {
+    return db.transaction(async (tx) => {
+      const analyticsResult = await tx
+        .delete(analyticsEvents)
+        .where(lt(analyticsEvents.createdAt, cutoff))
+        .limit(batchSize);
+      const webVitalsResult = await tx
+        .delete(webVitals)
+        .where(lt(webVitals.updatedAt, cutoff))
+        .limit(batchSize);
+      return {
+        analyticsEvents: affectedRows(analyticsResult),
+        webVitals: affectedRows(webVitalsResult),
+      };
+    });
   },
 };
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -659,6 +659,34 @@ export const analyticsEventsRelations = relations(analyticsEvents, ({ one }) => 
 }));
 
 // =====================
+// WEB VITALS TABLE
+// =====================
+export const webVitals = mysqlTable('web_vitals', {
+    id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => createId()),
+    pageLoadId: varchar('page_load_id', { length: 100 }).notNull(),
+    metricName: varchar('metric_name', { length: 10, enum: ['LCP', 'INP', 'CLS'] }).notNull(),
+    routeFamily: varchar('route_family', {
+        length: 40,
+        enum: ['home', 'catalog', 'product_detail', 'purchase', 'authentication', 'account', 'learning', 'certificate', 'content', 'legal_support', 'other'],
+    }).notNull(),
+    deviceClass: varchar('device_class', { length: 10, enum: ['mobile', 'desktop'] }).notNull(),
+    releaseIdentity: varchar('release_identity', { length: 100 }).notNull(),
+    value: decimal('value', { precision: 16, scale: 4 }).notNull(),
+    rating: varchar('rating', { length: 20, enum: ['good', 'needs-improvement', 'poor'] }).notNull(),
+    createdAt: datetime('created_at').$defaultFn(() => new Date()).notNull(),
+    updatedAt: datetime('updated_at').$defaultFn(() => new Date()).notNull(),
+}, (table) => [
+    uniqueIndex('uq_web_vitals_page_metric').on(table.pageLoadId, table.metricName),
+    index('idx_web_vitals_updated_at').on(table.updatedAt),
+    index('idx_web_vitals_release_route_metric_device').on(
+        table.releaseIdentity,
+        table.routeFamily,
+        table.metricName,
+        table.deviceClass,
+    ),
+]);
+
+// =====================
 // MEASUREMENT OUTBOX TABLE
 // =====================
 export const measurementOutbox = mysqlTable('measurement_outbox', {
@@ -773,6 +801,8 @@ export type BundleCourse = typeof bundleCourses.$inferSelect;
 export type NewBundleCourse = typeof bundleCourses.$inferInsert;
 export type AnalyticsEvent = typeof analyticsEvents.$inferSelect;
 export type NewAnalyticsEvent = typeof analyticsEvents.$inferInsert;
+export type WebVital = typeof webVitals.$inferSelect;
+export type NewWebVital = typeof webVitals.$inferInsert;
 export type MeasurementOutboxEntry = typeof measurementOutbox.$inferSelect;
 export type NewMeasurementOutboxEntry = typeof measurementOutbox.$inferInsert;
 export type RateLimitBucket = typeof rateLimitBuckets.$inferSelect;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,6 +1,12 @@
 import { mysqlTable, varchar, char, text, int, decimal, datetime, boolean, uniqueIndex, index, check } from 'drizzle-orm/mysql-core';
 import { relations, sql } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
+import {
+    WEB_VITAL_DEVICE_CLASSES,
+    WEB_VITAL_NAMES,
+    WEB_VITAL_RATINGS,
+    WEB_VITAL_ROUTE_FAMILIES,
+} from '@/lib/web-vitals-contract';
 
 // =====================
 // USERS TABLE
@@ -664,15 +670,15 @@ export const analyticsEventsRelations = relations(analyticsEvents, ({ one }) => 
 export const webVitals = mysqlTable('web_vitals', {
     id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => createId()),
     pageLoadId: varchar('page_load_id', { length: 100 }).notNull(),
-    metricName: varchar('metric_name', { length: 10, enum: ['LCP', 'INP', 'CLS'] }).notNull(),
+    metricName: varchar('metric_name', { length: 10, enum: WEB_VITAL_NAMES }).notNull(),
     routeFamily: varchar('route_family', {
         length: 40,
-        enum: ['home', 'catalog', 'product_detail', 'purchase', 'authentication', 'account', 'learning', 'certificate', 'content', 'legal_support', 'other'],
+        enum: WEB_VITAL_ROUTE_FAMILIES,
     }).notNull(),
-    deviceClass: varchar('device_class', { length: 10, enum: ['mobile', 'desktop'] }).notNull(),
+    deviceClass: varchar('device_class', { length: 10, enum: WEB_VITAL_DEVICE_CLASSES }).notNull(),
     releaseIdentity: varchar('release_identity', { length: 100 }).notNull(),
     value: decimal('value', { precision: 16, scale: 4 }).notNull(),
-    rating: varchar('rating', { length: 20, enum: ['good', 'needs-improvement', 'poor'] }).notNull(),
+    rating: varchar('rating', { length: 20, enum: WEB_VITAL_RATINGS }).notNull(),
     createdAt: datetime('created_at').$defaultFn(() => new Date()).notNull(),
     updatedAt: datetime('updated_at').$defaultFn(() => new Date()).notNull(),
 }, (table) => [

--- a/src/lib/web-vitals-contract.ts
+++ b/src/lib/web-vitals-contract.ts
@@ -1,0 +1,23 @@
+export const WEB_VITAL_NAMES = ['LCP', 'INP', 'CLS'] as const;
+
+export const WEB_VITAL_ROUTE_FAMILIES = [
+  'home',
+  'catalog',
+  'product_detail',
+  'purchase',
+  'authentication',
+  'account',
+  'learning',
+  'certificate',
+  'content',
+  'legal_support',
+  'other',
+] as const;
+
+export const WEB_VITAL_DEVICE_CLASSES = ['mobile', 'desktop'] as const;
+export const WEB_VITAL_RATINGS = ['good', 'needs-improvement', 'poor'] as const;
+
+export type WebVitalName = typeof WEB_VITAL_NAMES[number];
+export type WebVitalRouteFamily = typeof WEB_VITAL_ROUTE_FAMILIES[number];
+export type WebVitalDeviceClass = typeof WEB_VITAL_DEVICE_CLASSES[number];
+export type WebVitalRating = typeof WEB_VITAL_RATINGS[number];

--- a/src/lib/web-vitals-contract.ts
+++ b/src/lib/web-vitals-contract.ts
@@ -16,6 +16,8 @@ export const WEB_VITAL_ROUTE_FAMILIES = [
 
 export const WEB_VITAL_DEVICE_CLASSES = ['mobile', 'desktop'] as const;
 export const WEB_VITAL_RATINGS = ['good', 'needs-improvement', 'poor'] as const;
+export const WEB_VITAL_RELEASE_IDENTITY_MAX_LENGTH = 100;
+export const WEB_VITAL_RELEASE_IDENTITY_PATTERN = /^[A-Za-z0-9._:-]+$/;
 
 export type WebVitalName = typeof WEB_VITAL_NAMES[number];
 export type WebVitalRouteFamily = typeof WEB_VITAL_ROUTE_FAMILIES[number];

--- a/src/lib/web-vitals-release.ts
+++ b/src/lib/web-vitals-release.ts
@@ -1,0 +1,30 @@
+import 'server-only';
+
+import {
+  WEB_VITAL_RELEASE_IDENTITY_MAX_LENGTH,
+  WEB_VITAL_RELEASE_IDENTITY_PATTERN,
+} from '@/lib/web-vitals-contract';
+
+type ReleaseEnvironment = Partial<Record<
+  'RAILWAY_GIT_COMMIT_SHA' | 'VERCEL_GIT_COMMIT_SHA' | 'GITHUB_SHA',
+  string
+>>;
+
+export function getWebVitalsReleaseIdentity(
+  environment: ReleaseEnvironment = process.env as ReleaseEnvironment,
+): string {
+  const candidate = (
+    environment.RAILWAY_GIT_COMMIT_SHA
+      ?? environment.VERCEL_GIT_COMMIT_SHA
+      ?? environment.GITHUB_SHA
+      ?? 'local-development'
+  ).trim();
+
+  if (
+    candidate.length > 0
+    && candidate.length <= WEB_VITAL_RELEASE_IDENTITY_MAX_LENGTH
+    && WEB_VITAL_RELEASE_IDENTITY_PATTERN.test(candidate)
+  ) return candidate;
+
+  return 'unknown-release';
+}

--- a/src/lib/web-vitals.ts
+++ b/src/lib/web-vitals.ts
@@ -1,0 +1,144 @@
+import 'server-only';
+
+import { z } from 'zod';
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import { db } from '@/lib/db';
+import { webVitals } from '@/lib/db/schema';
+import {
+  WEB_VITAL_DEVICE_CLASSES,
+  WEB_VITAL_NAMES,
+  WEB_VITAL_RATINGS,
+  WEB_VITAL_ROUTE_FAMILIES,
+  type WebVitalName,
+  type WebVitalRating,
+} from '@/lib/web-vitals-contract';
+
+const MAX_DURATION_MS = 600_000;
+const MAX_CLS = 10;
+
+const releaseIdentitySchema = z.string().trim().min(1).max(100)
+  .regex(/^[A-Za-z0-9._:-]+$/);
+
+export function deriveWebVitalRating(
+  metricName: WebVitalName,
+  value: number,
+): WebVitalRating {
+  if (metricName === 'LCP') {
+    if (value <= 2_500) return 'good';
+    if (value <= 4_000) return 'needs-improvement';
+    return 'poor';
+  }
+  if (metricName === 'INP') {
+    if (value <= 200) return 'good';
+    if (value <= 500) return 'needs-improvement';
+    return 'poor';
+  }
+  if (value <= 0.1) return 'good';
+  if (value <= 0.25) return 'needs-improvement';
+  return 'poor';
+}
+
+export const webVitalReportSchema = z.object({
+  pageLoadId: z.string().trim().min(1).max(100).regex(/^[A-Za-z0-9._:-]+$/),
+  metricName: z.enum(WEB_VITAL_NAMES),
+  routeFamily: z.enum(WEB_VITAL_ROUTE_FAMILIES),
+  deviceClass: z.enum(WEB_VITAL_DEVICE_CLASSES),
+  value: z.number().finite().min(0),
+  rating: z.enum(WEB_VITAL_RATINGS),
+}).strict().superRefine((report, context) => {
+  const maximum = report.metricName === 'CLS' ? MAX_CLS : MAX_DURATION_MS;
+  if (report.value > maximum) {
+    context.addIssue({ code: 'custom', message: 'Web Vital value exceeds the accepted bound' });
+  }
+  if (report.rating !== deriveWebVitalRating(report.metricName, report.value)) {
+    context.addIssue({ code: 'custom', message: 'Web Vital rating does not match its value' });
+  }
+});
+
+export type WebVitalReport = z.infer<typeof webVitalReportSchema>;
+
+export type StoredWebVital = Omit<WebVitalReport, 'value'> & {
+  releaseIdentity: string;
+  value: string;
+  observedAt: Date;
+};
+
+export interface WebVitalsStore {
+  upsert(metric: StoredWebVital): Promise<void>;
+}
+
+export function getWebVitalsReleaseIdentity(): string {
+  return releaseIdentitySchema.parse(
+    process.env.RAILWAY_GIT_COMMIT_SHA
+      ?? process.env.VERCEL_GIT_COMMIT_SHA
+      ?? process.env.GITHUB_SHA
+      ?? 'local-development',
+  );
+}
+
+export function createWebVitalsRecorder(input: {
+  store: WebVitalsStore;
+  isEventEnabled(eventName: 'web_vitals'): Promise<boolean>;
+  getReleaseIdentity: () => string;
+  now?: () => Date;
+}) {
+  const now = input.now ?? (() => new Date());
+
+  return {
+    async record(report: WebVitalReport): Promise<{
+      status: 'recorded' | 'disabled' | 'ineligible' | 'failed';
+    }> {
+      const parsed = webVitalReportSchema.safeParse(report);
+      if (!parsed.success) return { status: 'ineligible' };
+
+      try {
+        if (!(await input.isEventEnabled('web_vitals'))) return { status: 'disabled' };
+        const releaseIdentity = releaseIdentitySchema.parse(input.getReleaseIdentity());
+        await input.store.upsert({
+          ...parsed.data,
+          releaseIdentity,
+          value: parsed.data.value.toFixed(4),
+          observedAt: now(),
+        });
+        return { status: 'recorded' };
+      } catch {
+        return { status: 'failed' };
+      }
+    },
+  };
+}
+
+const drizzleWebVitalsStore: WebVitalsStore = {
+  async upsert(metric) {
+    await db
+      .insert(webVitals)
+      .values({
+        pageLoadId: metric.pageLoadId,
+        metricName: metric.metricName,
+        routeFamily: metric.routeFamily,
+        deviceClass: metric.deviceClass,
+        releaseIdentity: metric.releaseIdentity,
+        value: metric.value,
+        rating: metric.rating,
+        createdAt: metric.observedAt,
+        updatedAt: metric.observedAt,
+      })
+      .onDuplicateKeyUpdate({
+        set: {
+          routeFamily: metric.routeFamily,
+          deviceClass: metric.deviceClass,
+          releaseIdentity: metric.releaseIdentity,
+          value: metric.value,
+          rating: metric.rating,
+          updatedAt: metric.observedAt,
+        },
+      });
+  },
+};
+
+export const webVitalsRecorder = createWebVitalsRecorder({
+  store: drizzleWebVitalsStore,
+  isEventEnabled: isAnalyticsEventEnabled,
+  getReleaseIdentity: getWebVitalsReleaseIdentity,
+});

--- a/src/lib/web-vitals.ts
+++ b/src/lib/web-vitals.ts
@@ -8,6 +8,8 @@ import { webVitals } from '@/lib/db/schema';
 import {
   WEB_VITAL_DEVICE_CLASSES,
   WEB_VITAL_NAMES,
+  WEB_VITAL_RELEASE_IDENTITY_MAX_LENGTH,
+  WEB_VITAL_RELEASE_IDENTITY_PATTERN,
   WEB_VITAL_RATINGS,
   WEB_VITAL_ROUTE_FAMILIES,
   type WebVitalName,
@@ -17,8 +19,9 @@ import {
 const MAX_DURATION_MS = 600_000;
 const MAX_CLS = 10;
 
-const releaseIdentitySchema = z.string().trim().min(1).max(100)
-  .regex(/^[A-Za-z0-9._:-]+$/);
+const releaseIdentitySchema = z.string().trim().min(1)
+  .max(WEB_VITAL_RELEASE_IDENTITY_MAX_LENGTH)
+  .regex(WEB_VITAL_RELEASE_IDENTITY_PATTERN);
 
 export function deriveWebVitalRating(
   metricName: WebVitalName,
@@ -44,6 +47,7 @@ export const webVitalReportSchema = z.object({
   metricName: z.enum(WEB_VITAL_NAMES),
   routeFamily: z.enum(WEB_VITAL_ROUTE_FAMILIES),
   deviceClass: z.enum(WEB_VITAL_DEVICE_CLASSES),
+  releaseIdentity: releaseIdentitySchema,
   value: z.number().finite().min(0),
   rating: z.enum(WEB_VITAL_RATINGS),
 }).strict().superRefine((report, context) => {
@@ -59,7 +63,6 @@ export const webVitalReportSchema = z.object({
 export type WebVitalReport = z.infer<typeof webVitalReportSchema>;
 
 export type StoredWebVital = Omit<WebVitalReport, 'value'> & {
-  releaseIdentity: string;
   value: string;
   observedAt: Date;
 };
@@ -68,19 +71,9 @@ export interface WebVitalsStore {
   upsert(metric: StoredWebVital): Promise<void>;
 }
 
-export function getWebVitalsReleaseIdentity(): string {
-  return releaseIdentitySchema.parse(
-    process.env.RAILWAY_GIT_COMMIT_SHA
-      ?? process.env.VERCEL_GIT_COMMIT_SHA
-      ?? process.env.GITHUB_SHA
-      ?? 'local-development',
-  );
-}
-
 export function createWebVitalsRecorder(input: {
   store: WebVitalsStore;
   isEventEnabled(eventName: 'web_vitals'): Promise<boolean>;
-  getReleaseIdentity: () => string;
   now?: () => Date;
 }) {
   const now = input.now ?? (() => new Date());
@@ -94,10 +87,8 @@ export function createWebVitalsRecorder(input: {
 
       try {
         if (!(await input.isEventEnabled('web_vitals'))) return { status: 'disabled' };
-        const releaseIdentity = releaseIdentitySchema.parse(input.getReleaseIdentity());
         await input.store.upsert({
           ...parsed.data,
-          releaseIdentity,
           value: parsed.data.value.toFixed(4),
           observedAt: now(),
         });
@@ -109,36 +100,36 @@ export function createWebVitalsRecorder(input: {
   };
 }
 
-const drizzleWebVitalsStore: WebVitalsStore = {
-  async upsert(metric) {
-    await db
-      .insert(webVitals)
-      .values({
-        pageLoadId: metric.pageLoadId,
-        metricName: metric.metricName,
-        routeFamily: metric.routeFamily,
-        deviceClass: metric.deviceClass,
-        releaseIdentity: metric.releaseIdentity,
-        value: metric.value,
-        rating: metric.rating,
-        createdAt: metric.observedAt,
-        updatedAt: metric.observedAt,
-      })
-      .onDuplicateKeyUpdate({
-        set: {
+export function createDrizzleWebVitalsStore(database: typeof db): WebVitalsStore {
+  return {
+    async upsert(metric) {
+      await database
+        .insert(webVitals)
+        .values({
+          pageLoadId: metric.pageLoadId,
+          metricName: metric.metricName,
           routeFamily: metric.routeFamily,
           deviceClass: metric.deviceClass,
           releaseIdentity: metric.releaseIdentity,
           value: metric.value,
           rating: metric.rating,
+          createdAt: metric.observedAt,
           updatedAt: metric.observedAt,
-        },
-      });
-  },
-};
+        })
+        .onDuplicateKeyUpdate({
+          set: {
+            value: metric.value,
+            rating: metric.rating,
+            updatedAt: metric.observedAt,
+          },
+        });
+    },
+  };
+}
+
+const drizzleWebVitalsStore = createDrizzleWebVitalsStore(db);
 
 export const webVitalsRecorder = createWebVitalsRecorder({
   store: drizzleWebVitalsStore,
   isEventEnabled: isAnalyticsEventEnabled,
-  getReleaseIdentity: getWebVitalsReleaseIdentity,
 });

--- a/tests/api/web-vitals.test.ts
+++ b/tests/api/web-vitals.test.ts
@@ -25,6 +25,7 @@ const validReport = {
   metricName: 'CLS',
   routeFamily: 'home',
   deviceClass: 'desktop',
+  releaseIdentity: 'release-1',
   value: 0.08,
   rating: 'good',
 };

--- a/tests/api/web-vitals.test.ts
+++ b/tests/api/web-vitals.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/analytics-control', () => ({ isAnalyticsEventEnabled: vi.fn() }));
+vi.mock('@/lib/web-vitals', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/web-vitals')>();
+  return {
+    ...actual,
+    webVitalsRecorder: { record: vi.fn() },
+  };
+});
+vi.mock('@/lib/error-handler', () => ({ logEvent: vi.fn() }));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  rateLimits: { general: { maxRequests: 100, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn().mockReturnValue(new Response(null, { status: 429 })),
+}));
+
+import { isAnalyticsEventEnabled } from '@/lib/analytics-control';
+import { checkRateLimit } from '@/lib/rate-limit';
+import { webVitalsRecorder } from '@/lib/web-vitals';
+
+const validReport = {
+  pageLoadId: 'v4-1720000000000-123456789',
+  metricName: 'CLS',
+  routeFamily: 'home',
+  deviceClass: 'desktop',
+  value: 0.08,
+  rating: 'good',
+};
+
+function request(body: unknown): Request {
+  return new Request('http://localhost/api/analytics/web-vitals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function post(input: Request) {
+  const route = await import('@/app/api/analytics/web-vitals/route');
+  return route.POST(input);
+}
+
+describe('POST /api/analytics/web-vitals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkRateLimit).mockReturnValue({
+      success: true,
+      remaining: 99,
+      resetTime: Date.now() + 60_000,
+    });
+    vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(true);
+    vi.mocked(webVitalsRecorder.record).mockResolvedValue({ status: 'recorded' });
+  });
+
+  it('returns before parsing page-load identity when performance analytics is disabled', async () => {
+    vi.mocked(isAnalyticsEventEnabled).mockResolvedValue(false);
+    const input = request(validReport);
+    const readBody = vi.spyOn(input, 'json');
+
+    const response = await post(input);
+
+    expect(response.status).toBe(204);
+    expect(isAnalyticsEventEnabled).toHaveBeenCalledWith('web_vitals');
+    expect(readBody).not.toHaveBeenCalled();
+    expect(webVitalsRecorder.record).not.toHaveBeenCalled();
+  });
+
+  it('records only a strict privacy-minimized report', async () => {
+    const response = await post(request(validReport));
+
+    expect(response.status).toBe(204);
+    expect(webVitalsRecorder.record).toHaveBeenCalledWith(validReport);
+  });
+
+  it('rejects unknown metrics, full URLs, and user identity', async () => {
+    for (const report of [
+      { ...validReport, metricName: 'FCP' },
+      { ...validReport, fullUrl: 'https://example.com/private?email=person@example.com' },
+      { ...validReport, userId: 'user-1' },
+    ]) {
+      const response = await post(request(report));
+      expect(response.status).toBe(400);
+    }
+    expect(webVitalsRecorder.record).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/web-vitals-reporter.test.tsx
+++ b/tests/components/web-vitals-reporter.test.tsx
@@ -11,6 +11,7 @@ vi.mock('next/web-vitals', () => ({ useReportWebVitals }));
 
 import WebVitalsReporter from '@/components/analytics/WebVitalsReporter';
 import {
+  initializeWebVitalsPageLoadContext,
   normalizeWebVitalRouteFamily,
   reportWebVitalMetric,
 } from '@/components/analytics/web-vitals-client';
@@ -24,13 +25,14 @@ describe('WebVitalsReporter', () => {
       configurable: true,
       value: vi.fn().mockReturnValue(true),
     });
+    initializeWebVitalsPageLoadContext('release-1');
   });
 
   afterEach(() => cleanup());
 
   it('keeps the Next.js callback stable across renders', () => {
-    const view = render(<WebVitalsReporter />);
-    view.rerender(<WebVitalsReporter />);
+    const view = render(<WebVitalsReporter releaseIdentity={'release-1'} />);
+    view.rerender(<WebVitalsReporter releaseIdentity={'release-1'} />);
 
     expect(useReportWebVitals).toHaveBeenCalledTimes(2);
     expect(useReportWebVitals.mock.calls[0][0]).toBe(useReportWebVitals.mock.calls[1][0]);
@@ -53,10 +55,32 @@ describe('WebVitalsReporter', () => {
       metricName: 'LCP',
       routeFamily: 'learning',
       deviceClass: 'mobile',
+      releaseIdentity: 'release-1',
       value: 1_900,
       rating: 'good',
     });
     expect(payload).not.toContain('/courses/typescript');
+  });
+
+  it('keeps page-load dimensions stable across callback updates', async () => {
+    const metric = {
+      id: 'v4-1720000000000-stable-context',
+      name: 'CLS',
+      value: 0.08,
+      rating: 'good',
+    };
+
+    reportWebVitalMetric(metric);
+    window.history.replaceState({}, '', '/blog/privacy-update');
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1_024 });
+    reportWebVitalMetric({ ...metric, value: 0.12, rating: 'needs-improvement' });
+
+    const calls = vi.mocked(navigator.sendBeacon).mock.calls;
+    const firstPayload = JSON.parse(await (calls[0][1] as Blob).text());
+    const updatedPayload = JSON.parse(await (calls[1][1] as Blob).text());
+
+    expect(firstPayload).toMatchObject({ routeFamily: 'learning', deviceClass: 'mobile' });
+    expect(updatedPayload).toMatchObject({ routeFamily: 'learning', deviceClass: 'mobile' });
   });
 
   it('ignores non-Core metrics and normalizes dynamic routes without retaining the path', () => {

--- a/tests/components/web-vitals-reporter.test.tsx
+++ b/tests/components/web-vitals-reporter.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { useReportWebVitals } = vi.hoisted(() => ({
+  useReportWebVitals: vi.fn(),
+}));
+
+vi.mock('next/web-vitals', () => ({ useReportWebVitals }));
+
+import WebVitalsReporter from '@/components/analytics/WebVitalsReporter';
+import {
+  normalizeWebVitalRouteFamily,
+  reportWebVitalMetric,
+} from '@/components/analytics/web-vitals-client';
+
+describe('WebVitalsReporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/courses/typescript/learn/lesson-1');
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  it('keeps the Next.js callback stable across renders', () => {
+    const view = render(<WebVitalsReporter />);
+    view.rerender(<WebVitalsReporter />);
+
+    expect(useReportWebVitals).toHaveBeenCalledTimes(2);
+    expect(useReportWebVitals.mock.calls[0][0]).toBe(useReportWebVitals.mock.calls[1][0]);
+  });
+
+  it('sends only a coarse privacy-minimized Core Web Vital payload', async () => {
+    reportWebVitalMetric({
+      id: 'v4-1720000000000-123456789',
+      name: 'LCP',
+      value: 1_900,
+      rating: 'good',
+    });
+
+    expect(navigator.sendBeacon).toHaveBeenCalledOnce();
+    const [endpoint, body] = vi.mocked(navigator.sendBeacon).mock.calls[0];
+    expect(endpoint).toBe('/api/analytics/web-vitals');
+    const payload = await (body as Blob).text();
+    expect(JSON.parse(payload)).toEqual({
+      pageLoadId: 'v4-1720000000000-123456789',
+      metricName: 'LCP',
+      routeFamily: 'learning',
+      deviceClass: 'mobile',
+      value: 1_900,
+      rating: 'good',
+    });
+    expect(payload).not.toContain('/courses/typescript');
+  });
+
+  it('ignores non-Core metrics and normalizes dynamic routes without retaining the path', () => {
+    reportWebVitalMetric({
+      id: 'v4-1720000000000-123456789',
+      name: 'FCP',
+      value: 100,
+      rating: 'good',
+    });
+
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+    expect(normalizeWebVitalRouteFamily('/courses/typescript/learn/lesson-1')).toBe('learning');
+    expect(normalizeWebVitalRouteFamily('/bundles/frontend/payment-success')).toBe('purchase');
+    expect(normalizeWebVitalRouteFamily('/admin/users')).toBeNull();
+  });
+});

--- a/tests/lib/analytics-control-service.test.ts
+++ b/tests/lib/analytics-control-service.test.ts
@@ -142,6 +142,22 @@ describe('analytics control service', () => {
 
     await expect(service.isEventEnabled('course_viewed')).resolves.toBe(true);
     await expect(service.isEventEnabled('purchase_completed')).resolves.toBe(false);
+    await expect(service.isEventEnabled('web_vitals')).resolves.toBe(false);
+  });
+
+  it('enables Web Vitals only when the performance class is approved', async () => {
+    const store = new MemoryAnalyticsControlStore();
+    const service = createAnalyticsControlService(store);
+
+    await service.recordGovernanceDecision({
+      decision: { ...governanceDecision, approvedEventClasses: ['performance'] },
+      actorId: 'admin-1',
+      auditContext,
+    });
+    await service.setOperationalEnabled({ enabled: true, actorId: 'admin-1', auditContext });
+
+    await expect(service.isEventEnabled('web_vitals')).resolves.toBe(true);
+    await expect(service.isEventEnabled('course_viewed')).resolves.toBe(false);
   });
 
   it('rejects incomplete or extensible governance records', async () => {

--- a/tests/lib/analytics-retention.test.ts
+++ b/tests/lib/analytics-retention.test.ts
@@ -9,9 +9,9 @@ import {
 class MemoryAnalyticsRetentionStore implements AnalyticsRetentionStore {
   calls: Array<{ cutoff: Date; batchSize: number }> = [];
 
-  async deleteRawEventsBefore(cutoff: Date, batchSize: number): Promise<number> {
+  async deleteRawMeasurementsBefore(cutoff: Date, batchSize: number) {
     this.calls.push({ cutoff, batchSize });
-    return 7;
+    return { analyticsEvents: 5, webVitals: 2 };
   }
 }
 
@@ -29,6 +29,8 @@ describe('analytics raw-event retention policy', () => {
     expect(result).toEqual({
       cutoff: new Date('2026-08-01T12:00:00.000Z'),
       deletedCount: 7,
+      deletedAnalyticsEventCount: 5,
+      deletedWebVitalCount: 2,
       batchSize: 500,
     });
     expect(store.calls).toEqual([{

--- a/tests/lib/web-vitals-release.test.ts
+++ b/tests/lib/web-vitals-release.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getWebVitalsReleaseIdentity } from '@/lib/web-vitals-release';
+
+describe('Web Vitals release identity', () => {
+  it('prefers the release that rendered the page', () => {
+    expect(getWebVitalsReleaseIdentity({
+      RAILWAY_GIT_COMMIT_SHA: 'railway-release',
+      VERCEL_GIT_COMMIT_SHA: 'vercel-release',
+      GITHUB_SHA: 'github-release',
+    })).toBe('railway-release');
+  });
+
+  it('falls back safely instead of breaking page rendering', () => {
+    expect(getWebVitalsReleaseIdentity({
+      RAILWAY_GIT_COMMIT_SHA: 'invalid release identity',
+      VERCEL_GIT_COMMIT_SHA: undefined,
+      GITHUB_SHA: undefined,
+    })).toBe('unknown-release');
+  });
+});

--- a/tests/lib/web-vitals-schema.test.ts
+++ b/tests/lib/web-vitals-schema.test.ts
@@ -50,4 +50,5 @@ describe('Web Vitals schema', () => {
     expect(migration).not.toMatch(/user_id|full_url|query|ip_address|user_agent/i);
     expect(migration).not.toMatch(/^\s*(DROP TABLE|DROP COLUMN|DELETE|UPDATE|RENAME|TRUNCATE)\b/im);
   });
+
 });

--- a/tests/lib/web-vitals-schema.test.ts
+++ b/tests/lib/web-vitals-schema.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/mysql-core';
+
+import { webVitals } from '@/lib/db/schema';
+
+function indexColumns(config: ReturnType<typeof getTableConfig>, name: string) {
+  const candidate = config.indexes.find((entry) => entry.config.name === name);
+  return {
+    unique: candidate?.config.unique,
+    columns: candidate?.config.columns.map((column) => (
+      'name' in column ? column.name : null
+    )),
+  };
+}
+
+describe('Web Vitals schema', () => {
+  it('stores only the page-load key, coarse dimensions, value, rating, and retention timestamps', () => {
+    const table = getTableConfig(webVitals);
+
+    expect(table.columns.map((column) => column.name)).toEqual([
+      'id',
+      'page_load_id',
+      'metric_name',
+      'route_family',
+      'device_class',
+      'release_identity',
+      'value',
+      'rating',
+      'created_at',
+      'updated_at',
+    ]);
+    expect(indexColumns(table, 'uq_web_vitals_page_metric')).toEqual({
+      unique: true,
+      columns: ['page_load_id', 'metric_name'],
+    });
+  });
+
+  it('uses an additive migration with the page-load metric upsert key', () => {
+    const migration = readFileSync(
+      resolve(process.cwd(), 'drizzle/0020_dapper_lenny_balinger.sql'),
+      'utf8',
+    );
+
+    expect(migration).toMatch(/CREATE TABLE .web_vitals./);
+    expect(migration).toMatch(
+      /CONSTRAINT .uq_web_vitals_page_metric. UNIQUE\(.page_load_id.,.metric_name.\)/,
+    );
+    expect(migration).not.toMatch(/user_id|full_url|query|ip_address|user_agent/i);
+    expect(migration).not.toMatch(/^\s*(DROP TABLE|DROP COLUMN|DELETE|UPDATE|RENAME|TRUNCATE)\b/im);
+  });
+});

--- a/tests/lib/web-vitals.test.ts
+++ b/tests/lib/web-vitals.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createWebVitalsRecorder,
+  deriveWebVitalRating,
+  webVitalReportSchema,
+  type StoredWebVital,
+  type WebVitalsStore,
+} from '@/lib/web-vitals';
+
+const validReport = {
+  pageLoadId: 'v4-1720000000000-123456789',
+  metricName: 'LCP',
+  routeFamily: 'product_detail',
+  deviceClass: 'mobile',
+  value: 2_400,
+  rating: 'good',
+} as const;
+
+class MemoryWebVitalsStore implements WebVitalsStore {
+  records = new Map<string, StoredWebVital>();
+
+  async upsert(metric: StoredWebVital) {
+    this.records.set(`${metric.pageLoadId}:${metric.metricName}`, metric);
+  }
+}
+
+describe('Web Vitals contract', () => {
+  it('accepts only bounded LCP, INP, and CLS values with matching ratings', () => {
+    expect(webVitalReportSchema.safeParse(validReport).success).toBe(true);
+    expect(webVitalReportSchema.safeParse({
+      ...validReport,
+      metricName: 'INP',
+      value: 200,
+      rating: 'good',
+    }).success).toBe(true);
+    expect(webVitalReportSchema.safeParse({
+      ...validReport,
+      metricName: 'CLS',
+      value: 0.25,
+      rating: 'needs-improvement',
+    }).success).toBe(true);
+
+    for (const report of [
+      { ...validReport, metricName: 'FCP' },
+      { ...validReport, value: Number.NaN },
+      { ...validReport, value: Number.POSITIVE_INFINITY },
+      { ...validReport, value: -1 },
+      { ...validReport, value: 600_001 },
+      { ...validReport, metricName: 'CLS', value: 10.01, rating: 'poor' },
+      { ...validReport, value: 4_001, rating: 'good' },
+      { ...validReport, fullUrl: 'https://example.com/courses/private?email=person@example.com' },
+      { ...validReport, userId: 'user-1' },
+      { ...validReport, releaseIdentity: 'client-controlled-release' },
+    ]) {
+      expect(webVitalReportSchema.safeParse(report).success).toBe(false);
+    }
+  });
+
+  it('derives Chrome rating thresholds consistently', () => {
+    expect(deriveWebVitalRating('LCP', 2_500)).toBe('good');
+    expect(deriveWebVitalRating('LCP', 4_000)).toBe('needs-improvement');
+    expect(deriveWebVitalRating('INP', 200)).toBe('good');
+    expect(deriveWebVitalRating('INP', 500)).toBe('needs-improvement');
+    expect(deriveWebVitalRating('CLS', 0.1)).toBe('good');
+    expect(deriveWebVitalRating('CLS', 0.25)).toBe('needs-improvement');
+  });
+});
+
+describe('Web Vitals recorder', () => {
+  it('stops before release identity and persistence when performance analytics is disabled', async () => {
+    const store = new MemoryWebVitalsStore();
+    const getReleaseIdentity = vi.fn(() => 'release-1');
+    const recorder = createWebVitalsRecorder({
+      store,
+      isEventEnabled: async () => false,
+      getReleaseIdentity,
+    });
+
+    await expect(recorder.record(validReport)).resolves.toEqual({ status: 'disabled' });
+    expect(getReleaseIdentity).not.toHaveBeenCalled();
+    expect(store.records.size).toBe(0);
+  });
+
+  it('upserts the latest callback by page-load identity and metric name', async () => {
+    const store = new MemoryWebVitalsStore();
+    const recorder = createWebVitalsRecorder({
+      store,
+      isEventEnabled: async () => true,
+      getReleaseIdentity: () => 'release-1',
+      now: () => new Date('2026-09-01T03:00:00.000Z'),
+    });
+
+    await expect(recorder.record(validReport)).resolves.toEqual({ status: 'recorded' });
+    await expect(recorder.record({
+      ...validReport,
+      value: 3_200,
+      rating: 'needs-improvement',
+    })).resolves.toEqual({ status: 'recorded' });
+    await recorder.record({
+      ...validReport,
+      metricName: 'INP',
+      value: 180,
+      rating: 'good',
+    });
+
+    expect(store.records.size).toBe(2);
+    expect(store.records.get(`${validReport.pageLoadId}:LCP`)).toEqual({
+      ...validReport,
+      releaseIdentity: 'release-1',
+      value: '3200.0000',
+      rating: 'needs-improvement',
+      observedAt: new Date('2026-09-01T03:00:00.000Z'),
+    });
+  });
+});

--- a/tests/lib/web-vitals.test.ts
+++ b/tests/lib/web-vitals.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
+  createDrizzleWebVitalsStore,
   createWebVitalsRecorder,
   deriveWebVitalRating,
   webVitalReportSchema,
@@ -13,6 +14,7 @@ const validReport = {
   metricName: 'LCP',
   routeFamily: 'product_detail',
   deviceClass: 'mobile',
+  releaseIdentity: 'release-1',
   value: 2_400,
   rating: 'good',
 } as const;
@@ -51,7 +53,7 @@ describe('Web Vitals contract', () => {
       { ...validReport, value: 4_001, rating: 'good' },
       { ...validReport, fullUrl: 'https://example.com/courses/private?email=person@example.com' },
       { ...validReport, userId: 'user-1' },
-      { ...validReport, releaseIdentity: 'client-controlled-release' },
+      { ...validReport, releaseIdentity: 'release identity with spaces' },
     ]) {
       expect(webVitalReportSchema.safeParse(report).success).toBe(false);
     }
@@ -70,15 +72,12 @@ describe('Web Vitals contract', () => {
 describe('Web Vitals recorder', () => {
   it('stops before release identity and persistence when performance analytics is disabled', async () => {
     const store = new MemoryWebVitalsStore();
-    const getReleaseIdentity = vi.fn(() => 'release-1');
     const recorder = createWebVitalsRecorder({
       store,
       isEventEnabled: async () => false,
-      getReleaseIdentity,
     });
 
     await expect(recorder.record(validReport)).resolves.toEqual({ status: 'disabled' });
-    expect(getReleaseIdentity).not.toHaveBeenCalled();
     expect(store.records.size).toBe(0);
   });
 
@@ -87,7 +86,6 @@ describe('Web Vitals recorder', () => {
     const recorder = createWebVitalsRecorder({
       store,
       isEventEnabled: async () => true,
-      getReleaseIdentity: () => 'release-1',
       now: () => new Date('2026-09-01T03:00:00.000Z'),
     });
 
@@ -111,6 +109,44 @@ describe('Web Vitals recorder', () => {
       value: '3200.0000',
       rating: 'needs-improvement',
       observedAt: new Date('2026-09-01T03:00:00.000Z'),
+    });
+  });
+
+  it('keeps cohort dimensions immutable through the Drizzle store boundary', async () => {
+    const records = new Map<string, Record<string, unknown>>();
+    const database = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) => ({
+          onDuplicateKeyUpdate: async ({ set }: { set: Record<string, unknown> }) => {
+            const key = `${values.pageLoadId}:${values.metricName}`;
+            records.set(key, records.has(key)
+              ? { ...records.get(key), ...set }
+              : values);
+          },
+        }),
+      }),
+    } as unknown as Parameters<typeof createDrizzleWebVitalsStore>[0];
+    const store = createDrizzleWebVitalsStore(database);
+    const observedAt = new Date('2026-09-01T03:00:00.000Z');
+
+    await store.upsert({ ...validReport, value: '2400.0000', observedAt });
+    await store.upsert({
+      ...validReport,
+      routeFamily: 'content',
+      deviceClass: 'desktop',
+      releaseIdentity: 'release-2',
+      value: '3200.0000',
+      rating: 'needs-improvement',
+      observedAt: new Date('2026-09-01T03:01:00.000Z'),
+    });
+
+    expect(records.get(`${validReport.pageLoadId}:LCP`)).toMatchObject({
+      routeFamily: 'product_detail',
+      deviceClass: 'mobile',
+      releaseIdentity: 'release-1',
+      value: '3200.0000',
+      rating: 'needs-improvement',
+      updatedAt: new Date('2026-09-01T03:01:00.000Z'),
     });
   });
 });


### PR DESCRIPTION
## Summary
- collect only finite, bounded LCP, INP, and CLS through an isolated stable Web Vitals reporter
- upsert the latest value by page-load metric identity with coarse route/device dimensions and server-owned release identity
- extend performance governance and shared raw-measurement retention with an additive Drizzle migration

## Verification
- focused tests: 8 files, 28 tests passed
- full test suite: 121 files, 715 tests passed
- `npm run lint`
- `npm run build` (92 routes, including `/api/analytics/web-vitals`)
- `git diff --check`

## Not run locally
- `npm run test:e2e`
- migration rehearsal against disposable MySQL (covered by required CI E2E)

Closes #32