### PR TITLE
feat(auth): harden account recovery states

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -10,6 +10,12 @@ import {
     consumeAuthRateLimit,
 } from '@/lib/auth-rate-limit';
 import { sendWelcomeEmail } from '@/lib/email';
+import {
+  PASSWORD_LOWERCASE_PATTERN,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_NUMBER_PATTERN,
+  PASSWORD_UPPERCASE_PATTERN,
+} from '@/lib/password-policy';
 
 // Validation schema
 const registerSchema = z.object({
@@ -17,15 +23,15 @@ const registerSchema = z.object({
     email: z.string().email('รูปแบบอีเมลไม่ถูกต้อง'),
     password: z
         .string()
-        .min(8, 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร')
-        .regex(/[A-Z]/, 'รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว')
-        .regex(/[a-z]/, 'รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว')
-        .regex(/[0-9]/, 'รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว'),
+        .min(PASSWORD_MIN_LENGTH, 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร')
+        .regex(PASSWORD_UPPERCASE_PATTERN, 'รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว')
+        .regex(PASSWORD_LOWERCASE_PATTERN, 'รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว')
+        .regex(PASSWORD_NUMBER_PATTERN, 'รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว'),
 });
 
 export async function POST(request: Request) {
   try {
-    const genericRegisterMessage = 'หากอีเมลนี้ยังไม่มีในระบบ บัญชีจะถูกสร้างให้อัตโนมัติ กรุณาลองเข้าสู่ระบบ';
+    const genericRegisterMessage = 'ตรวจสอบคำขอแล้ว';
 
     // Rate limiting - 5 requests per minute per IP
     const clientIP = getClientIP(request);

--- a/src/app/api/auth/reset-password/confirm/route.ts
+++ b/src/app/api/auth/reset-password/confirm/route.ts
@@ -10,16 +10,32 @@ import {
     consumeAuthRateLimit,
 } from '@/lib/auth-rate-limit';
 import { createHash } from 'crypto';
+import {
+    PASSWORD_LOWERCASE_PATTERN,
+    PASSWORD_MIN_LENGTH,
+    PASSWORD_NUMBER_PATTERN,
+    PASSWORD_UPPERCASE_PATTERN,
+} from '@/lib/password-policy';
 
 const confirmResetSchema = z.object({
     token: z.string().min(1, 'Token ไม่ถูกต้อง'),
     newPassword: z
         .string()
-        .min(8, 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร')
-        .regex(/[A-Z]/, 'รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว')
-        .regex(/[a-z]/, 'รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว')
-        .regex(/[0-9]/, 'รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว'),
+        .min(PASSWORD_MIN_LENGTH, 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร')
+        .regex(PASSWORD_UPPERCASE_PATTERN, 'รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว')
+        .regex(PASSWORD_LOWERCASE_PATTERN, 'รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว')
+        .regex(PASSWORD_NUMBER_PATTERN, 'รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว'),
 });
+
+function invalidResetLinkResponse() {
+    return NextResponse.json(
+        {
+            kind: 'invalid_or_expired_link',
+            error: 'ลิงก์รีเซ็ตรหัสผ่านไม่ถูกต้องหรือหมดอายุแล้ว',
+        },
+        { status: 400 }
+    );
+}
 
 export async function POST(request: Request) {
     try {
@@ -68,10 +84,7 @@ export async function POST(request: Request) {
             .limit(1);
 
         if (!user || user.deactivatedAt !== null) {
-            return NextResponse.json(
-                { error: 'ลิงก์รีเซ็ตรหัสผ่านไม่ถูกต้องหรือหมดอายุแล้ว' },
-                { status: 400 }
-            );
+            return invalidResetLinkResponse();
         }
 
         // Hash new password and clear reset token
@@ -94,10 +107,7 @@ export async function POST(request: Request) {
             ));
 
         if (updateResult[0]?.affectedRows !== 1) {
-            return NextResponse.json(
-                { error: 'ลิงก์รีเซ็ตรหัสผ่านไม่ถูกต้องหรือหมดอายุแล้ว' },
-                { status: 400 }
-            );
+            return invalidResetLinkResponse();
         }
 
         return NextResponse.json({

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -10,18 +10,22 @@ import {
     authRateLimitUnavailableResponse,
     consumeAuthRateLimit,
 } from '@/lib/auth-rate-limit';
+import { resolveSafeAuthReturn } from '@/lib/safe-auth-return';
 
 const RESET_TOKEN_TTL_MS = 60 * 60 * 1000;
 const DUPLICATE_RESET_SUPPRESSION_MS = 5 * 60 * 1000;
+const RESET_REQUEST_ACCEPTED = {
+    message: 'ตรวจสอบคำขอแล้ว',
+    retryAfterSeconds: DUPLICATE_RESET_SUPPRESSION_MS / 1000,
+};
 
 const resetSchema = z.object({
     email: z.string().email('รูปแบบอีเมลไม่ถูกต้อง'),
+    callbackUrl: z.unknown().optional(),
 });
 
 export async function POST(request: Request) {
     try {
-        const genericMessage = 'หากอีเมลนี้มีในระบบ คุณจะได้รับลิงก์รีเซ็ตรหัสผ่าน';
-
         // Rate limiting
         const clientIP = getClientIP(request);
         const rateLimit = await consumeAuthRateLimit({
@@ -49,6 +53,7 @@ export async function POST(request: Request) {
         }
 
         const email = validation.data.email.toLowerCase().trim();
+        const { pathname: returnTo } = resolveSafeAuthReturn(validation.data.callbackUrl);
 
         // Check if user exists
         const [user] = await db
@@ -59,9 +64,7 @@ export async function POST(request: Request) {
 
         // Always return success to prevent email enumeration
         if (!user || user.deactivatedAt !== null) {
-            return NextResponse.json({
-                message: genericMessage
-            });
+            return NextResponse.json(RESET_REQUEST_ACCEPTED);
         }
 
         const now = Date.now();
@@ -74,7 +77,7 @@ export async function POST(request: Request) {
         // Avoid invalidating the email that was just sent if the user taps submit twice
         // or requests another reset before the first message arrives.
         if (hasFreshResetToken) {
-            return NextResponse.json({ message: genericMessage });
+            return NextResponse.json(RESET_REQUEST_ACCEPTED);
         }
 
         // Generate cryptographically secure reset token
@@ -92,7 +95,7 @@ export async function POST(request: Request) {
             .where(and(eq(users.id, user.id), isNull(users.deactivatedAt)));
 
         if (issueResult[0]?.affectedRows !== 1) {
-            return NextResponse.json({ message: genericMessage });
+            return NextResponse.json(RESET_REQUEST_ACCEPTED);
         }
 
         // Wait for delivery so serverless runtimes do not end the request first.
@@ -101,6 +104,7 @@ export async function POST(request: Request) {
                 email: user.email,
                 name: user.name,
                 resetToken,
+                returnTo,
             });
 
             if (!emailSent) {
@@ -119,9 +123,7 @@ export async function POST(request: Request) {
             }
         }
 
-        return NextResponse.json({
-            message: genericMessage
-        });
+        return NextResponse.json(RESET_REQUEST_ACCEPTED);
     } catch {
         console.error('Password reset request failed');
         return NextResponse.json(

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,7 +1,16 @@
 import AuthShell from '@/components/auth/AuthShell';
 import ForgotPasswordForm from '@/components/auth/ForgotPasswordForm';
+import { createAuthReturnHref, resolveSafeAuthReturn } from '@/lib/safe-auth-return';
 
-export default function ForgotPasswordPage() {
+export default async function ForgotPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
+}) {
+  const { callbackUrl } = await searchParams;
+  const { pathname: returnTo } = resolveSafeAuthReturn(callbackUrl);
+  const loginHref = createAuthReturnHref('/login', returnTo);
+
   return (
     <AuthShell
       pageId={'forgot-password'}
@@ -16,7 +25,7 @@ export default function ForgotPasswordPage() {
         { label: 'ตั้งรหัสผ่าน', text: 'ใช้ลิงก์เพื่อตั้งรหัสผ่านใหม่' },
       ]}
     >
-      <ForgotPasswordForm />
+      <ForgotPasswordForm returnTo={returnTo} loginHref={loginHref} />
     </AuthShell>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,6 +12,7 @@ export default async function LoginPage({
   const { callbackUrl } = await searchParams;
   const { pathname: returnTo } = resolveSafeAuthReturn(callbackUrl);
   const registerHref = createAuthReturnHref('/register', returnTo);
+  const forgotPasswordHref = createAuthReturnHref('/forgot-password', returnTo);
 
   return (
     <AuthShell
@@ -20,7 +21,11 @@ export default async function LoginPage({
       panelDescription={'ใช้บัญชี MilerDev เพื่อกลับไปเรียนต่อ'}
     >
       <Suspense fallback={<div className="flex flex-col gap-4" aria-busy="true"><span className="sr-only" role="status" aria-live="polite">กำลังเตรียมแบบฟอร์ม</span><Skeleton aria-hidden="true" className="h-5 w-24" /><Skeleton aria-hidden="true" className="h-11 w-full" /><Skeleton aria-hidden="true" className="h-11 w-full" /></div>}>
-        <LoginForm returnTo={returnTo} registerHref={registerHref} />
+        <LoginForm
+          returnTo={returnTo}
+          registerHref={registerHref}
+          forgotPasswordHref={forgotPasswordHref}
+        />
       </Suspense>
     </AuthShell>
   );

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -10,15 +10,20 @@ export default async function RegisterPage({
   const { callbackUrl } = await searchParams;
   const { pathname: returnTo } = resolveSafeAuthReturn(callbackUrl);
   const loginHref = createAuthReturnHref('/login', returnTo);
+  const forgotPasswordHref = createAuthReturnHref('/forgot-password', returnTo);
 
   return (
     <AuthShell
       pageId={'register'}
       variant={'register'}
       panelTitle={'สมัครสมาชิก'}
-      panelDescription={'กรอกข้อมูลสำหรับบัญชีผู้เรียน หรือสมัครด้วย Google'}
+      panelDescription={'กรอกข้อมูลสำหรับบัญชีสมาชิก หรือสมัครด้วย Google'}
     >
-      <RegisterForm returnTo={returnTo} loginHref={loginHref} />
+      <RegisterForm
+        returnTo={returnTo}
+        loginHref={loginHref}
+        forgotPasswordHref={forgotPasswordHref}
+      />
     </AuthShell>
   );
 }

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,9 +1,22 @@
-import { Suspense } from 'react';
 import AuthShell from '@/components/auth/AuthShell';
 import ResetPasswordForm from '@/components/auth/ResetPasswordForm';
-import { Skeleton } from '@/components/ui/skeleton';
+import { createAuthReturnHref, resolveSafeAuthReturn } from '@/lib/safe-auth-return';
 
-export default function ResetPasswordPage() {
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    token?: string | string[];
+    callbackUrl?: string | string[];
+  }>;
+}) {
+  const { token, callbackUrl } = await searchParams;
+  const opaqueToken = typeof token === 'string' && token.length > 0 ? token : null;
+  const { pathname: returnTo } = resolveSafeAuthReturn(callbackUrl);
+  const forgotPasswordHref = createAuthReturnHref('/forgot-password', returnTo);
+  const loginHref = createAuthReturnHref('/login', returnTo);
+  const successLoginHref = `${loginHref}&reason=password-reset`;
+
   return (
     <AuthShell
       pageId={'reset-password'}
@@ -18,9 +31,12 @@ export default function ResetPasswordPage() {
         { label: 'กลับเข้าสู่ระบบ', text: 'กลับไปเข้าสู่ระบบอีกครั้ง' },
       ]}
     >
-      <Suspense fallback={<div className="flex flex-col gap-4" aria-busy="true"><span className="sr-only" role="status" aria-live="polite">กำลังตรวจสอบลิงก์</span><Skeleton aria-hidden="true" className="h-5 w-36" /><Skeleton aria-hidden="true" className="h-11 w-full" /><Skeleton aria-hidden="true" className="h-11 w-full" /></div>}>
-        <ResetPasswordForm />
-      </Suspense>
+      <ResetPasswordForm
+        token={opaqueToken}
+        forgotPasswordHref={forgotPasswordHref}
+        loginHref={loginHref}
+        successLoginHref={successLoginHref}
+      />
     </AuthShell>
   );
 }

--- a/src/components/auth/AuthFormLayout.tsx
+++ b/src/components/auth/AuthFormLayout.tsx
@@ -5,6 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   Field,
   FieldDescription,
+  FieldError,
   FieldLabel,
   FieldSeparator,
 } from '@/components/ui/field';
@@ -15,11 +16,32 @@ import {
   InputGroupInput,
 } from '@/components/ui/input-group';
 
-export function AuthError({ children }: { children: ReactNode }) {
+export function AuthError({
+  children,
+  live = 'assertive',
+}: {
+  children: ReactNode;
+  live?: 'assertive' | 'polite';
+}) {
   return (
-    <Alert variant="destructive" className="mb-5">
+    <Alert
+      variant={'destructive'}
+      className={'mb-5'}
+      role={live === 'polite' ? 'status' : 'alert'}
+      aria-live={live}
+    >
       <AlertCircle aria-hidden="true" />
       <AlertTitle>ไม่สามารถดำเนินการได้</AlertTitle>
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  );
+}
+
+export function AuthNotice({ children }: { children: ReactNode }) {
+  return (
+    <Alert variant={'success'} role={'status'} aria-live={'polite'} className={'mb-5'}>
+      <CheckCircle2 aria-hidden={'true'} />
+      <AlertTitle>ดำเนินการสำเร็จ</AlertTitle>
       <AlertDescription>{children}</AlertDescription>
     </Alert>
   );
@@ -32,6 +54,7 @@ export function AuthField({
   help,
   children,
   invalid = false,
+  error,
 }: {
   htmlFor: string;
   label: string;
@@ -39,6 +62,7 @@ export function AuthField({
   help?: ReactNode;
   children: ReactNode;
   invalid?: boolean;
+  error?: { id: string; message: string };
 }) {
   return (
     <Field data-invalid={invalid || undefined}>
@@ -47,6 +71,7 @@ export function AuthField({
         {trailing}
       </div>
       {children}
+      {error ? <FieldError id={error.id}>{error.message}</FieldError> : null}
       {help ? <FieldDescription>{help}</FieldDescription> : null}
     </Field>
   );
@@ -108,7 +133,11 @@ export function RecoveryState({
 }) {
   const Icon = tone === 'success' ? CheckCircle2 : AlertCircle;
   return (
-    <Alert variant={tone === 'error' ? 'destructive' : 'default'}>
+    <Alert
+      variant={tone === 'error' ? 'destructive' : 'success'}
+      role={tone === 'error' ? 'alert' : 'status'}
+      aria-live={tone === 'error' ? 'assertive' : 'polite'}
+    >
       <Icon aria-hidden="true" />
       <AlertTitle>{title}</AlertTitle>
       <AlertDescription>

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -1,36 +1,79 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { FieldGroup } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
+import { getAuthPublicError } from '@/lib/auth-public-error';
+import type { SafeAuthReturnPath } from '@/lib/safe-auth-return';
 import { AuthError, AuthField, AuthFootnote, RecoveryState } from './AuthFormLayout';
 
-export default function ForgotPasswordForm() {
+export default function ForgotPasswordForm({
+  returnTo,
+  loginHref,
+}: {
+  returnTo: SafeAuthReturnPath;
+  loginHref: string;
+}) {
+  const emailInputRef = useRef<HTMLInputElement>(null);
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
   const [error, setError] = useState('');
+  const [emailError, setEmailError] = useState('');
 
-  const handleSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
+  useEffect(() => {
+    if (!sent || cooldownSeconds <= 0) return;
+
+    const timer = window.setTimeout(() => {
+      setCooldownSeconds((seconds) => Math.max(0, seconds - 1));
+    }, 1000);
+
+    return () => window.clearTimeout(timer);
+  }, [cooldownSeconds, sent]);
+
+  const requestReset = async () => {
     setError('');
+
+    const normalizedEmail = email.trim();
+    const validationError = !normalizedEmail
+      ? 'กรุณากรอกอีเมล'
+      : !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)
+        ? 'กรุณากรอกอีเมลให้ถูกต้อง'
+        : '';
+
+    if (validationError) {
+      setEmailError(validationError);
+      emailInputRef.current?.focus();
+      return;
+    }
+
+    setEmail(normalizedEmail);
+    setEmailError('');
     setLoading(true);
 
     try {
       const response = await fetch('/api/auth/reset-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email: normalizedEmail, callbackUrl: returnTo }),
       });
 
+      const data = await response.json();
+
       if (response.ok) {
+        const retryAfterSeconds = Number(data.retryAfterSeconds);
+        setCooldownSeconds(
+          Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+            ? Math.ceil(retryAfterSeconds)
+            : 0,
+        );
         setSent(true);
       } else {
-        const data = await response.json();
-        setError(data.error || 'เกิดข้อผิดพลาด กรุณาลองใหม่');
+        setError(getAuthPublicError(response.status, data));
       }
     } catch {
       setError('เกิดข้อผิดพลาด กรุณาลองใหม่');
@@ -39,30 +82,75 @@ export default function ForgotPasswordForm() {
     }
   };
 
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    await requestReset();
+  };
+
+  const resetForm = () => {
+    setSent(false);
+    setEmail('');
+    setCooldownSeconds(0);
+    setError('');
+    setEmailError('');
+  };
+
+  const cooldownLabel = `${Math.floor(cooldownSeconds / 60)}:${String(cooldownSeconds % 60).padStart(2, '0')}`;
+
   if (sent) {
     return (
-      <RecoveryState tone="success" title="ส่งลิงก์รีเซ็ตแล้ว!" actions={<><Button type={'button'} variant="outline" onClick={() => { setSent(false); setEmail(''); }}>ลองใหม่อีกครั้ง</Button><Button asChild><Link href={'/login'}>กลับไปหน้าเข้าสู่ระบบ</Link></Button></>}>
-        <p>หากอีเมล <strong>{email}</strong> มีในระบบ คุณจะได้รับลิงก์สำหรับตั้งรหัสผ่านใหม่ภายในไม่กี่นาที</p>
-        <p>ไม่ได้รับอีเมล? ตรวจสอบโฟลเดอร์สแปม แล้วลองส่งใหม่ได้</p>
+      <RecoveryState
+        tone={'success'}
+        title={'ตรวจสอบคำขอแล้ว'}
+        actions={<>
+          <Button asChild><Link href={loginHref}>เข้าสู่ระบบ</Link></Button>
+          <Button type={'button'} variant={'outline'} onClick={resetForm}>ใช้อีเมลอื่น</Button>
+          <Button
+            type={'button'}
+            variant={'outline'}
+            disabled={loading || cooldownSeconds > 0}
+            onClick={requestReset}
+          >
+            {loading
+              ? 'กำลังส่ง...'
+              : cooldownSeconds > 0
+                ? `ส่งอีกครั้งใน ${cooldownLabel}`
+                : 'ส่งอีกครั้ง'}
+          </Button>
+        </>}
+      >
+        <p>หากอีเมลเชื่อมกับบัญชีที่พร้อมใช้งาน ระบบจะส่งลิงก์สำหรับตั้งรหัสผ่านใหม่</p>
+        <p>ตรวจสอบกล่องขาเข้าและโฟลเดอร์สแปม ลิงก์มีอายุ 1 ชั่วโมง</p>
       </RecoveryState>
     );
   }
 
   return (
     <>
-      {error && <AuthError>{error}</AuthError>}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading}>
+      {error && <AuthError live={'polite'}>{error}</AuthError>}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading} noValidate>
         <FieldGroup className="gap-5">
-          <AuthField htmlFor="forgot-email" label="อีเมล">
+          <AuthField
+            htmlFor={'forgot-email'}
+            label={'อีเมล'}
+            invalid={Boolean(emailError)}
+            help={emailError ? <span id={'forgot-email-error'}>{emailError}</span> : null}
+          >
             <Input
+            ref={emailInputRef}
             id={'forgot-email'}
             name={'email'}
             type={'email'}
             value={email}
-            onChange={(event) => setEmail(event.target.value)}
+            onChange={(event) => {
+              setEmail(event.target.value);
+              if (emailError) setEmailError('');
+            }}
             required
             autoComplete={'email'}
             placeholder={'your@email.com'}
+            aria-invalid={Boolean(emailError) || undefined}
+            aria-describedby={emailError ? 'forgot-email-error' : undefined}
             />
           </AuthField>
         </FieldGroup>
@@ -71,7 +159,7 @@ export default function ForgotPasswordForm() {
           {loading ? 'กำลังส่ง...' : 'ส่งลิงก์รีเซ็ตรหัสผ่าน'}
         </Button>
       </form>
-      <AuthFootnote><Link href={'/login'}>กลับไปหน้าเข้าสู่ระบบ</Link></AuthFootnote>
+      <AuthFootnote><Link href={loginHref}>กลับไปหน้าเข้าสู่ระบบ</Link></AuthFootnote>
     </>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -10,7 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import type { SafeAuthReturnPath } from '@/lib/safe-auth-return';
 import { GoogleIcon } from './AuthIcons';
-import { AuthDivider, AuthError, AuthField, AuthFootnote, PasswordInput } from './AuthFormLayout';
+import { AuthDivider, AuthError, AuthField, AuthFootnote, AuthNotice, PasswordInput } from './AuthFormLayout';
 
 export const AUTH_ERROR_MESSAGES: Record<string, string> = {
   OAuthAccountNotLinked: 'อีเมลนี้มีบัญชีอยู่แล้ว กรุณาเข้าสู่ระบบด้วยรหัสผ่านก่อน แล้วจึงเชื่อมบัญชี Google ภายหลัง',
@@ -23,9 +23,11 @@ export const AUTH_ERROR_MESSAGES: Record<string, string> = {
 export default function LoginForm({
   returnTo,
   registerHref,
+  forgotPasswordHref,
 }: {
   returnTo: SafeAuthReturnPath;
   registerHref: string;
+  forgotPasswordHref: string;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -34,6 +36,12 @@ export default function LoginForm({
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const arrivalReason = searchParams.get('reason');
+  const arrivalMessage = arrivalReason === 'password-reset'
+    ? 'ตั้งรหัสผ่านใหม่แล้ว กรุณาเข้าสู่ระบบอีกครั้ง'
+    : arrivalReason === 'password-changed'
+      ? 'เปลี่ยนรหัสผ่านแล้ว กรุณาเข้าสู่ระบบอีกครั้ง'
+      : '';
 
   useEffect(() => {
     const errorCode = searchParams.get('error');
@@ -69,6 +77,7 @@ export default function LoginForm({
 
   return (
     <>
+      {arrivalMessage && <AuthNotice>{arrivalMessage}</AuthNotice>}
       {error && <AuthError>{error}</AuthError>}
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading}>
@@ -86,7 +95,7 @@ export default function LoginForm({
             />
           </AuthField>
 
-          <AuthField htmlFor="login-password" label="รหัสผ่าน" trailing={<Link className="text-xs font-semibold text-primary hover:underline" href="/forgot-password">ลืมรหัสผ่าน?</Link>}>
+          <AuthField htmlFor="login-password" label="รหัสผ่าน" trailing={<Link className="text-xs font-semibold text-primary hover:underline" href={forgotPasswordHref}>ลืมรหัสผ่าน?</Link>}>
             <PasswordInput
               id={'login-password'}
               name={'password'}

--- a/src/components/auth/PasswordPolicyFeedback.tsx
+++ b/src/components/auth/PasswordPolicyFeedback.tsx
@@ -1,0 +1,58 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { getPasswordPolicy } from '@/lib/password-policy';
+import { Check, X } from 'lucide-react';
+
+function Requirement({
+  passed,
+  children,
+}: {
+  passed: boolean;
+  children: string;
+}) {
+  return (
+    <li>
+      <Badge variant={passed ? 'secondary' : 'outline'}>
+        {passed ? <Check aria-hidden={'true'} /> : <X aria-hidden={'true'} />}
+        <span>{children}</span>
+        <span>— {passed ? 'ผ่าน' : 'ยังไม่ผ่าน'}</span>
+      </Badge>
+    </li>
+  );
+}
+
+export default function PasswordPolicyFeedback({
+  password,
+  id,
+}: {
+  password: string;
+  id: string;
+}) {
+  const policy = getPasswordPolicy(password);
+
+  return (
+    <Card id={id} aria-live={'polite'}>
+      <CardHeader>
+        <CardTitle>ความแข็งแกร่งของรหัสผ่าน</CardTitle>
+        <CardDescription>{password ? policy.label : 'ยังไม่ได้ระบุ'}</CardDescription>
+      </CardHeader>
+      <CardContent className={'flex flex-col gap-4'}>
+        <Progress value={policy.percentage} aria-label={`ความแข็งแกร่ง ${policy.percentage}%`} />
+        <ul className={'grid gap-2 sm:grid-cols-2'}>
+          <Requirement passed={policy.checks.length}>อย่างน้อย 8 ตัวอักษร</Requirement>
+          <Requirement passed={policy.checks.uppercase}>มีตัวพิมพ์ใหญ่</Requirement>
+          <Requirement passed={policy.checks.lowercase}>มีตัวพิมพ์เล็ก</Requirement>
+          <Requirement passed={policy.checks.number}>มีตัวเลข</Requirement>
+          <Requirement passed={policy.checks.special}>อักขระพิเศษ (แนะนำ)</Requirement>
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -1,76 +1,74 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
 import { FieldGroup } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { Progress } from '@/components/ui/progress';
 import { Spinner } from '@/components/ui/spinner';
+import { getAuthPublicError } from '@/lib/auth-public-error';
 import type { SafeAuthReturnPath } from '@/lib/safe-auth-return';
+import { getPasswordPolicy, getPasswordPolicyError } from '@/lib/password-policy';
 import { GoogleIcon } from './AuthIcons';
-import { AuthDivider, AuthError, AuthField, AuthFootnote, PasswordInput } from './AuthFormLayout';
+import { AuthDivider, AuthError, AuthField, AuthFootnote, PasswordInput, RecoveryState } from './AuthFormLayout';
+import PasswordPolicyFeedback from './PasswordPolicyFeedback';
 
-export const getPasswordStrength = (password: string) => {
-  let score = 0;
-  const checks = {
-    length: password.length >= 8,
-    uppercase: /[A-Z]/.test(password),
-    lowercase: /[a-z]/.test(password),
-    number: /[0-9]/.test(password),
-    special: /[!@#$%^&*(),.?":{}|<>]/.test(password),
-  };
-  Object.values(checks).forEach((passes) => {
-    if (passes) score++;
-  });
-
-  let label = 'อ่อนมาก';
-  if (score >= 5) label = 'แข็งแกร่งมาก';
-  else if (score >= 4) label = 'แข็งแกร่ง';
-  else if (score >= 3) label = 'ปานกลาง';
-  else if (score >= 2) label = 'อ่อน';
-
-  return { score, checks, label, percentage: (score / 5) * 100 };
-};
+export const getPasswordStrength = getPasswordPolicy;
 
 export default function RegisterForm({
   returnTo,
   loginHref,
+  forgotPasswordHref,
 }: {
   returnTo: SafeAuthReturnPath;
   loginHref: string;
+  forgotPasswordHref: string;
 }) {
   const router = useRouter();
+  const nameRef = useRef<HTMLInputElement>(null);
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const confirmPasswordRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [error, setError] = useState('');
+  const [serverError, setServerError] = useState('');
+  const [fieldError, setFieldError] = useState('');
   const [loading, setLoading] = useState(false);
-  const passwordStrength = useMemo(() => getPasswordStrength(password), [password]);
+  const [registrationReviewed, setRegistrationReviewed] = useState(false);
+  const [invalidField, setInvalidField] = useState<'name' | 'email' | 'password' | 'confirmPassword' | null>(null);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    setError('');
+    setServerError('');
+    setFieldError('');
 
-    if (name.trim().length < 2) return setError('ชื่อต้องมีอย่างน้อย 2 ตัวอักษร');
-    if (password.length < 8) return setError('รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร');
-    if (!passwordStrength.checks.uppercase) return setError('รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว');
-    if (!passwordStrength.checks.lowercase) return setError('รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว');
-    if (!passwordStrength.checks.number) return setError('รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว');
-    if (password !== confirmPassword) return setError('รหัสผ่านไม่ตรงกัน');
+    const normalizedEmail = email.trim();
+    const passwordPolicyError = getPasswordPolicyError(password);
+    const validation = name.trim().length < 2
+      ? { field: 'name' as const, message: 'กรุณากรอกชื่ออย่างน้อย 2 ตัวอักษร', ref: nameRef }
+      : !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)
+        ? { field: 'email' as const, message: 'กรุณากรอกอีเมลให้ถูกต้อง', ref: emailRef }
+        : passwordPolicyError
+          ? { field: 'password' as const, message: passwordPolicyError, ref: passwordRef }
+          : password !== confirmPassword
+            ? { field: 'confirmPassword' as const, message: 'รหัสผ่านไม่ตรงกัน', ref: confirmPasswordRef }
+            : null;
+
+    if (validation) {
+      setInvalidField(validation.field);
+      setFieldError(validation.message);
+      validation.ref.current?.focus();
+      return;
+    }
+
+    setInvalidField(null);
+    setFieldError('');
 
     setLoading(true);
     try {
@@ -81,79 +79,83 @@ export default function RegisterForm({
       });
       const data = await response.json();
       if (!response.ok) {
-        setError(data.error || 'เกิดข้อผิดพลาด กรุณาลองใหม่');
+        setServerError(getAuthPublicError(response.status, data));
         return;
       }
 
       const result = await signIn('credentials', { email, password, redirect: false });
       if (result?.error) {
-        router.push(loginHref);
+        setRegistrationReviewed(true);
       } else {
         router.push(returnTo);
         router.refresh();
       }
     } catch {
-      setError('เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง');
+      setServerError('เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง');
     } finally {
       setLoading(false);
     }
   };
 
+  if (registrationReviewed) {
+    return (
+      <RecoveryState
+        tone={'success'}
+        title={'ตรวจสอบคำขอแล้ว'}
+        actions={<>
+          <Button asChild><Link href={loginHref}>เข้าสู่ระบบ</Link></Button>
+          <Button asChild variant={'outline'}>
+            <Link href={forgotPasswordHref}>ตั้งรหัสผ่านใหม่</Link>
+          </Button>
+        </>}
+      >
+        <p>หากบัญชีพร้อมใช้งาน คุณสามารถเข้าสู่ระบบได้</p>
+        <p>หากจำรหัสผ่านไม่ได้ ให้ขอลิงก์ตั้งรหัสผ่านใหม่</p>
+      </RecoveryState>
+    );
+  }
+
   return (
     <>
-      {error && <AuthError>{error}</AuthError>}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading}>
+      {serverError && <AuthError live={'polite'}>{serverError}</AuthError>}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading} noValidate>
         <FieldGroup className="gap-5">
           <div className="grid gap-5 sm:grid-cols-2">
-            <AuthField htmlFor="register-name" label="ชื่อ-นามสกุล">
-              <Input id="register-name" name="name" type="text" value={name} onChange={(event) => setName(event.target.value)} required maxLength={100} autoComplete="name" placeholder="ชื่อที่ใช้ในบัญชี" />
+            <AuthField htmlFor="register-name" label="ชื่อ-นามสกุล" invalid={invalidField === 'name'} error={invalidField === 'name' ? { id: 'register-name-error', message: fieldError } : undefined}>
+              <Input ref={nameRef} id="register-name" name="name" type="text" value={name} onChange={(event) => { setName(event.target.value); if (invalidField === 'name') { setInvalidField(null); setFieldError(''); } }} required maxLength={100} autoComplete="name" placeholder="ชื่อที่ใช้ในบัญชี" aria-invalid={invalidField === 'name' || undefined} aria-describedby={invalidField === 'name' ? 'register-name-error' : undefined} />
             </AuthField>
-            <AuthField htmlFor="register-email" label="อีเมล">
-              <Input id="register-email" name="email" type="email" value={email} onChange={(event) => setEmail(event.target.value)} required autoComplete="email" placeholder="name@example.com" />
+            <AuthField htmlFor="register-email" label="อีเมล" invalid={invalidField === 'email'} error={invalidField === 'email' ? { id: 'register-email-error', message: fieldError } : undefined}>
+              <Input ref={emailRef} id="register-email" name="email" type="email" value={email} onChange={(event) => { setEmail(event.target.value); if (invalidField === 'email') { setInvalidField(null); setFieldError(''); } }} required autoComplete="email" inputMode="email" spellCheck={false} placeholder="name@example.com" aria-invalid={invalidField === 'email' || undefined} aria-describedby={invalidField === 'email' ? 'register-email-error' : undefined} />
             </AuthField>
           </div>
 
           <div className="grid gap-5 sm:grid-cols-2">
-            <AuthField htmlFor="register-password" label="รหัสผ่าน">
-              <PasswordInput id="register-password" name="password" visible={showPassword} onVisibilityChange={() => setShowPassword((visible) => !visible)} value={password} onChange={(event) => setPassword(event.target.value)} required autoComplete="new-password" placeholder="อย่างน้อย 8 ตัวอักษร" aria-describedby="register-password-strength" />
+            <AuthField htmlFor="register-password" label="รหัสผ่าน" invalid={invalidField === 'password'} error={invalidField === 'password' ? { id: 'register-password-error', message: fieldError } : undefined}>
+              <PasswordInput ref={passwordRef} id="register-password" name="password" visible={showPassword} onVisibilityChange={() => setShowPassword((visible) => !visible)} value={password} onChange={(event) => { setPassword(event.target.value); if (invalidField === 'password') { setInvalidField(null); setFieldError(''); } }} required autoComplete="new-password" placeholder="อย่างน้อย 8 ตัวอักษร" aria-invalid={invalidField === 'password' || undefined} aria-describedby={invalidField === 'password' ? 'register-password-strength register-password-error' : 'register-password-strength'} />
             </AuthField>
             <AuthField
               htmlFor="register-confirm-password"
               label="ยืนยันรหัสผ่าน"
-              invalid={Boolean(confirmPassword && confirmPassword !== password)}
+              invalid={invalidField === 'confirmPassword' || Boolean(confirmPassword && confirmPassword !== password)}
+              error={invalidField === 'confirmPassword' ? { id: 'register-confirm-error', message: fieldError } : undefined}
               help={<span id="register-confirm-status" aria-live="polite">{confirmPassword ? (confirmPassword === password ? 'รหัสผ่านตรงกัน' : 'รหัสผ่านไม่ตรงกัน') : 'พิมพ์รหัสผ่านเดิมอีกครั้ง'}</span>}
             >
-              <PasswordInput id="register-confirm-password" name="confirmPassword" visible={showConfirmPassword} onVisibilityChange={() => setShowConfirmPassword((visible) => !visible)} value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} required autoComplete="new-password" placeholder="พิมพ์รหัสผ่านอีกครั้ง" aria-invalid={Boolean(confirmPassword && confirmPassword !== password) || undefined} aria-describedby="register-confirm-status" showLabel="แสดงรหัสผ่านยืนยัน" hideLabel="ซ่อนรหัสผ่านยืนยัน" />
+              <PasswordInput ref={confirmPasswordRef} id="register-confirm-password" name="confirmPassword" visible={showConfirmPassword} onVisibilityChange={() => setShowConfirmPassword((visible) => !visible)} value={confirmPassword} onChange={(event) => { setConfirmPassword(event.target.value); if (invalidField === 'confirmPassword') { setInvalidField(null); setFieldError(''); } }} required autoComplete="new-password" placeholder="พิมพ์รหัสผ่านอีกครั้ง" aria-invalid={invalidField === 'confirmPassword' || Boolean(confirmPassword && confirmPassword !== password) || undefined} aria-describedby={invalidField === 'confirmPassword' ? 'register-confirm-status register-confirm-error' : 'register-confirm-status'} showLabel="แสดงรหัสผ่านยืนยัน" hideLabel="ซ่อนรหัสผ่านยืนยัน" />
             </AuthField>
           </div>
         </FieldGroup>
 
-        <Card id="register-password-strength" aria-live="polite">
-          <CardHeader>
-            <CardTitle>ความแข็งแกร่งของรหัสผ่าน</CardTitle>
-            <CardDescription>{password ? passwordStrength.label : 'ยังไม่ได้ระบุ'}</CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
-            <Progress value={passwordStrength.percentage} aria-label={`ความแข็งแกร่ง ${passwordStrength.percentage}%`} />
-            <ul className="grid gap-2 sm:grid-cols-2">
-              <li><Badge variant={passwordStrength.checks.length ? 'secondary' : 'outline'}>อย่างน้อย 8 ตัวอักษร</Badge></li>
-              <li><Badge variant={passwordStrength.checks.uppercase ? 'secondary' : 'outline'}>มีตัวพิมพ์ใหญ่</Badge></li>
-              <li><Badge variant={passwordStrength.checks.lowercase ? 'secondary' : 'outline'}>มีตัวพิมพ์เล็ก</Badge></li>
-              <li><Badge variant={passwordStrength.checks.number ? 'secondary' : 'outline'}>มีตัวเลข</Badge></li>
-              <li><Badge variant={passwordStrength.checks.special ? 'secondary' : 'outline'}>อักขระพิเศษ (แนะนำ)</Badge></li>
-            </ul>
-          </CardContent>
-        </Card>
+        <PasswordPolicyFeedback password={password} id={'register-password-strength'} />
         <Button type="submit" className="w-full" disabled={loading} aria-busy={loading}>
           {loading && <Spinner data-icon="inline-start" aria-hidden="true" />}
-          {loading ? 'กำลังสร้างบัญชี...' : 'สร้างบัญชีผู้เรียน'}
+          {loading ? 'กำลังสร้างบัญชี...' : 'สร้างบัญชีสมาชิก'}
         </Button>
       </form>
 
       <AuthDivider>หรือใช้บัญชี Google</AuthDivider>
       <Button type="button" variant="outline" className="w-full" onClick={() => signIn('google', { callbackUrl: returnTo })}><GoogleIcon />สมัครสมาชิกด้วย Google</Button>
       <AuthFootnote>มีบัญชีอยู่แล้ว? <Link href={loginHref}>เข้าสู่ระบบ</Link></AuthFootnote>
-      <p className="mt-2 text-center text-xs leading-5 text-muted-foreground">การสมัครสมาชิกหมายถึงคุณยอมรับข้อกำหนดการใช้งานและนโยบายความเป็นส่วนตัวของ MilerDev</p>
+      <p className="mt-2 text-center text-xs leading-5 text-muted-foreground">การสมัครสมาชิกหมายถึงคุณยอมรับ <Link className={'underline underline-offset-4'} href={'/terms'}>ข้อกำหนดการใช้งาน</Link> และ <Link className={'underline underline-offset-4'} href={'/privacy'}>นโยบายความเป็นส่วนตัว</Link> ของ MilerDev</p>
     </>
   );
 }

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -1,31 +1,60 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { FieldGroup } from '@/components/ui/field';
 import { Spinner } from '@/components/ui/spinner';
+import { getAuthPublicError } from '@/lib/auth-public-error';
+import { getPasswordPolicyError } from '@/lib/password-policy';
 import { AuthError, AuthField, AuthFootnote, PasswordInput, RecoveryState } from './AuthFormLayout';
+import PasswordPolicyFeedback from './PasswordPolicyFeedback';
 
-export default function ResetPasswordForm() {
-  const searchParams = useSearchParams();
-  const token = searchParams.get('token');
+export default function ResetPasswordForm({
+  token,
+  forgotPasswordHref,
+  loginHref,
+  successLoginHref,
+}: {
+  token: string | null;
+  forgotPasswordHref: string;
+  loginHref: string;
+  successLoginHref: string;
+}) {
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const confirmPasswordRef = useRef<HTMLInputElement>(null);
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [invalidLink, setInvalidLink] = useState(false);
   const [error, setError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [confirmPasswordError, setConfirmPasswordError] = useState('');
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setError('');
 
-    if (password !== confirmPassword) {
-      setError('รหัสผ่านไม่ตรงกัน');
+    const nextPasswordError = getPasswordPolicyError(password);
+    if (nextPasswordError) {
+      setPasswordError(nextPasswordError);
+      setConfirmPasswordError('');
+      passwordRef.current?.focus();
       return;
     }
+
+    if (password !== confirmPassword) {
+      setPasswordError('');
+      setConfirmPasswordError('รหัสผ่านไม่ตรงกัน');
+      confirmPasswordRef.current?.focus();
+      return;
+    }
+
+    setPasswordError('');
+    setConfirmPasswordError('');
 
     setLoading(true);
     try {
@@ -38,8 +67,10 @@ export default function ResetPasswordForm() {
 
       if (response.ok) {
         setSuccess(true);
+      } else if (data.kind === 'invalid_or_expired_link') {
+        setInvalidLink(true);
       } else {
-        setError(data.error || 'เกิดข้อผิดพลาด กรุณาลองใหม่');
+        setError(getAuthPublicError(response.status, data));
       }
     } catch {
       setError('เกิดข้อผิดพลาด กรุณาลองใหม่');
@@ -50,66 +81,85 @@ export default function ResetPasswordForm() {
 
   if (!token) {
     return (
-      <RecoveryState tone="error" title="ลิงก์ไม่ถูกต้อง" actions={<><Button asChild><Link href={'/forgot-password'}>ขอลิงก์รีเซ็ตใหม่</Link></Button><Button variant="outline" asChild><Link href={'/login'}>กลับไปหน้าเข้าสู่ระบบ</Link></Button></>}><p>ลิงก์รีเซ็ตรหัสผ่านไม่ถูกต้อง กรุณาขอลิงก์ใหม่</p></RecoveryState>
+      <RecoveryState tone={'error'} title={'ลิงก์ไม่สมบูรณ์'} actions={<><Button asChild><Link href={forgotPasswordHref}>ขอลิงก์ใหม่</Link></Button><Button variant={'outline'} asChild><Link href={loginHref}>กลับไปหน้าเข้าสู่ระบบ</Link></Button></>}><p>กรุณาขอลิงก์ตั้งรหัสผ่านใหม่</p></RecoveryState>
+    );
+  }
+
+  if (invalidLink) {
+    return (
+      <RecoveryState tone={'error'} title={'ลิงก์นี้ใช้ไม่ได้แล้ว'} actions={<><Button asChild><Link href={forgotPasswordHref}>ขอลิงก์ใหม่</Link></Button><Button variant={'outline'} asChild><Link href={loginHref}>กลับไปหน้าเข้าสู่ระบบ</Link></Button></>}><p>ลิงก์อาจหมดอายุหรือถูกใช้ไปแล้ว กรุณาขอลิงก์ใหม่</p></RecoveryState>
     );
   }
 
   if (success) {
     return (
-      <RecoveryState tone="success" title="ตั้งรหัสผ่านใหม่สำเร็จ!" actions={<Button asChild><Link href={'/login'}>ไปหน้าเข้าสู่ระบบ</Link></Button>}><p>คุณสามารถเข้าสู่ระบบด้วยรหัสผ่านใหม่ได้แล้ว</p></RecoveryState>
+      <RecoveryState tone={'success'} title={'ตั้งรหัสผ่านใหม่แล้ว'} actions={<Button asChild><Link href={successLoginHref}>ไปหน้าเข้าสู่ระบบ</Link></Button>}><p>เพื่อความปลอดภัย กรุณาเข้าสู่ระบบอีกครั้ง</p></RecoveryState>
     );
   }
 
   return (
     <>
-      {error && <AuthError>{error}</AuthError>}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading}>
+      {error && <AuthError live={'polite'}>{error}</AuthError>}
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5" aria-busy={loading} noValidate>
         <FieldGroup className="gap-5">
-          <AuthField htmlFor="reset-password" label="รหัสผ่านใหม่" help={<span id="reset-password-help">อย่างน้อย 8 ตัวอักษร มีตัวพิมพ์ใหญ่ ตัวพิมพ์เล็ก และตัวเลข</span>}>
+          <AuthField htmlFor="reset-password" label="รหัสผ่านใหม่" invalid={Boolean(passwordError)} help={passwordError ? <span id={'reset-password-error'}>{passwordError}</span> : null}>
             <PasswordInput
+              ref={passwordRef}
               id={'reset-password'}
               name={'password'}
               visible={showPassword}
               onVisibilityChange={() => setShowPassword((visible) => !visible)}
               value={password}
-              onChange={(event) => setPassword(event.target.value)}
+              onChange={(event) => {
+                setPassword(event.target.value);
+                if (passwordError) setPasswordError('');
+              }}
               required
               minLength={8}
               autoComplete={'new-password'}
               placeholder={'••••••••'}
-              aria-describedby={'reset-password-help'}
+              aria-invalid={Boolean(passwordError) || undefined}
+              aria-describedby={passwordError ? 'reset-password-policy reset-password-error' : 'reset-password-policy'}
             />
           </AuthField>
 
           <AuthField
             htmlFor="reset-confirm-password"
             label="ยืนยันรหัสผ่านใหม่"
-            invalid={Boolean(confirmPassword && password !== confirmPassword)}
+            invalid={Boolean(confirmPasswordError)}
+            help={confirmPasswordError ? <span id={'reset-confirm-password-error'}>{confirmPasswordError}</span> : null}
           >
             <PasswordInput
+            ref={confirmPasswordRef}
             id={'reset-confirm-password'}
             name={'confirmPassword'}
-            visible={showPassword}
-            onVisibilityChange={() => setShowPassword((visible) => !visible)}
+            visible={showConfirmPassword}
+            onVisibilityChange={() => setShowConfirmPassword((visible) => !visible)}
             value={confirmPassword}
-            onChange={(event) => setConfirmPassword(event.target.value)}
+            onChange={(event) => {
+              setConfirmPassword(event.target.value);
+              if (confirmPasswordError) setConfirmPasswordError('');
+            }}
             required
             minLength={8}
             autoComplete={'new-password'}
             placeholder={'••••••••'}
-            aria-invalid={Boolean(confirmPassword && password !== confirmPassword) || undefined}
+            aria-invalid={Boolean(confirmPasswordError) || undefined}
+            aria-describedby={confirmPasswordError ? 'reset-confirm-password-error' : undefined}
             showLabel="แสดงรหัสผ่านยืนยัน"
             hideLabel="ซ่อนรหัสผ่านยืนยัน"
             />
           </AuthField>
         </FieldGroup>
 
+        <PasswordPolicyFeedback password={password} id={'reset-password-policy'} />
+
         <Button type="submit" className="w-full" disabled={loading} aria-busy={loading}>
           {loading && <Spinner data-icon="inline-start" aria-hidden="true" />}
           {loading ? 'กำลังบันทึก...' : 'ตั้งรหัสผ่านใหม่'}
         </Button>
       </form>
-      <AuthFootnote><Link href={'/login'}>กลับไปหน้าเข้าสู่ระบบ</Link></AuthFootnote>
+      <AuthFootnote><Link href={loginHref}>กลับไปหน้าเข้าสู่ระบบ</Link></AuthFootnote>
     </>
   );
 }

--- a/src/components/settings/PasswordSettingsForm.tsx
+++ b/src/components/settings/PasswordSettingsForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { CircleAlert, CircleCheck, Info } from 'lucide-react';
+import { signOut } from 'next-auth/react';
 
 import {
   Accordion,
@@ -53,17 +54,10 @@ export default function PasswordSettingsForm({ hasPassword }: { hasPassword: boo
   const [success, setSuccess] = useState(false);
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
-  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const strength = getPasswordStrength(newPassword);
   const passwordsMatch = newPassword === confirmPassword;
   const isDisabled = loading || !currentPassword || !newPassword || !confirmPassword || !passwordsMatch;
-
-  useEffect(() => {
-    return () => {
-      if (successTimerRef.current) clearTimeout(successTimerRef.current);
-    };
-  }, []);
 
   function resetForm() {
     setCurrentPassword('');
@@ -96,11 +90,7 @@ export default function PasswordSettingsForm({ hasPassword }: { hasPassword: boo
       if (response.ok) {
         resetForm();
         setSuccess(true);
-        successTimerRef.current = setTimeout(() => {
-          setOpenItem('');
-          setSuccess(false);
-          successTimerRef.current = null;
-        }, 3000);
+        await signOut({ callbackUrl: '/login?reason=password-changed' });
       } else {
         setError(data.error || 'เกิดข้อผิดพลาด กรุณาลองใหม่');
       }
@@ -189,14 +179,14 @@ export default function PasswordSettingsForm({ hasPassword }: { hasPassword: boo
                     hideLabel="ซ่อนรหัสผ่านใหม่"
                   />
                   {newPassword && (
-                    <FieldDescription id="password-strength">
-                      ความแข็งแรง: {strength.label}
+                    <div id="password-strength">
+                      <FieldDescription>ความแข็งแรง: {strength.label}</FieldDescription>
                       <Progress
                         className="mt-2"
                         value={(strength.score / 6) * 100}
                         aria-label={`ความแข็งแรงของรหัสผ่าน ${strength.label}`}
                       />
-                    </FieldDescription>
+                    </div>
                   )}
                 </Field>
 

--- a/src/lib/auth-public-error.ts
+++ b/src/lib/auth-public-error.ts
@@ -1,0 +1,19 @@
+type AuthFailurePayload = {
+  retryAfter?: unknown;
+};
+
+export function getAuthPublicError(status: number, payload: AuthFailurePayload): string {
+  if (status === 429) {
+    const parsedRetryAfter = Number(payload.retryAfter);
+    const retryAfter = Number.isFinite(parsedRetryAfter)
+      ? Math.min(3600, Math.max(1, Math.ceil(parsedRetryAfter)))
+      : 60;
+    return `ส่งคำขอถี่เกินไป กรุณารอ ${retryAfter} วินาทีแล้วลองใหม่`;
+  }
+
+  if (status === 503) {
+    return 'ระบบป้องกันการใช้งานผิดปกติไม่พร้อม กรุณาลองใหม่ภายหลัง';
+  }
+
+  return 'เกิดข้อผิดพลาด กรุณาลองใหม่';
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,6 +1,7 @@
 import nodemailer from 'nodemailer';
 import { Resend } from 'resend';
 import { logError, logEvent } from '@/lib/error-handler';
+import type { SafeAuthReturnPath } from '@/lib/safe-auth-return';
 
 // =====================
 // EMAIL PROVIDER (Resend for production, nodemailer for local)
@@ -210,6 +211,7 @@ interface SendPasswordResetEmailParams {
     email: string;
     name: string | null;
     resetToken: string;
+    returnTo: SafeAuthReturnPath;
 }
 
 interface SendCertificateEmailParams {
@@ -280,8 +282,11 @@ export async function sendPasswordResetEmail({
     email,
     name,
     resetToken,
+    returnTo,
 }: SendPasswordResetEmailParams) {
-    const resetUrl = `${APP_URL}/reset-password?token=${resetToken}`;
+    const resetUrl = new URL('/reset-password', APP_URL);
+    resetUrl.searchParams.set('token', resetToken);
+    resetUrl.searchParams.set('callbackUrl', returnTo);
     const html = emailLayout(`
       <h2 style="color:#1e293b;font-size:1.375rem;margin:0 0 8px;">รีเซ็ตรหัสผ่าน</h2>
       <p style="color:#475569;line-height:1.7;margin:0 0 16px;">
@@ -291,7 +296,7 @@ export async function sendPasswordResetEmail({
         คลิกปุ่มด้านล่างเพื่อตั้งรหัสผ่านใหม่ ลิงก์นี้จะหมดอายุใน <strong>1 ชั่วโมง</strong>
       </p>
       <div style="text-align:center;margin:24px 0;">
-        ${button('ตั้งรหัสผ่านใหม่', resetUrl, '#dc2626')}
+        ${button('ตั้งรหัสผ่านใหม่', resetUrl.toString(), '#dc2626')}
       </div>
       <div style="background:#fef2f2;border-radius:8px;padding:12px 16px;margin-top:20px;">
         <p style="color:#991b1b;font-size:0.8125rem;margin:0;">

--- a/src/lib/password-policy.ts
+++ b/src/lib/password-policy.ts
@@ -1,0 +1,33 @@
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_UPPERCASE_PATTERN = /[A-Z]/;
+export const PASSWORD_LOWERCASE_PATTERN = /[a-z]/;
+export const PASSWORD_NUMBER_PATTERN = /[0-9]/;
+export const PASSWORD_SPECIAL_PATTERN = /[!@#$%^&*(),.?":{}|<>]/;
+
+export function getPasswordPolicy(password: string) {
+  const checks = {
+    length: password.length >= PASSWORD_MIN_LENGTH,
+    uppercase: PASSWORD_UPPERCASE_PATTERN.test(password),
+    lowercase: PASSWORD_LOWERCASE_PATTERN.test(password),
+    number: PASSWORD_NUMBER_PATTERN.test(password),
+    special: PASSWORD_SPECIAL_PATTERN.test(password),
+  };
+  const score = Object.values(checks).filter(Boolean).length;
+
+  let label = 'อ่อนมาก';
+  if (score >= 5) label = 'แข็งแกร่งมาก';
+  else if (score >= 4) label = 'แข็งแกร่ง';
+  else if (score >= 3) label = 'ปานกลาง';
+  else if (score >= 2) label = 'อ่อน';
+
+  return { checks, score, label, percentage: (score / 5) * 100 };
+}
+
+export function getPasswordPolicyError(password: string): string {
+  const { checks } = getPasswordPolicy(password);
+  if (!checks.length) return 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร';
+  if (!checks.uppercase) return 'รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว';
+  if (!checks.lowercase) return 'รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว';
+  if (!checks.number) return 'รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว';
+  return '';
+}

--- a/src/lib/safe-auth-return.ts
+++ b/src/lib/safe-auth-return.ts
@@ -13,7 +13,7 @@ export type SafeAuthReturn = {
   source: 'validated' | 'fallback';
 };
 
-export type AuthEntryPath = '/login' | '/register';
+export type AuthEntryPath = '/login' | '/register' | '/forgot-password';
 
 const AUTH_LOOP_PATHS = ['/login', '/register', '/forgot-password', '/reset-password'];
 const INTERNAL_PATHS = ['/api', '/_next', '/_vercel'];

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -128,6 +128,23 @@ describe('POST /api/auth/register', () => {
         return mod.POST(makeRequest('http://localhost:3000/api/auth/register', body));
     }
 
+    it('should return the same neutral response for new, password, Google-only, and inactive accounts', async () => {
+        const request = { name: 'Test User', email: 'test@example.com', password: 'Test1234' };
+        const accountStates = [
+            [],
+            [{ id: 'password-user', passwordHash: 'hash', deactivatedAt: null }],
+            [{ id: 'google-user', passwordHash: null, deactivatedAt: null }],
+            [{ id: 'inactive-user', passwordHash: 'hash', deactivatedAt: new Date() }],
+        ];
+
+        for (const accountState of accountStates) {
+            mockDbState.selectResult = accountState;
+            const response = await callRegister(request);
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({ message: 'ตรวจสอบคำขอแล้ว' });
+        }
+    });
+
     it('should register a valid user', async () => {
         const res = await callRegister({ name: 'Test User', email: 'test@example.com', password: 'Test1234' });
         expect(res.status).toBe(200);
@@ -235,12 +252,44 @@ describe('POST /api/auth/reset-password', () => {
         return mod.POST(makeRequest('http://localhost:3000/api/auth/reset-password', body));
     }
 
+    it('should return the same neutral cooldown contract for every account state', async () => {
+        const expected = {
+            message: 'ตรวจสอบคำขอแล้ว',
+            retryAfterSeconds: 300,
+        };
+
+        mockDbState.selectResult = [];
+        const missingAccount = await callReset({ email: 'nobody@example.com' });
+
+        mockDbState.selectResult = [{
+            id: 'inactive-user',
+            email: 'inactive@example.com',
+            name: 'Inactive',
+            deactivatedAt: new Date('2026-07-24T00:00:00.000Z'),
+        }];
+        const inactiveAccount = await callReset({ email: 'inactive@example.com' });
+
+        mockDbState.selectResult = [{
+            id: 'active-user',
+            email: 'active@example.com',
+            name: 'Active',
+            resetToken: 'existing-token-hash',
+            resetExpires: new Date(Date.now() + 58 * 60 * 1000),
+            deactivatedAt: null,
+        }];
+        const activeAccount = await callReset({ email: 'active@example.com' });
+
+        await expect(missingAccount.json()).resolves.toEqual(expected);
+        await expect(inactiveAccount.json()).resolves.toEqual(expected);
+        await expect(activeAccount.json()).resolves.toEqual(expected);
+    });
+
     it('should return success even for non-existent email (anti-enumeration)', async () => {
         mockDbState.selectResult = [];
         const res = await callReset({ email: 'nobody@example.com' });
         expect(res.status).toBe(200);
         const data = await res.json();
-        expect(data.message).toContain('หากอีเมลนี้มีในระบบ');
+        expect(data.message).toBe('ตรวจสอบคำขอแล้ว');
     });
 
     it('should return success for existing email', async () => {
@@ -248,7 +297,7 @@ describe('POST /api/auth/reset-password', () => {
         const res = await callReset({ email: 'user@example.com' });
         expect(res.status).toBe(200);
         const data = await res.json();
-        expect(data.message).toContain('หากอีเมลนี้มีในระบบ');
+        expect(data.message).toBe('ตรวจสอบคำขอแล้ว');
     });
 
     it('should generate reset token for existing user', async () => {
@@ -257,6 +306,24 @@ describe('POST /api/auth/reset-password', () => {
         expect(mockDbState.updateSet).toBeTruthy();
         expect(mockDbState.updateSet).toHaveProperty('resetToken');
         expect(mockDbState.updateSet).toHaveProperty('resetExpires');
+    });
+
+    it('should validate the return destination before putting it in a reset email', async () => {
+        mockDbState.selectResult = [{
+            id: 'user-1',
+            email: 'user@example.com',
+            name: 'User',
+            deactivatedAt: null,
+        }];
+
+        await callReset({
+            email: 'user@example.com',
+            callbackUrl: 'https://evil.example/steal-token',
+        });
+
+        expect(mockedSendPasswordResetEmail).toHaveBeenCalledWith(expect.objectContaining({
+            returnTo: '/dashboard',
+        }));
     });
 
     it('should return the generic success shape without issuing a token for an inactive user', async () => {
@@ -354,6 +421,7 @@ describe('POST /api/auth/reset-password/confirm', () => {
         const res = await callResetConfirm({ token: 'invalid-token', newPassword: 'NewPass1' });
         expect(res.status).toBe(400);
         const data = await res.json();
+        expect(data.kind).toBe('invalid_or_expired_link');
         expect(data.error).toContain('หมดอายุ');
     });
 
@@ -381,6 +449,7 @@ describe('POST /api/auth/reset-password/confirm', () => {
 
         expect(res.status).toBe(400);
         const data = await res.json();
+        expect(data.kind).toBe('invalid_or_expired_link');
         expect(data.error).toContain('หมดอายุ');
     });
 
@@ -395,6 +464,7 @@ describe('POST /api/auth/reset-password/confirm', () => {
         const res = await callResetConfirm({ token: 'valid-token', newPassword: 'NewPass1' });
 
         expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({ kind: 'invalid_or_expired_link' });
         expect(mockDbState.updateSet).toBeNull();
         expect(mockedBcrypt.hash).not.toHaveBeenCalled();
     });

--- a/tests/components/auth-recovery.test.tsx
+++ b/tests/components/auth-recovery.test.tsx
@@ -9,13 +9,10 @@ describe('account recovery UI contracts', () => {
     const source = readSource('src/components/auth/ForgotPasswordForm.tsx');
 
     expect(page).not.toContain('use client');
-    expect(page).toContain('<ForgotPasswordForm />');
+    expect(page).toContain('<ForgotPasswordForm');
     expect(source).toContain("fetch('/api/auth/reset-password'");
     expect(source).toContain("method: 'POST'");
     expect(source).toContain("'Content-Type': 'application/json'");
-    expect(source).toContain('JSON.stringify({ email })');
-    expect(source).toContain('หากอีเมล');
-    expect(source).toContain('มีในระบบ');
     expect(source).toContain("type={'email'}");
     expect(source).toContain("autoComplete={'email'}");
     expect(source).toContain("type={'button'}");
@@ -27,27 +24,19 @@ describe('account recovery UI contracts', () => {
     const source = readSource('src/components/auth/ResetPasswordForm.tsx');
 
     expect(page).not.toContain('use client');
-    expect(page).toContain('<Suspense');
-    expect(page).toContain('<ResetPasswordForm />');
-    expect(source).toContain('useSearchParams()');
-    expect(source).toContain("searchParams.get('token')");
+    expect(page).toContain('<ResetPasswordForm');
     expect(source).toContain("fetch('/api/auth/reset-password/confirm'");
     expect(source).toContain('JSON.stringify({ token, newPassword: password })');
     expect(source).not.toContain('{token}');
     expect(source).not.toContain('console.');
   });
 
-  it('preserves Reset password constraints and missing/error/success recovery targets', () => {
+  it('preserves Reset password request field contracts', () => {
     const source = readSource('src/components/auth/ResetPasswordForm.tsx');
 
     expect(source).toContain("name={'password'}");
     expect(source).toContain("name={'confirmPassword'}");
     expect(source.match(/minLength=\{8\}/g)).toHaveLength(2);
     expect(source.match(/autoComplete=\{'new-password'\}/g)).toHaveLength(2);
-    expect(source).toContain('รหัสผ่านไม่ตรงกัน');
-    expect(source).toContain('ลิงก์ไม่ถูกต้อง');
-    expect(source).toContain('ตั้งรหัสผ่านใหม่สำเร็จ!');
-    expect(source).toContain("href={'/forgot-password'}");
-    expect(source).toContain("href={'/login'}");
   });
 });

--- a/tests/components/auth-register.test.tsx
+++ b/tests/components/auth-register.test.tsx
@@ -17,20 +17,13 @@ describe('Register UI contracts', () => {
     expect(source).toContain("signIn('credentials'");
   });
 
-  it('keeps fields and client password policy aligned with the API', () => {
+  it('keeps the account identity fields aligned with the API request', () => {
     const source = readSource('src/components/auth/RegisterForm.tsx');
 
     expect(source).toMatch(/name=(?:["']name["']|\{["']name["']\})/);
-    expect(source).toContain('name.trim().length < 2');
     expect(source).toContain('maxLength={100}');
     expect(source).toMatch(/name=(?:["']email["']|\{["']email["']\})/);
     expect(source).toMatch(/name=(?:["']password["']|\{["']password["']\})/);
-    expect(source).toContain('password.length < 8');
-    expect(source).toContain('/[A-Z]/');
-    expect(source).toContain('/[a-z]/');
-    expect(source).toContain('/[0-9]/');
     expect(source).toMatch(/name=(?:["']confirmPassword["']|\{["']confirmPassword["']\})/);
-    expect(source).toContain('รหัสผ่านไม่ตรงกัน');
-    expect(source).toContain('อักขระพิเศษ (แนะนำ)');
   });
 });

--- a/tests/components/auth-safe-return.test.tsx
+++ b/tests/components/auth-safe-return.test.tsx
@@ -8,18 +8,21 @@ import LoginForm from '@/components/auth/LoginForm';
 import RegisterForm from '@/components/auth/RegisterForm';
 import LoginPage from '@/app/login/page';
 import RegisterPage from '@/app/register/page';
+import ForgotPasswordPage from '@/app/forgot-password/page';
+import ResetPasswordPage from '@/app/reset-password/page';
 import { createAuthReturnHref, resolveSafeAuthReturn } from '@/lib/safe-auth-return';
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   refresh: vi.fn(),
   signIn: vi.fn(),
+  searchParams: new URLSearchParams(),
 }));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
   usePathname: () => '/login',
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mocks.searchParams,
 }));
 
 vi.mock('next-auth/react', () => ({
@@ -36,6 +39,7 @@ describe('auth safe-return integration', () => {
     mocks.push.mockReset();
     mocks.refresh.mockReset();
     mocks.signIn.mockReset();
+    mocks.searchParams = new URLSearchParams();
   });
 
   afterEach(() => {
@@ -50,6 +54,7 @@ describe('auth safe-return integration', () => {
       <LoginForm
         returnTo={returnTo}
         registerHref={createAuthReturnHref('/register', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
       />,
     );
 
@@ -89,6 +94,7 @@ describe('auth safe-return integration', () => {
       <RegisterForm
         returnTo={returnTo}
         loginHref={createAuthReturnHref('/login', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
       />,
     );
 
@@ -143,5 +149,171 @@ describe('auth safe-return integration', () => {
     expect(loginLink?.getAttribute('href')).toBe(
       '/login?callbackUrl=%2Fbundles%2Ffull-stack',
     );
+  });
+
+  it('shows neutral recovery actions instead of silently redirecting when registration cannot sign in', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ message: 'ตรวจสอบคำขอแล้ว' }),
+      }),
+    );
+    mocks.signIn.mockResolvedValue({ error: 'CredentialsSignin' });
+    const returnTo = resolveSafeAuthReturn('/courses/typescript-foundations').pathname;
+    const view = render(
+      <RegisterForm
+        returnTo={returnTo}
+        loginHref={createAuthReturnHref('/login', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
+      />,
+    );
+
+    for (const [name, value] of [
+      ['name', 'Test Member'],
+      ['email', 'private@example.com'],
+      ['password', 'StrongPass1!'],
+      ['confirmPassword', 'StrongPass1!'],
+    ]) {
+      fireEvent.change(view.container.querySelector(`input[name=${name}]`)!, {
+        target: { value },
+      });
+    }
+    fireEvent.submit(view.container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(view.getByText('ตรวจสอบคำขอแล้ว')).toBeTruthy();
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(view.queryByText('private@example.com')).toBeNull();
+    expect(view.getByRole('link', { name: 'เข้าสู่ระบบ' }).getAttribute('href')).toBe(
+      '/login?callbackUrl=%2Fcourses%2Ftypescript-foundations',
+    );
+  });
+
+  it('uses shared Thai field validation and focuses the first invalid Register field', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const returnTo = resolveSafeAuthReturn('/dashboard').pathname;
+    const view = render(
+      <RegisterForm
+        returnTo={returnTo}
+        loginHref={createAuthReturnHref('/login', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
+      />,
+    );
+
+    fireEvent.submit(view.container.querySelector('form')!);
+
+    const nameInput = view.container.querySelector('input[name=name]') as HTMLInputElement;
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(nameInput.getAttribute('aria-invalid')).toBe('true');
+    expect(nameInput.getAttribute('aria-describedby')).toBe('register-name-error');
+    expect(document.activeElement).toBe(nameInput);
+    expect(nameInput.closest('form')?.noValidate).toBe(true);
+    expect(document.getElementById('register-name-error')?.textContent).toBe('กรุณากรอกชื่ออย่างน้อย 2 ตัวอักษร');
+    expect(view.getByText('มีตัวพิมพ์ใหญ่')).toBeTruthy();
+    expect(view.getByRole('link', { name: 'ข้อกำหนดการใช้งาน' }).getAttribute('href')).toBe('/terms');
+    expect(view.getByRole('link', { name: 'นโยบายความเป็นส่วนตัว' }).getAttribute('href')).toBe('/privacy');
+  });
+
+  it('announces asynchronous Register failures politely without attaching them to a field', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: vi.fn().mockResolvedValue({ retryAfter: 30 }),
+    }));
+    const returnTo = resolveSafeAuthReturn('/dashboard').pathname;
+    const view = render(
+      <RegisterForm
+        returnTo={returnTo}
+        loginHref={createAuthReturnHref('/login', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
+      />,
+    );
+
+    for (const [name, value] of [
+      ['name', 'Test Member'],
+      ['email', 'private@example.com'],
+      ['password', 'StrongPass1!'],
+      ['confirmPassword', 'StrongPass1!'],
+    ]) {
+      fireEvent.change(view.container.querySelector(`input[name=${name}]`)!, {
+        target: { value },
+      });
+    }
+    fireEvent.submit(view.container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(view.getByRole('status').textContent).toContain('ส่งคำขอถี่เกินไป');
+    });
+    expect(view.getByRole('status').getAttribute('aria-live')).toBe('polite');
+    expect(view.container.querySelector('input[name=email]')?.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('preserves a safe destination from Login through Forgot Password and back to Login', async () => {
+    const searchParams = Promise.resolve({ callbackUrl: '/courses/typescript-foundations' });
+    const loginView = await LoginPage({ searchParams });
+    const login = render(loginView);
+    const forgotLink = Array.from(login.container.querySelectorAll('a')).find((link) =>
+      link.getAttribute('href')?.startsWith('/forgot-password'),
+    );
+    expect(forgotLink?.getAttribute('href')).toBe(
+      '/forgot-password?callbackUrl=%2Fcourses%2Ftypescript-foundations',
+    );
+
+    cleanup();
+
+    const forgotView = await ForgotPasswordPage({ searchParams } as never);
+    const forgot = render(forgotView);
+    const loginLink = Array.from(forgot.container.querySelectorAll('a')).find((link) =>
+      link.getAttribute('href')?.startsWith('/login'),
+    );
+    expect(loginLink?.getAttribute('href')).toBe(
+      '/login?callbackUrl=%2Fcourses%2Ftypescript-foundations',
+    );
+  });
+
+  it('renders the missing Reset link state on the server with safe recovery destinations', async () => {
+    const resetView = await ResetPasswordPage({
+      searchParams: Promise.resolve({ callbackUrl: '/courses/typescript-foundations' }),
+    });
+    const reset = render(resetView);
+
+    expect(reset.getByText('ลิงก์ไม่สมบูรณ์')).toBeTruthy();
+    expect(reset.queryAllByLabelText(/รหัสผ่านใหม่/)).toHaveLength(0);
+    expect(reset.getByRole('link', { name: 'ขอลิงก์ใหม่' }).getAttribute('href')).toBe(
+      '/forgot-password?callbackUrl=%2Fcourses%2Ftypescript-foundations',
+    );
+    expect(reset.getByRole('link', { name: 'กลับไปหน้าเข้าสู่ระบบ' }).getAttribute('href')).toBe(
+      '/login?callbackUrl=%2Fcourses%2Ftypescript-foundations',
+    );
+  });
+
+  it('shows only the allowlisted password-reset arrival reason on Login', async () => {
+    const returnTo = resolveSafeAuthReturn('/courses/typescript-foundations').pathname;
+    mocks.searchParams = new URLSearchParams({ reason: 'password-reset' });
+    const resetArrival = render(
+      <LoginForm
+        returnTo={returnTo}
+        registerHref={createAuthReturnHref('/register', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(resetArrival.getByText('ตั้งรหัสผ่านใหม่แล้ว กรุณาเข้าสู่ระบบอีกครั้ง')).toBeTruthy();
+    });
+
+    cleanup();
+    mocks.searchParams = new URLSearchParams({ reason: '<img src=x onerror=alert(1)>' });
+    const unknownArrival = render(
+      <LoginForm
+        returnTo={returnTo}
+        registerHref={createAuthReturnHref('/register', returnTo)}
+        forgotPasswordHref={createAuthReturnHref('/forgot-password', returnTo)}
+      />,
+    );
+    expect(unknownArrival.queryByText('<img src=x onerror=alert(1)>')).toBeNull();
   });
 });

--- a/tests/components/forgot-password-form.test.tsx
+++ b/tests/components/forgot-password-form.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ForgotPasswordForm from '@/components/auth/ForgotPasswordForm';
+import { DEFAULT_AUTH_RETURN_PATH } from '@/lib/safe-auth-return';
+
+describe('ForgotPasswordForm', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows a neutral result without exposing the submitted email and honors server cooldown', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        message: 'ตรวจสอบคำขอแล้ว',
+        retryAfterSeconds: 300,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ForgotPasswordForm returnTo={DEFAULT_AUTH_RETURN_PATH} loginHref={'/login'} />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'อีเมล' }), {
+      target: { value: 'private@example.com' },
+    });
+    fireEvent.submit(screen.getByRole('textbox', { name: 'อีเมล' }).closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('ตรวจสอบคำขอแล้ว')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('private@example.com')).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/reset-password', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ email: 'private@example.com', callbackUrl: DEFAULT_AUTH_RETURN_PATH }),
+    }));
+    const resendButton = screen.getByRole('button', { name: 'ส่งอีกครั้งใน 5:00' });
+    expect((resendButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('uses Thai validation and focuses the invalid email field before sending', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ForgotPasswordForm returnTo={DEFAULT_AUTH_RETURN_PATH} loginHref={'/login'} />);
+
+    const emailInput = screen.getByRole('textbox', { name: 'อีเมล' });
+    fireEvent.change(emailInput, { target: { value: 'not-an-email' } });
+    fireEvent.submit(emailInput.closest('form')!);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(emailInput.getAttribute('aria-invalid')).toBe('true');
+    expect(emailInput.getAttribute('aria-describedby')).toBe('forgot-email-error');
+    expect(screen.getByText('กรุณากรอกอีเมลให้ถูกต้อง')).toBeTruthy();
+    expect(document.activeElement).toBe(emailInput);
+    expect(emailInput.closest('form')?.noValidate).toBe(true);
+  });
+
+  it('presents rate limits as stable Thai polite feedback', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: vi.fn().mockResolvedValue({
+        error: 'Too many requests. Please try again later.',
+        retryAfter: 47,
+      }),
+    }));
+    render(<ForgotPasswordForm returnTo={DEFAULT_AUTH_RETURN_PATH} loginHref={'/login'} />);
+
+    const emailInput = screen.getByRole('textbox', { name: 'อีเมล' });
+    fireEvent.change(emailInput, { target: { value: 'member@example.com' } });
+    fireEvent.submit(emailInput.closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('ส่งคำขอถี่เกินไป กรุณารอ 47 วินาทีแล้วลองใหม่')).toBeTruthy();
+    });
+    expect(screen.getByRole('status').getAttribute('aria-live')).toBe('polite');
+    expect(screen.queryByText('Too many requests. Please try again later.')).toBeNull();
+  });
+});

--- a/tests/components/password-policy-feedback.test.tsx
+++ b/tests/components/password-policy-feedback.test.tsx
@@ -1,0 +1,19 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import PasswordPolicyFeedback from '@/components/auth/PasswordPolicyFeedback';
+
+describe('PasswordPolicyFeedback', () => {
+  afterEach(cleanup);
+
+  it('communicates each live requirement without relying on color', () => {
+    render(<PasswordPolicyFeedback password={'lowercase1'} id={'password-policy'} />);
+
+    expect(screen.getByText('มีตัวพิมพ์เล็ก').closest('li')?.textContent).toContain('ผ่าน');
+    expect(screen.getByText('มีตัวเลข').closest('li')?.textContent).toContain('ผ่าน');
+    expect(screen.getByText('มีตัวพิมพ์ใหญ่').closest('li')?.textContent).toContain('ยังไม่ผ่าน');
+    expect(screen.getByText('อักขระพิเศษ (แนะนำ)').closest('li')?.textContent).toContain('ยังไม่ผ่าน');
+  });
+});

--- a/tests/components/password-settings-fresh-sign-in.test.tsx
+++ b/tests/components/password-settings-fresh-sign-in.test.tsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import PasswordSettingsForm from '@/components/settings/PasswordSettingsForm';
+
+const mocks = vi.hoisted(() => ({ signOut: vi.fn() }));
+
+vi.mock('next-auth/react', () => ({ signOut: mocks.signOut }));
+
+describe('PasswordSettingsForm fresh sign-in', () => {
+  beforeEach(() => mocks.signOut.mockReset());
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('ends the current session after a successful password change', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ message: 'เปลี่ยนรหัสผ่านสำเร็จ' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    mocks.signOut.mockResolvedValue(undefined);
+
+    render(<PasswordSettingsForm hasPassword />);
+    fireEvent.click(screen.getByRole('button', { name: /เปลี่ยนรหัสผ่าน/ }));
+
+    fireEvent.change(screen.getByLabelText('รหัสผ่านปัจจุบัน'), {
+      target: { value: 'CurrentPassword1' },
+    });
+    fireEvent.change(screen.getByLabelText('รหัสผ่านใหม่'), {
+      target: { value: 'NewPassword2' },
+    });
+    fireEvent.change(screen.getByLabelText('ยืนยันรหัสผ่านใหม่'), {
+      target: { value: 'NewPassword2' },
+    });
+    fireEvent.submit(screen.getByLabelText('รหัสผ่านใหม่').closest('form')!);
+
+    await waitFor(() => {
+      expect(mocks.signOut).toHaveBeenCalledWith({
+        callbackUrl: '/login?reason=password-changed',
+      });
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/change-password', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        currentPassword: 'CurrentPassword1',
+        newPassword: 'NewPassword2',
+      }),
+    }));
+  });
+});

--- a/tests/components/reset-password-form.test.tsx
+++ b/tests/components/reset-password-form.test.tsx
@@ -1,0 +1,109 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ResetPasswordForm from '@/components/auth/ResetPasswordForm';
+
+describe('ResetPasswordForm', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows a dedicated missing-link state without rendering password fields', () => {
+    render(<ResetPasswordForm token={null} forgotPasswordHref={'/forgot-password'} loginHref={'/login'} successLoginHref={'/login?reason=password-reset'} />);
+
+    expect(screen.getByText('ลิงก์ไม่สมบูรณ์')).toBeTruthy();
+    expect(screen.queryAllByLabelText(/รหัสผ่านใหม่/)).toHaveLength(0);
+    expect(screen.getByRole('link', { name: 'ขอลิงก์ใหม่' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'กลับไปหน้าเข้าสู่ระบบ' })).toBeTruthy();
+  });
+
+  it('replaces the form with one safe invalid-link state after token rejection', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue({
+        kind: 'invalid_or_expired_link',
+        error: 'ลิงก์นี้ใช้ไม่ได้แล้ว',
+      }),
+    }));
+    render(<ResetPasswordForm token={'opaque-token'} forgotPasswordHref={'/forgot-password'} loginHref={'/login'} successLoginHref={'/login?reason=password-reset'} />);
+
+    fireEvent.change(screen.getByLabelText('รหัสผ่านใหม่'), {
+      target: { value: 'NewPassword1' },
+    });
+    fireEvent.change(screen.getByLabelText('ยืนยันรหัสผ่านใหม่'), {
+      target: { value: 'NewPassword1' },
+    });
+    fireEvent.submit(screen.getByLabelText('รหัสผ่านใหม่').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('ลิงก์นี้ใช้ไม่ได้แล้ว')).toBeTruthy();
+    });
+    expect(screen.queryAllByLabelText(/รหัสผ่านใหม่/)).toHaveLength(0);
+    expect(screen.getByRole('link', { name: 'ขอลิงก์ใหม่' })).toBeTruthy();
+  });
+
+  it('controls password and confirmation visibility independently', () => {
+    render(<ResetPasswordForm token={'opaque-token'} forgotPasswordHref={'/forgot-password'} loginHref={'/login'} successLoginHref={'/login?reason=password-reset'} />);
+
+    const password = screen.getByLabelText('รหัสผ่านใหม่') as HTMLInputElement;
+    const confirmation = screen.getByLabelText('ยืนยันรหัสผ่านใหม่') as HTMLInputElement;
+    fireEvent.click(screen.getByRole('button', { name: 'แสดงรหัสผ่าน' }));
+
+    expect(password.type).toBe('text');
+    expect(confirmation.type).toBe('password');
+  });
+
+  it('requires a fresh sign-in after success while preserving the safe destination', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ message: 'ตั้งรหัสผ่านใหม่สำเร็จ' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    render(<ResetPasswordForm token={'opaque-token'} forgotPasswordHref={'/forgot-password?callbackUrl=%2Fcourses%2Ftypescript-foundations'} loginHref={'/login?callbackUrl=%2Fcourses%2Ftypescript-foundations'} successLoginHref={'/login?callbackUrl=%2Fcourses%2Ftypescript-foundations&reason=password-reset'} />);
+
+    fireEvent.change(screen.getByLabelText('รหัสผ่านใหม่'), {
+      target: { value: 'NewPassword1' },
+    });
+    fireEvent.change(screen.getByLabelText('ยืนยันรหัสผ่านใหม่'), {
+      target: { value: 'NewPassword1' },
+    });
+    fireEvent.submit(screen.getByLabelText('รหัสผ่านใหม่').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('ตั้งรหัสผ่านใหม่แล้ว')).toBeTruthy();
+    });
+    expect(screen.getByText('เพื่อความปลอดภัย กรุณาเข้าสู่ระบบอีกครั้ง')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'ไปหน้าเข้าสู่ระบบ' }).getAttribute('href')).toBe(
+      '/login?callbackUrl=%2Fcourses%2Ftypescript-foundations&reason=password-reset',
+    );
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/reset-password/confirm', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ token: 'opaque-token', newPassword: 'NewPassword1' }),
+    }));
+  });
+
+  it('shows the password checklist and focuses the first invalid field before sending', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    render(<ResetPasswordForm token={'opaque-token'} forgotPasswordHref={'/forgot-password'} loginHref={'/login'} successLoginHref={'/login?reason=password-reset'} />);
+
+    const password = screen.getByLabelText('รหัสผ่านใหม่') as HTMLInputElement;
+    const confirmation = screen.getByLabelText('ยืนยันรหัสผ่านใหม่') as HTMLInputElement;
+    fireEvent.change(password, { target: { value: 'alllowercase' } });
+    fireEvent.change(confirmation, { target: { value: 'alllowercase' } });
+    fireEvent.submit(password.closest('form')!);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(password.getAttribute('aria-invalid')).toBe('true');
+    expect(document.activeElement).toBe(password);
+    expect(password.closest('form')?.noValidate).toBe(true);
+    expect(screen.getByText('มีตัวพิมพ์ใหญ่')).toBeTruthy();
+    expect(screen.getByText('มีตัวเลข')).toBeTruthy();
+    expect(screen.getByText('รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว')).toBeTruthy();
+  });
+});

--- a/tests/lib/password-policy.test.ts
+++ b/tests/lib/password-policy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPasswordPolicy, getPasswordPolicyError } from '@/lib/password-policy';
+
+describe('password policy', () => {
+  it('uses the required account password rules and keeps special characters recommended', () => {
+    expect(getPasswordPolicyError('short')).toBe('รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร');
+    expect(getPasswordPolicyError('lowercase1')).toBe('รหัสผ่านต้องมีตัวพิมพ์ใหญ่อย่างน้อย 1 ตัว');
+    expect(getPasswordPolicyError('UPPERCASE1')).toBe('รหัสผ่านต้องมีตัวพิมพ์เล็กอย่างน้อย 1 ตัว');
+    expect(getPasswordPolicyError('NoNumbers')).toBe('รหัสผ่านต้องมีตัวเลขอย่างน้อย 1 ตัว');
+    expect(getPasswordPolicyError('Required1')).toBe('');
+    expect(getPasswordPolicy('Required1').checks.special).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- make Register and Forgot Password responses neutral to reduce account enumeration risk
- add safe recovery states, authoritative cooldown handling, safe return paths, and fresh sign-in after password changes
- add accessible password feedback, field-local validation, and behavior-focused regression coverage

## Verification
- npm run test -- --run (131 files, 789 tests)
- npm run lint
- npm run build (93 pages)
- git diff --check
- browser smoke test: Register, Forgot Password, Reset Password on desktop/mobile; 0 console errors

## Safety notes
- invalid, expired, and used reset tokens intentionally share one public state to avoid a token oracle
- external email delivery and production data were not exercised

Closes #35