### PR TITLE
feat(auth): preserve safe return intent

### DIFF
--- a/e2e/required/public-product-auth.spec.ts
+++ b/e2e/required/public-product-auth.spec.ts
@@ -1,7 +1,29 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 import { E2E_FIXTURES } from '../fixtures';
 import { installRequiredE2EProviderMocks } from './provider-mock-adapter.mjs';
+
+async function registerAndReturnTo(page: Page, destination: string, journeyName: string) {
+  const uniqueId = crypto.randomUUID().replaceAll('-', '');
+  const generatedPassword = 'Aa1!' + uniqueId;
+
+  await expect(page).toHaveURL(/\/login\?/);
+  expect(new URL(page.url()).searchParams.get('callbackUrl')).toBe(destination);
+
+  await page.getByRole('link', { name: /สมัครสมาชิกฟรี/ }).click();
+  await expect(page).toHaveURL(/\/register\?/);
+  expect(new URL(page.url()).searchParams.get('callbackUrl')).toBe(destination);
+
+  await page.locator('input[name=name]').fill('Safe Return ' + journeyName);
+  await page.locator('input[name=email]').fill('safe-return-' + uniqueId + '@example.test');
+  await page.locator('input[name=password]').fill(generatedPassword);
+  await page.locator('input[name=confirmPassword]').fill(generatedPassword);
+  await page.locator('button[type=submit]').click();
+
+  await page.waitForURL((url) => url.pathname === destination);
+  expect(new URL(page.url()).pathname).toBe(destination);
+  expect(new URL(page.url()).search).toBe('');
+}
 
 test('public paid product preserves its destination at the authentication boundary', async ({ page }, testInfo) => {
   const appBaseUrl = testInfo.project.use.baseURL;
@@ -40,4 +62,46 @@ test('public paid product preserves its destination at the authentication bounda
   );
   expect(network.providerRequests, 'required journey must not invoke provider mocks').toEqual([]);
   expect(network.blockedRequests, 'required journey must not attempt unknown external traffic').toEqual([]);
+});
+
+test('desktop guest returns to the exact Course after registration', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const appBaseUrl = testInfo.project.use.baseURL;
+  if (typeof appBaseUrl !== 'string') {
+    throw new Error('Required E2E project must define a baseURL');
+  }
+  const network = await installRequiredE2EProviderMocks(page, appBaseUrl);
+  const destination = `/courses/${E2E_FIXTURES.courses.paid.slug}`;
+
+  await page.goto(destination);
+  await page.getByRole('button', { name: /ซื้อคอร์สนี้/ }).first().click();
+  await registerAndReturnTo(page, destination, 'Desktop Course');
+
+  expect(network.providerRequests, 'credentials journey must not invoke provider mocks').toEqual([]);
+  expect(network.blockedRequests, 'credentials journey must not attempt unknown external traffic').toEqual([]);
+});
+
+test('mobile guest returns to the exact Bundle after registration', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const appBaseUrl = testInfo.project.use.baseURL;
+  if (typeof appBaseUrl !== 'string') {
+    throw new Error('Required E2E project must define a baseURL');
+  }
+  const network = await installRequiredE2EProviderMocks(page, appBaseUrl);
+  const response = await page.request.get('/api/bundles');
+  expect(response.ok(), 'fixture-backed bundle API must be available').toBe(true);
+  const payload = await response.json() as {
+    bundles?: Array<{ slug: string; title: string }>;
+  };
+  const bundle = payload.bundles?.[0];
+  expect(bundle, 'at least one published bundle fixture must exist').toBeTruthy();
+  const destination = `/bundles/${bundle!.slug}`;
+
+  await page.goto(destination);
+  await expect(page.getByRole('heading', { level: 1, name: bundle!.title })).toBeVisible();
+  await page.getByRole('button', { name: /Bundle/ }).first().click();
+  await registerAndReturnTo(page, destination, 'Mobile Bundle');
+
+  expect(network.providerRequests, 'credentials journey must not invoke provider mocks').toEqual([]);
+  expect(network.blockedRequests, 'credentials journey must not attempt unknown external traffic').toEqual([]);
 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,8 +2,17 @@ import { Suspense } from 'react';
 import AuthShell from '@/components/auth/AuthShell';
 import LoginForm from '@/components/auth/LoginForm';
 import { Skeleton } from '@/components/ui/skeleton';
+import { createAuthReturnHref, resolveSafeAuthReturn } from '@/lib/safe-auth-return';
 
-export default function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
+}) {
+  const { callbackUrl } = await searchParams;
+  const { pathname: returnTo } = resolveSafeAuthReturn(callbackUrl);
+  const registerHref = createAuthReturnHref('/register', returnTo);
+
   return (
     <AuthShell
       pageId={'login'}
@@ -11,7 +20,7 @@ export default function LoginPage() {
       panelDescription={'ใช้บัญชี MilerDev เพื่อกลับไปเรียนต่อ'}
     >
       <Suspense fallback={<div className="flex flex-col gap-4" aria-busy="true"><span className="sr-only" role="status" aria-live="polite">กำลังเตรียมแบบฟอร์ม</span><Skeleton aria-hidden="true" className="h-5 w-24" /><Skeleton aria-hidden="true" className="h-11 w-full" /><Skeleton aria-hidden="true" className="h-11 w-full" /></div>}>
-        <LoginForm />
+        <LoginForm returnTo={returnTo} registerHref={registerHref} />
       </Suspense>
     </AuthShell>
   );

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,7 +1,16 @@
 import AuthShell from '@/components/auth/AuthShell';
 import RegisterForm from '@/components/auth/RegisterForm';
+import { createAuthReturnHref, resolveSafeAuthReturn } from '@/lib/safe-auth-return';
 
-export default function RegisterPage() {
+export default async function RegisterPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
+}) {
+  const { callbackUrl } = await searchParams;
+  const { pathname: returnTo } = resolveSafeAuthReturn(callbackUrl);
+  const loginHref = createAuthReturnHref('/login', returnTo);
+
   return (
     <AuthShell
       pageId={'register'}
@@ -9,7 +18,7 @@ export default function RegisterPage() {
       panelTitle={'สมัครสมาชิก'}
       panelDescription={'กรอกข้อมูลสำหรับบัญชีผู้เรียน หรือสมัครด้วย Google'}
     >
-      <RegisterForm />
+      <RegisterForm returnTo={returnTo} loginHref={loginHref} />
     </AuthShell>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { FieldGroup } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
+import type { SafeAuthReturnPath } from '@/lib/safe-auth-return';
 import { GoogleIcon } from './AuthIcons';
 import { AuthDivider, AuthError, AuthField, AuthFootnote, PasswordInput } from './AuthFormLayout';
 
@@ -19,7 +20,13 @@ export const AUTH_ERROR_MESSAGES: Record<string, string> = {
   unauthorized: 'กรุณาเข้าสู่ระบบก่อนเข้าใช้งานหน้านี้',
 };
 
-export default function LoginForm() {
+export default function LoginForm({
+  returnTo,
+  registerHref,
+}: {
+  returnTo: SafeAuthReturnPath;
+  registerHref: string;
+}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [email, setEmail] = useState('');
@@ -50,7 +57,7 @@ export default function LoginForm() {
       if (result?.error) {
         setError('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
       } else {
-        router.push('/dashboard');
+        router.push(returnTo);
         router.refresh();
       }
     } catch {
@@ -104,7 +111,7 @@ export default function LoginForm() {
 
       <Button
         type="button"
-        onClick={() => signIn('google', { callbackUrl: '/dashboard' })}
+        onClick={() => signIn('google', { callbackUrl: returnTo })}
         variant="outline"
         className="w-full"
       >
@@ -112,7 +119,7 @@ export default function LoginForm() {
         เข้าสู่ระบบด้วย Google
       </Button>
 
-      <AuthFootnote>ยังไม่มีบัญชี? <Link href="/register">สมัครสมาชิกฟรี</Link></AuthFootnote>
+      <AuthFootnote>ยังไม่มีบัญชี? <Link href={registerHref}>สมัครสมาชิกฟรี</Link></AuthFootnote>
       <p className="mt-2 text-center text-xs leading-5 text-muted-foreground">การเข้าสู่ระบบจะใช้ข้อมูลบัญชีตามนโยบายความเป็นส่วนตัวของ MilerDev</p>
     </>
   );

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -17,6 +17,7 @@ import { FieldGroup } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
 import { Spinner } from '@/components/ui/spinner';
+import type { SafeAuthReturnPath } from '@/lib/safe-auth-return';
 import { GoogleIcon } from './AuthIcons';
 import { AuthDivider, AuthError, AuthField, AuthFootnote, PasswordInput } from './AuthFormLayout';
 
@@ -42,7 +43,13 @@ export const getPasswordStrength = (password: string) => {
   return { score, checks, label, percentage: (score / 5) * 100 };
 };
 
-export default function RegisterForm() {
+export default function RegisterForm({
+  returnTo,
+  loginHref,
+}: {
+  returnTo: SafeAuthReturnPath;
+  loginHref: string;
+}) {
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -80,9 +87,9 @@ export default function RegisterForm() {
 
       const result = await signIn('credentials', { email, password, redirect: false });
       if (result?.error) {
-        router.push('/login');
+        router.push(loginHref);
       } else {
-        router.push('/dashboard');
+        router.push(returnTo);
         router.refresh();
       }
     } catch {
@@ -144,8 +151,8 @@ export default function RegisterForm() {
       </form>
 
       <AuthDivider>หรือใช้บัญชี Google</AuthDivider>
-      <Button type="button" variant="outline" className="w-full" onClick={() => signIn('google', { callbackUrl: '/dashboard' })}><GoogleIcon />สมัครสมาชิกด้วย Google</Button>
-      <AuthFootnote>มีบัญชีอยู่แล้ว? <Link href="/login">เข้าสู่ระบบ</Link></AuthFootnote>
+      <Button type="button" variant="outline" className="w-full" onClick={() => signIn('google', { callbackUrl: returnTo })}><GoogleIcon />สมัครสมาชิกด้วย Google</Button>
+      <AuthFootnote>มีบัญชีอยู่แล้ว? <Link href={loginHref}>เข้าสู่ระบบ</Link></AuthFootnote>
       <p className="mt-2 text-center text-xs leading-5 text-muted-foreground">การสมัครสมาชิกหมายถึงคุณยอมรับข้อกำหนดการใช้งานและนโยบายความเป็นส่วนตัวของ MilerDev</p>
     </>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,6 +9,7 @@ import { authorizeGoogleSignIn, createGoogleProvider } from "./auth-google";
 import { applyJwtSessionPolicy, exposeAuthorizedSession } from "./auth-session";
 import { authorizeCredentials } from "./auth-credentials";
 import { consumeAuthRateLimit } from "./auth-rate-limit";
+import { resolveSafeAuthRedirect } from "./safe-auth-return";
 
 const EXPECTED_AUTH_ERROR_TYPES = new Set(["CredentialsSignin", "MissingCSRF"]);
 
@@ -73,6 +74,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }),
     ],
     callbacks: {
+        async redirect({ url, baseUrl }) {
+            return resolveSafeAuthRedirect(url, baseUrl);
+        },
         async signIn({ account, profile, user }) {
             if (account?.provider === "google") {
                 return authorizeGoogleSignIn(profile, user?.id, async ({ email, userId }) => {

--- a/src/lib/safe-auth-return.ts
+++ b/src/lib/safe-auth-return.ts
@@ -1,0 +1,119 @@
+import 'server-only';
+
+declare const safeAuthReturnPathBrand: unique symbol;
+
+export type SafeAuthReturnPath = string & {
+  readonly [safeAuthReturnPathBrand]: true;
+};
+
+export const DEFAULT_AUTH_RETURN_PATH = '/dashboard' as SafeAuthReturnPath;
+
+export type SafeAuthReturn = {
+  pathname: SafeAuthReturnPath;
+  source: 'validated' | 'fallback';
+};
+
+export type AuthEntryPath = '/login' | '/register';
+
+const AUTH_LOOP_PATHS = ['/login', '/register', '/forgot-password', '/reset-password'];
+const INTERNAL_PATHS = ['/api', '/_next', '/_vercel'];
+const INTERNAL_PREFIXES = ['/__nextjs'];
+const PRODUCT_ROUTE_PATHS = ['/courses', '/bundles'];
+const ENCODED_STRUCTURE = /%(?:0[0-9a-f]|1[0-9a-f]|23|25|2e|2f|5c|7f)/i;
+const ASSET_EXTENSION = /\.[a-z0-9]+$/i;
+const UNSAFE_AUTH_RETURN_CHARACTERS = /[\\\u0000-\u001F\u007F-\u009F]/;
+
+function fallback(): SafeAuthReturn {
+  return { pathname: DEFAULT_AUTH_RETURN_PATH, source: 'fallback' };
+}
+
+function matchesPath(pathname: string, blockedPath: string): boolean {
+  return pathname === blockedPath || pathname.startsWith(`${blockedPath}/`);
+}
+
+export function resolveSafeAuthReturn(value: unknown): SafeAuthReturn {
+  if (
+    typeof value !== 'string' ||
+    value.length > 2_048 ||
+    UNSAFE_AUTH_RETURN_CHARACTERS.test(value)
+  ) {
+    return fallback();
+  }
+
+  const [pathname] = value.split(/[?#]/, 1);
+
+  if (
+    !pathname ||
+    !pathname.startsWith('/') ||
+    pathname.startsWith('//') ||
+    /%(?![0-9a-f]{2})/i.test(pathname) ||
+    ENCODED_STRUCTURE.test(pathname)
+  ) {
+    return fallback();
+  }
+
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(pathname);
+  } catch {
+    return fallback();
+  }
+
+  const segments = decodedPathname.split('/');
+  if (
+    UNSAFE_AUTH_RETURN_CHARACTERS.test(decodedPathname) ||
+    /[?#]/.test(decodedPathname) ||
+    decodedPathname.startsWith('//') ||
+    segments.some((segment, index) =>
+      index > 0 && index < segments.length - 1 ? segment.length === 0 : false,
+    ) ||
+    segments.some((segment) => segment === '.' || segment === '..')
+  ) {
+    return fallback();
+  }
+
+  const comparablePathname = decodedPathname.toLowerCase().replace(/\/$/, '') || '/';
+  const isProductRoute = PRODUCT_ROUTE_PATHS.some((productPath) =>
+    matchesPath(comparablePathname, productPath),
+  );
+  if (
+    [...AUTH_LOOP_PATHS, ...INTERNAL_PATHS].some((blockedPath) =>
+      matchesPath(comparablePathname, blockedPath),
+    ) ||
+    INTERNAL_PREFIXES.some((blockedPrefix) => comparablePathname.startsWith(blockedPrefix)) ||
+    (ASSET_EXTENSION.test(comparablePathname) && !isProductRoute)
+  ) {
+    return fallback();
+  }
+
+  return { pathname: pathname as SafeAuthReturnPath, source: 'validated' };
+}
+
+export function createAuthReturnHref(entryPath: AuthEntryPath, value: unknown): string {
+  const { pathname } = resolveSafeAuthReturn(value);
+  return `${entryPath}?callbackUrl=${encodeURIComponent(pathname)}`;
+}
+
+export function resolveSafeAuthRedirect(url: unknown, baseUrl: string): string {
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    return DEFAULT_AUTH_RETURN_PATH;
+  }
+
+  let candidate = url;
+  if (typeof url === 'string' && UNSAFE_AUTH_RETURN_CHARACTERS.test(url)) {
+    candidate = undefined;
+  } else if (typeof url === 'string' && !url.startsWith('/')) {
+    try {
+      const absoluteUrl = new URL(url);
+      candidate = absoluteUrl.origin === base.origin ? absoluteUrl.pathname : undefined;
+    } catch {
+      candidate = undefined;
+    }
+  }
+
+  const { pathname } = resolveSafeAuthReturn(candidate);
+  return new URL(pathname, base.origin).toString();
+}

--- a/tests/components/auth-pages.test.tsx
+++ b/tests/components/auth-pages.test.tsx
@@ -24,7 +24,7 @@ describe('account journey UI contracts', () => {
 
     expect(page).not.toContain('use client');
     expect(page).toContain('<Suspense');
-    expect(page).toContain('<LoginForm />');
+    expect(page).toContain('<LoginForm');
     expect(form).toContain('useSearchParams()');
   });
 
@@ -33,8 +33,6 @@ describe('account journey UI contracts', () => {
 
     expect(source).toContain("signIn('credentials'");
     expect(source).toContain('redirect: false');
-    expect(source).toContain("router.push('/dashboard')");
-    expect(source).toContain("signIn('google', { callbackUrl: '/dashboard' })");
     expect(source).toContain('OAuthAccountNotLinked');
     expect(source).toContain('อีเมลหรือรหัสผ่านไม่ถูกต้อง');
     expect(source).toMatch(/name=(?:["']email["']|\{["']email["']\})/);

--- a/tests/components/auth-register.test.tsx
+++ b/tests/components/auth-register.test.tsx
@@ -9,15 +9,12 @@ describe('Register UI contracts', () => {
     const source = readSource('src/components/auth/RegisterForm.tsx');
 
     expect(page).not.toContain('use client');
-    expect(page).toContain('<RegisterForm />');
+    expect(page).toContain('<RegisterForm');
     expect(source).toContain("fetch('/api/auth/register'");
     expect(source).toContain("method: 'POST'");
     expect(source).toContain("'Content-Type': 'application/json'");
     expect(source).toContain('JSON.stringify({ name, email, password })');
     expect(source).toContain("signIn('credentials'");
-    expect(source).toContain("router.push('/login')");
-    expect(source).toContain("router.push('/dashboard')");
-    expect(source).toContain("signIn('google', { callbackUrl: '/dashboard' })");
   });
 
   it('keeps fields and client password policy aligned with the API', () => {

--- a/tests/components/auth-safe-return.test.tsx
+++ b/tests/components/auth-safe-return.test.tsx
@@ -1,0 +1,147 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import LoginForm from '@/components/auth/LoginForm';
+import RegisterForm from '@/components/auth/RegisterForm';
+import LoginPage from '@/app/login/page';
+import RegisterPage from '@/app/register/page';
+import { createAuthReturnHref, resolveSafeAuthReturn } from '@/lib/safe-auth-return';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+  signIn: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
+  usePathname: () => '/login',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  signIn: mocks.signIn,
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/components/auth/AuthShell', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe('auth safe-return integration', () => {
+  beforeEach(() => {
+    mocks.push.mockReset();
+    mocks.refresh.mockReset();
+    mocks.signIn.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the same course destination for Login credentials, Google, and Register link', async () => {
+    mocks.signIn.mockResolvedValue({ error: null });
+    const returnTo = resolveSafeAuthReturn('/courses/typescript-foundations').pathname;
+    const { container, getByRole } = render(
+      <LoginForm
+        returnTo={returnTo}
+        registerHref={createAuthReturnHref('/register', returnTo)}
+      />,
+    );
+
+    fireEvent.click(getByRole('button', { name: /Google/i }));
+    expect(mocks.signIn).toHaveBeenCalledWith('google', {
+      callbackUrl: '/courses/typescript-foundations',
+    });
+
+    const registerLink = Array.from(container.querySelectorAll('a')).find((link) =>
+      link.getAttribute('href')?.startsWith('/register'),
+    );
+    expect(registerLink?.getAttribute('href')).toBe(
+      '/register?callbackUrl=%2Fcourses%2Ftypescript-foundations',
+    );
+
+    fireEvent.change(container.querySelector('input[name=email]')!, {
+      target: { value: 'learner@example.com' },
+    });
+    fireEvent.change(container.querySelector('input[name=password]')!, {
+      target: { value: 'StrongPass1!' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith('/courses/typescript-foundations');
+    });
+  });
+
+  it('uses the same bundle destination for Register credentials, Google, and Login link', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({ success: true }) }),
+    );
+    mocks.signIn.mockResolvedValue({ error: null });
+    const returnTo = resolveSafeAuthReturn('/bundles/full-stack').pathname;
+    const { container, getByRole } = render(
+      <RegisterForm
+        returnTo={returnTo}
+        loginHref={createAuthReturnHref('/login', returnTo)}
+      />,
+    );
+
+    fireEvent.click(getByRole('button', { name: /Google/i }));
+    expect(mocks.signIn).toHaveBeenCalledWith('google', {
+      callbackUrl: '/bundles/full-stack',
+    });
+
+    const loginLink = Array.from(container.querySelectorAll('a')).find((link) =>
+      link.getAttribute('href')?.startsWith('/login'),
+    );
+    expect(loginLink?.getAttribute('href')).toBe(
+      '/login?callbackUrl=%2Fbundles%2Ffull-stack',
+    );
+
+    for (const [name, value] of [
+      ['name', 'Test Learner'],
+      ['email', 'learner@example.com'],
+      ['password', 'StrongPass1!'],
+      ['confirmPassword', 'StrongPass1!'],
+    ]) {
+      fireEvent.change(container.querySelector(`input[name=${name}]`)!, {
+        target: { value },
+      });
+    }
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith('/bundles/full-stack');
+    });
+  });
+
+  it('validates callbackUrl at both server-owned auth page boundaries', async () => {
+    const loginView = await LoginPage({
+      searchParams: Promise.resolve({ callbackUrl: 'https://evil.example/course' }),
+    });
+    const login = render(loginView);
+    const registerLink = Array.from(login.container.querySelectorAll('a')).find((link) =>
+      link.getAttribute('href')?.startsWith('/register?callbackUrl='),
+    );
+    expect(registerLink?.getAttribute('href')).toBe('/register?callbackUrl=%2Fdashboard');
+
+    cleanup();
+
+    const registerView = await RegisterPage({
+      searchParams: Promise.resolve({ callbackUrl: '/bundles/full-stack?coupon=secret' }),
+    });
+    const register = render(registerView);
+    const loginLink = Array.from(register.container.querySelectorAll('a')).find((link) =>
+      link.getAttribute('href')?.startsWith('/login?callbackUrl='),
+    );
+    expect(loginLink?.getAttribute('href')).toBe(
+      '/login?callbackUrl=%2Fbundles%2Ffull-stack',
+    );
+  });
+});

--- a/tests/lib/safe-auth-return.test.ts
+++ b/tests/lib/safe-auth-return.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAuthReturnHref,
+  resolveSafeAuthRedirect,
+  resolveSafeAuthReturn,
+} from '@/lib/safe-auth-return';
+
+describe('SafeReturnIntent', () => {
+  it('preserves a single-slash internal pathname', () => {
+    expect(resolveSafeAuthReturn('/courses/typescript-foundations')).toEqual({
+      pathname: '/courses/typescript-foundations',
+      source: 'validated',
+    });
+  });
+
+  it('keeps only the pathname and drops query or hash state', () => {
+    expect(resolveSafeAuthReturn('/courses/typescript?coupon=secret#curriculum')).toEqual({
+      pathname: '/courses/typescript',
+      source: 'validated',
+    });
+  });
+
+  it.each(['/courses/node.js', '/bundles/fullstack.v2'])(
+    'preserves a dotted product slug %s',
+    (destination) => {
+      expect(resolveSafeAuthReturn(destination)).toEqual({
+        pathname: destination,
+        source: 'validated',
+      });
+    },
+  );
+
+  it.each([
+    undefined,
+    ['/courses/typescript-foundations'],
+    'https://evil.example/course',
+    '//evil.example/course',
+    '/\\evil.example/course',
+    '/courses/typescript\u0000foundations',
+    '/courses/typescript\u0085foundations',
+    '/courses/typescript%C2%85foundations',
+    '%2F%2Fevil.example/course',
+    '/%2F%2Fevil.example/course',
+    '%252F%252Fevil.example/course',
+    '%2Fapi%2Fpayments',
+    '/api/payments',
+    '/API/payments',
+    '/_next/static/chunk.js',
+    '/__nextjs_source-map',
+    '/favicon.ico',
+    '/manifest.webmanifest',
+    '/login',
+    '/register',
+    '/forgot-password',
+    '/reset-password/token',
+    '/courses/%2e%2e/login',
+    '/courses/../login',
+  ])('falls back for unsafe destination %j', (destination) => {
+    expect(resolveSafeAuthReturn(destination)).toEqual({
+      pathname: '/dashboard',
+      source: 'fallback',
+    });
+  });
+
+  it('revalidates values when carrying the intent to another auth entry page', () => {
+    expect(createAuthReturnHref('/register', '//evil.example/course')).toBe(
+      '/register?callbackUrl=%2Fdashboard',
+    );
+  });
+
+  it('revalidates Auth.js redirects and returns an absolute same-origin URL', () => {
+    const baseUrl = 'https://milerdev.tech';
+
+    expect(resolveSafeAuthRedirect('/courses/typescript?coupon=secret', baseUrl)).toBe(
+      'https://milerdev.tech/courses/typescript',
+    );
+    expect(resolveSafeAuthRedirect('https://milerdev.tech/bundles/full-stack#buy', baseUrl)).toBe(
+      'https://milerdev.tech/bundles/full-stack',
+    );
+    expect(resolveSafeAuthRedirect('https://evil.example/courses/typescript', baseUrl)).toBe(
+      'https://milerdev.tech/dashboard',
+    );
+    expect(resolveSafeAuthRedirect('https://milerdev.tech/api/payments', baseUrl)).toBe(
+      'https://milerdev.tech/dashboard',
+    );
+    expect(resolveSafeAuthRedirect('https://milerdev.tech/courses\\typescript', baseUrl)).toBe(
+      'https://milerdev.tech/dashboard',
+    );
+    expect(resolveSafeAuthRedirect('https://milerdev.tech/courses\ttypescript', baseUrl)).toBe(
+      'https://milerdev.tech/dashboard',
+    );
+  });
+});


### PR DESCRIPTION
Closes #34

## Summary
- add one server-only SafeReturnIntent contract for Login, Register, cross-links, and Auth.js redirects
- preserve exact validated Course/Bundle destinations while rejecting external, encoded, auth-loop, API, asset, and internal routes
- add unit, integration, and required desktop/mobile Playwright round-trip coverage

## Verification
- npm run test -- --run (126 files, 769 tests)
- npm run lint
- npm run build
- npx playwright test --config=playwright.required.config.ts --list (3 journeys discovered)

## Review
- Standards: no remaining actionable findings
- Spec #34: no remaining actionable findings

Required E2E registration journeys intentionally run in CI's isolated MySQL service; no local database mutation was performed.