### PR TITLE
feat(courses): centralize decision facts

### DIFF
--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -20,6 +20,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty';
 import { Separator } from '@/components/ui/separator';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { deriveCourseDecisionFacts } from '@/lib/course-decision-facts';
 
 function normalizeUrl(url: string | null): string | null {
     if (!url || url.trim() === '') return null;
@@ -134,33 +135,34 @@ export default async function CourseDetailPage({ params }: Props) {
       })()
     : course.previewVideoUrl;
 
-  const price = parseFloat(course.price || '0');
-
   // Calculate total course duration
   const totalSeconds = course.lessons.reduce((sum: number, l: { videoDuration: number | null }) => sum + (l.videoDuration || 0), 0);
   const freePreviewCount = course.lessons.filter((lesson: { isFreePreview: boolean | null }) => lesson.isFreePreview).length;
-  const courseReady = course.lessons.length > 0;
   const firstPreviewLesson = course.lessons.find((lesson: { isFreePreview: boolean | null }) => lesson.isFreePreview) || null;
   const totalHours = Math.floor(totalSeconds / 3600);
   const totalMinutes = Math.floor((totalSeconds % 3600) / 60);
   const durationText = totalHours > 0
     ? `${totalHours} ชั่วโมง ${totalMinutes > 0 ? `${totalMinutes} นาที` : ''}`
     : `${totalMinutes} นาที`;
-  const now = new Date();
-  const hasPromo = course.promoPrice !== null && course.promoPrice !== undefined;
-  const promoStartOk = !course.promoStartsAt || new Date(course.promoStartsAt) <= now;
-  const promoEndOk = !course.promoEndsAt || new Date(course.promoEndsAt) >= now;
-  const isPromoActive = hasPromo && promoStartOk && promoEndOk;
-  const promoPrice = isPromoActive ? parseFloat(course.promoPrice || '0') : null;
-  const displayPrice = promoPrice !== null ? promoPrice : price;
-  const instructorName = course.instructor?.name?.trim() || null;
+  const decisionFacts = deriveCourseDecisionFacts({
+    slug: course.slug,
+    regularPrice: course.price,
+    promotion: course.promoPrice === null
+      ? null
+      : {
+          price: course.promoPrice,
+          startsAt: course.promoStartsAt,
+          endsAt: course.promoEndsAt,
+        },
+    lessonCount: course.lessons.length,
+    knownDurationSeconds: totalSeconds,
+    freePreviewCount,
+    instructor: course.instructor ? { name: course.instructor.name } : null,
+  }, { now: new Date() });
+  const displayPrice = decisionFacts.price.effective;
+  const courseReady = decisionFacts.readiness === 'ready';
+  const instructorName = decisionFacts.evidence.instructorName;
   const instructorAvatarUrl = normalizeUrl(course.instructor?.avatarUrl || null);
-  const promoDiscount = isPromoActive && price > 0
-    ? Math.round((1 - displayPrice / price) * 100)
-    : null;
-  const promoLabel = promoDiscount !== null
-    ? `โปรโมชั่น ลด ${promoDiscount}%${course.promoEndsAt ? ` ถึง ${new Date(course.promoEndsAt).toLocaleDateString('th-TH', { day: 'numeric', month: 'short', year: 'numeric' })}` : ''}`
-    : null;
 
   const courseSectionItems = [
     { id: 'course-overview', label: 'รายละเอียดคอร์ส' },
@@ -279,10 +281,7 @@ export default async function CourseDetailPage({ params }: Props) {
                     <CourseDetailClient
                       courseId={course.id}
                       courseSlug={course.slug}
-                      price={displayPrice}
-                      originalPrice={price}
-                      promoLabel={promoLabel}
-                      courseReady={courseReady}
+                      decisionFacts={decisionFacts}
                       previewLessonHref={firstPreviewLesson ? `/courses/${course.slug}/learn/${firstPreviewLesson.id}` : null}
                       hasVideoPreview={Boolean(signedPreviewVideoUrl)}
                       renderMode="button"
@@ -329,7 +328,7 @@ export default async function CourseDetailPage({ params }: Props) {
                     รายการบทเรียนทั้งหมด
                   </AccordionTrigger>
                   <AccordionContent className="-mx-4 pb-0">
-                    <CourseDetailClient courseId={course.id} courseSlug={course.slug} lessons={course.lessons} />
+                    <CourseDetailClient courseId={course.id} courseSlug={course.slug} decisionFacts={decisionFacts} lessons={course.lessons} />
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>
@@ -369,7 +368,7 @@ export default async function CourseDetailPage({ params }: Props) {
                     <h2 className="text-xl font-bold">พร้อมเริ่มเรียนแล้วหรือยัง?</h2>
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">กลับไปสมัครคอร์ส หรือเข้าเรียนต่อได้จากตรงนี้</p>
                   </div>
-                  <CourseDetailClient courseId={course.id} courseSlug={course.slug} price={displayPrice} courseReady={courseReady} renderMode="final-action" />
+                  <CourseDetailClient courseId={course.id} courseSlug={course.slug} decisionFacts={decisionFacts} renderMode="final-action" />
                 </CardContent>
               </Card>
             )}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/empty';
 import { db } from '@/lib/db';
 import { bundles, bundleCourses, courses, courseTags, lessons, tags, users } from '@/lib/db/schema';
+import { deriveCourseDecisionFacts, type CourseDecisionFacts } from '@/lib/course-decision-facts';
 import { and, asc, count, desc, eq, gt, like, sql } from 'drizzle-orm';
 
 export const revalidate = 300;
@@ -44,13 +45,7 @@ interface CourseListItem {
   slug: string;
   description: string | null;
   thumbnailUrl: string | null;
-  price: string;
-  promoPrice: string | null;
-  isPromoActive: boolean;
-  instructor: { id: string; name: string | null; avatarUrl: string | null } | null;
-  lessonCount: number;
-  totalDurationSeconds: number;
-  hasFreePreview: boolean;
+  decisionFacts: CourseDecisionFacts;
   tags: Tag[];
 }
 
@@ -269,10 +264,12 @@ async function getCoursesData(input: {
 
   const now = new Date();
   const formattedCourses: CourseListItem[] = courseRows.map((row) => {
-    const hasPromo = row.promoPrice !== null && row.promoPrice !== undefined;
-    const promoStartOk = !row.promoStartsAt || new Date(row.promoStartsAt) <= now;
-    const promoEndOk = !row.promoEndsAt || new Date(row.promoEndsAt) >= now;
-    const isPromoActive = hasPromo && promoStartOk && promoEndOk;
+    const lessonCount = Number(row.lessonCount) || 0;
+    const totalDurationSeconds = Number(row.totalDurationSeconds) || 0;
+    const freePreviewCount = Number(row.freePreviewCount) || 0;
+    const instructor = row.instructorId
+      ? { id: row.instructorId, name: row.instructorName, avatarUrl: row.instructorAvatarUrl }
+      : null;
 
     return {
       id: row.id,
@@ -280,15 +277,21 @@ async function getCoursesData(input: {
       slug: row.slug,
       description: row.description,
       thumbnailUrl: row.thumbnailUrl,
-      price: row.price,
-      promoPrice: row.promoPrice,
-      isPromoActive,
-      instructor: row.instructorId
-        ? { id: row.instructorId, name: row.instructorName, avatarUrl: row.instructorAvatarUrl }
-        : null,
-      lessonCount: Number(row.lessonCount) || 0,
-      totalDurationSeconds: Number(row.totalDurationSeconds) || 0,
-      hasFreePreview: Number(row.freePreviewCount) > 0,
+      decisionFacts: deriveCourseDecisionFacts({
+        slug: row.slug,
+        regularPrice: row.price,
+        promotion: row.promoPrice === null
+          ? null
+          : {
+              price: row.promoPrice,
+              startsAt: row.promoStartsAt,
+              endsAt: row.promoEndsAt,
+            },
+        lessonCount,
+        knownDurationSeconds: totalDurationSeconds,
+        freePreviewCount,
+        instructor,
+      }, { now }),
       tags: tagsByCourse.get(row.id) || [],
     };
   });
@@ -371,7 +374,7 @@ export default async function CoursesPage({ searchParams }: Props) {
               </Empty>
             ) : (
               <>
-                <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">{courseList.map((course) => <CourseCard key={course.id} id={course.id} title={course.title} slug={course.slug} description={course.description} thumbnailUrl={course.thumbnailUrl} price={parseFloat(course.price || '0')} promoPrice={course.promoPrice ? parseFloat(course.promoPrice) : null} isPromoActive={course.isPromoActive} instructorName={course.instructor?.name || null} lessonCount={course.lessonCount} totalDurationSeconds={course.totalDurationSeconds} hasFreePreview={course.hasFreePreview} tags={course.tags} />)}</div>
+                <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">{courseList.map((course) => <CourseCard key={course.id} id={course.id} title={course.title} slug={course.slug} description={course.description} thumbnailUrl={course.thumbnailUrl} decisionFacts={course.decisionFacts} tags={course.tags} />)}</div>
                 {pagination.totalPages > 1 ? <nav className="mt-10 flex flex-wrap items-center justify-center gap-2" aria-label="หน้ารายการคอร์ส">{currentPage > 1 ? <Button variant="outline" asChild><Link href={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort, page: currentPage - 1 })}>← ก่อนหน้า</Link></Button> : null}{Array.from({ length: Math.min(5, pagination.totalPages) }, (_, index) => { let pageNumber; if (pagination.totalPages <= 5) pageNumber = index + 1; else if (currentPage <= 3) pageNumber = index + 1; else if (currentPage >= pagination.totalPages - 2) pageNumber = pagination.totalPages - 4 + index; else pageNumber = currentPage - 2 + index; const isActive = currentPage === pageNumber; return <Button key={pageNumber} variant={isActive ? 'default' : 'outline'} size="icon-sm" asChild><Link href={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort, page: pageNumber })} aria-current={isActive ? 'page' : undefined}>{pageNumber}</Link></Button>; })}{currentPage < pagination.totalPages ? <Button variant="outline" asChild><Link href={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort, page: currentPage + 1 })}>ถัดไป →</Link></Button> : null}</nav> : null}
               </>
             )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,7 @@ import {
 import { Progress } from '@/components/ui/progress';
 import { db } from '@/lib/db';
 import { courses, courseTags, lessons, tags, users } from '@/lib/db/schema';
+import { deriveCourseDecisionFacts } from '@/lib/course-decision-facts';
 
 async function getLatestCourses() {
   const lessonStatsSq = db
@@ -104,16 +105,27 @@ async function getLatestCourses() {
 
   const now = new Date();
   return rows.map((row) => {
-    const hasPromo = row.promoPrice !== null && row.promoPrice !== undefined;
-    const promoStartOk = !row.promoStartsAt || new Date(row.promoStartsAt) <= now;
-    const promoEndOk = !row.promoEndsAt || new Date(row.promoEndsAt) >= now;
+    const lessonCount = Number(row.lessonCount) || 0;
+    const totalDurationSeconds = Number(row.totalDurationSeconds) || 0;
+    const freePreviewCount = Number(row.freePreviewCount) || 0;
 
     return {
       ...row,
-      isPromoActive: hasPromo && promoStartOk && promoEndOk,
-      lessonCount: Number(row.lessonCount) || 0,
-      totalDurationSeconds: Number(row.totalDurationSeconds) || 0,
-      hasFreePreview: Number(row.freePreviewCount) > 0,
+      decisionFacts: deriveCourseDecisionFacts({
+        slug: row.slug,
+        regularPrice: row.price,
+        promotion: row.promoPrice === null
+          ? null
+          : {
+              price: row.promoPrice,
+              startsAt: row.promoStartsAt,
+              endsAt: row.promoEndsAt,
+            },
+        lessonCount,
+        knownDurationSeconds: totalDurationSeconds,
+        freePreviewCount,
+        instructor: row.instructorName ? { name: row.instructorName } : null,
+      }, { now }),
       tags: tagsByCourse.get(row.id) ?? [],
     };
   });
@@ -379,13 +391,7 @@ export default async function HomePage() {
                       slug={course.slug}
                       description={course.description}
                       thumbnailUrl={course.thumbnailUrl}
-                      price={parseFloat(course.price)}
-                      promoPrice={course.promoPrice ? parseFloat(course.promoPrice) : null}
-                      isPromoActive={course.isPromoActive}
-                      instructorName={course.instructorName}
-                      lessonCount={course.lessonCount}
-                      totalDurationSeconds={course.totalDurationSeconds}
-                      hasFreePreview={course.hasFreePreview}
+                      decisionFacts={course.decisionFacts}
                       tags={course.tags}
                     />
                   </div>

--- a/src/components/course/CourseCard.tsx
+++ b/src/components/course/CourseCard.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link';
-import { ArrowRight, BookOpen, Clock3, PlayCircle } from 'lucide-react';
+import { ArrowRight, BookOpen, Clock3, PlayCircle, Star } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { getExcerpt } from '@/lib/sanitize';
+import type { CourseDecisionFacts } from '@/lib/course-decision-facts';
 import CourseArtwork from '@/components/course/CourseArtwork';
 
 interface Tag { id: string; name: string; slug: string }
@@ -12,15 +13,9 @@ interface CourseCardProps {
   slug: string;
   description: string | null;
   thumbnailUrl: string | null;
-  price: number;
-  promoPrice?: number | null;
-  isPromoActive?: boolean;
-  instructorName: string | null;
-  lessonCount: number;
+  decisionFacts: CourseDecisionFacts;
   tags?: Tag[];
   outcomes?: string[];
-  totalDurationSeconds?: number;
-  hasFreePreview?: boolean;
 }
 
 function normalizeUrl(url: string | null): string | null {
@@ -43,21 +38,19 @@ export default function CourseCard({
   slug,
   description,
   thumbnailUrl: rawThumbnailUrl,
-  price,
-  promoPrice,
-  isPromoActive,
-  instructorName,
-  lessonCount,
+  decisionFacts,
   tags,
   outcomes,
-  totalDurationSeconds,
-  hasFreePreview = false,
 }: CourseCardProps) {
-  const displayPrice = isPromoActive && promoPrice != null ? promoPrice : price;
-  const showOriginalPrice = isPromoActive && promoPrice != null && promoPrice < price;
-  const discountPercent = showOriginalPrice ? Math.round((1 - displayPrice / price) * 100) : 0;
+  const { evidence, price: pricing } = decisionFacts;
+  const displayPrice = pricing.effective;
+  const showOriginalPrice = pricing.discountPercent !== null;
+  const discountPercent = pricing.discountPercent ?? 0;
+  const instructorName = evidence.instructorName;
+  const lessonCount = evidence.lessonCount;
   const thumbnailUrl = normalizeUrl(rawThumbnailUrl);
-  const durationText = formatCourseDuration(totalDurationSeconds);
+  const durationText = formatCourseDuration(evidence.knownDurationSeconds ?? undefined);
+  const hasFreePreview = evidence.freePreviewCount > 0;
 
   return (
     <Link href={`/courses/${slug}`} className="group block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30">
@@ -66,7 +59,10 @@ export default function CourseCard({
           {thumbnailUrl
             ? <img src={thumbnailUrl} alt={title} loading="lazy" decoding="async" className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03] motion-reduce:transform-none" />
             : <CourseArtwork title={title} slug={slug} tags={tags} />}
-          {hasFreePreview ? <Badge className="absolute top-4 left-4 gap-1.5 bg-background/95 text-foreground shadow-sm"><PlayCircle />มีบทเรียนทดลอง</Badge> : null}
+          <div className="absolute top-4 left-4 flex flex-col items-start gap-2">
+            {decisionFacts.readiness === 'preparing' ? <Badge variant="secondary">กำลังเตรียมเนื้อหา</Badge> : null}
+            {hasFreePreview ? <Badge className="gap-1.5 bg-background/95 text-foreground shadow-sm"><PlayCircle />มีบทเรียนทดลอง</Badge> : null}
+          </div>
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col">
@@ -78,14 +74,19 @@ export default function CourseCard({
               <span className="inline-flex items-center gap-1.5"><BookOpen className="size-3.5" />{lessonCount} บทเรียน</span>
               {durationText ? <span className="inline-flex items-center gap-1.5"><Clock3 className="size-3.5" />{durationText}</span> : null}
               {instructorName ? <span className="basis-full">สอนโดย {instructorName}</span> : null}
+              {evidence.verifiedReview ? <span className="inline-flex items-center gap-1.5"><Star className="size-3.5 fill-current" />{evidence.verifiedReview.average.toFixed(1)} · {evidence.verifiedReview.count} รีวิว</span> : null}
             </div>
           </CardContent>
 
           <CardFooter className="mt-5 flex-wrap justify-between gap-x-4 gap-y-3 border-t px-5 py-5 sm:px-6">
-            <div aria-label={displayPrice === 0 ? 'ราคา ฟรี' : showOriginalPrice ? `ราคาพิเศษ ฿${displayPrice.toLocaleString()} จาก ฿${price.toLocaleString()} ลด ${discountPercent}%` : `ราคา ฿${displayPrice.toLocaleString()}`}>
-              {displayPrice === 0 ? <strong className="text-xl text-primary">ฟรี</strong> : <div className="flex flex-wrap items-baseline gap-2"><strong className="text-xl">฿{displayPrice.toLocaleString()}</strong>{showOriginalPrice ? <><s className="text-sm text-muted-foreground">฿{price.toLocaleString()}</s><Badge variant="destructive">ลด {discountPercent}%</Badge></> : null}</div>}
-            </div>
-            <span className="inline-flex items-center gap-2 text-sm font-semibold text-primary">{hasFreePreview ? 'ทดลองฟรี' : 'ดูคอร์ส'}<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" /></span>
+            {decisionFacts.readiness === 'preparing' ? (
+              <strong className="text-sm text-muted-foreground">ยังไม่เปิดลงทะเบียน</strong>
+            ) : (
+              <div aria-label={displayPrice === 0 ? 'ราคา ฟรี' : showOriginalPrice ? `ราคาพิเศษ ${pricing.effectiveFormatted} จาก ${pricing.regularFormatted} ลด ${discountPercent}%` : `ราคา ${pricing.effectiveFormatted}`}>
+                {displayPrice === 0 ? <strong className="text-xl text-primary">ฟรี</strong> : <div className="flex flex-wrap items-baseline gap-2"><strong className="text-xl">{pricing.effectiveFormatted}</strong>{showOriginalPrice ? <><s className="text-sm text-muted-foreground">{pricing.regularFormatted}</s><Badge variant="destructive">ลด {discountPercent}%</Badge></> : null}</div>}
+              </div>
+            )}
+            <span className="inline-flex items-center gap-2 text-sm font-semibold text-primary">{decisionFacts.actions.discovery.label}<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" /></span>
           </CardFooter>
         </div>
       </Card>

--- a/src/components/course/CourseDetailClient.tsx
+++ b/src/components/course/CourseDetailClient.tsx
@@ -15,6 +15,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { Spinner } from '@/components/ui/spinner';
+import type { CourseDecisionFacts } from '@/lib/course-decision-facts';
 
 export type EnrollmentStatus = 'checking' | 'enrolled' | 'not-enrolled';
 
@@ -30,8 +31,14 @@ export function useEnrollment() {
 }
 
 // Provider that wraps the course detail section
-export function CourseDetailProvider({ children }: { children: React.ReactNode }) {
-  const [status, setEnrollmentStatus] = useState<EnrollmentStatus>('checking');
+export function CourseDetailProvider({
+  children,
+  initialStatus = 'checking',
+}: {
+  children: React.ReactNode;
+  initialStatus?: EnrollmentStatus;
+}) {
+  const [status, setEnrollmentStatus] = useState<EnrollmentStatus>(initialStatus);
   return (
     <EnrollmentContext.Provider value={{
       status,
@@ -55,11 +62,8 @@ interface Lesson {
 interface CourseDetailClientProps {
   courseId: string;
   courseSlug: string;
+  decisionFacts: CourseDecisionFacts;
   lessons?: Lesson[];
-  price?: number;
-  originalPrice?: number;
-  promoLabel?: string | null;
-  courseReady?: boolean;
   previewLessonHref?: string | null;
   hasVideoPreview?: boolean;
   renderMode?: 'lessons' | 'button' | 'final-action';
@@ -68,23 +72,24 @@ interface CourseDetailClientProps {
 export default function CourseDetailClient({
   courseId,
   courseSlug,
+  decisionFacts,
   lessons,
-  price = 0,
-  originalPrice = price,
-  promoLabel = null,
-  courseReady = true,
   previewLessonHref = null,
   hasVideoPreview = false,
   renderMode,
 }: CourseDetailClientProps) {
   const { status, isEnrolled, setEnrollmentStatus } = useEnrollment();
+  const price = decisionFacts.price.effective;
+  const originalPrice = decisionFacts.price.regular;
+  const promoLabel = decisionFacts.promotion.label;
+  const courseReady = decisionFacts.readiness === 'ready';
 
   const handleEnrollmentChange = useCallback((enrolled: boolean) => {
     setEnrollmentStatus(enrolled ? 'enrolled' : 'not-enrolled');
   }, [setEnrollmentStatus]);
 
   if (renderMode === 'button') {
-    if (!courseReady) {
+    if (!courseReady && status !== 'enrolled') {
       return (
         <Empty className="border">
           <EmptyHeader>
@@ -110,7 +115,7 @@ export default function CourseDetailClient({
             <AlertDescription>กลับไปยังบทเรียนและเรียนต่อจากจุดที่ค้างไว้ได้เลย</AlertDescription>
           </Alert>
           <Button asChild className="w-full">
-            <Link href={`/courses/${courseSlug}/learn`}>เข้าเรียน / เรียนต่อ</Link>
+            <Link href={decisionFacts.actions.learner.href!}>{decisionFacts.actions.learner.label}</Link>
           </Button>
         </div>
       );
@@ -177,19 +182,19 @@ export default function CourseDetailClient({
   }
 
   if (renderMode === 'final-action') {
-    if (!courseReady || status === 'checking') return null;
+    if (status === 'checking' || (!courseReady && status !== 'enrolled')) return null;
 
     if (status === 'enrolled') {
       return (
         <Button asChild>
-          <Link href={`/courses/${courseSlug}/learn`}>เข้าเรียน / เรียนต่อ</Link>
+          <Link href={decisionFacts.actions.learner.href!}>{decisionFacts.actions.learner.label}</Link>
         </Button>
       );
     }
 
     return (
       <Button asChild>
-        <a href="#course-action">{price === 0 ? 'ลงทะเบียนเรียนฟรี' : 'สมัครคอร์สนี้'}</a>
+        <a href="#course-action">{decisionFacts.actions.member.label}</a>
       </Button>
     );
   }

--- a/src/lib/course-decision-facts.ts
+++ b/src/lib/course-decision-facts.ts
@@ -1,0 +1,196 @@
+export type CourseActorState = 'visitor' | 'member' | 'buyer' | 'learner';
+
+type LinkedCourseActionDescriptor = {
+  kind: 'view-details' | 'review-payment' | 'continue-learning';
+  label: string;
+  href: string;
+};
+
+type CourseAcquisitionActionDescriptor = {
+  kind: 'enroll-free' | 'start-checkout' | 'unavailable';
+  label: string;
+  href: null;
+};
+
+export type CourseActionDescriptor =
+  | LinkedCourseActionDescriptor
+  | CourseAcquisitionActionDescriptor;
+
+export type VerifiedCourseReviewSummary = {
+  average: number | string;
+  count: number;
+};
+
+export type CourseDecisionSource = {
+  slug: string;
+  regularPrice: number | string;
+  promotion?: {
+    price: number | string;
+    startsAt?: Date | null;
+    endsAt?: Date | null;
+  } | null;
+  lessonCount: number;
+  knownDurationSeconds?: number | null;
+  freePreviewCount?: number | null;
+  instructor?: { name: string | null } | null;
+  verifiedReview?: VerifiedCourseReviewSummary | null;
+};
+
+export type CourseDecisionFacts = {
+  readiness: 'ready' | 'preparing';
+  price: {
+    regular: number;
+    effective: number;
+    regularFormatted: string;
+    effectiveFormatted: string;
+    isFree: boolean;
+    discountPercent: number | null;
+  };
+  promotion: {
+    status: 'none' | 'future' | 'active' | 'expired' | 'inactive';
+    isActive: boolean;
+    endsAt: string | null;
+    label: string | null;
+  };
+  evidence: {
+    lessonCount: number;
+    knownDurationSeconds: number | null;
+    freePreviewCount: number;
+    instructorName: string | null;
+    verifiedReview: { average: number; count: number } | null;
+  };
+  actions: {
+    discovery: LinkedCourseActionDescriptor;
+    visitor: CourseAcquisitionActionDescriptor;
+    member: CourseAcquisitionActionDescriptor;
+    buyer: LinkedCourseActionDescriptor;
+    learner: LinkedCourseActionDescriptor;
+  };
+};
+
+const thbFormatter = new Intl.NumberFormat('th-TH', {
+  style: 'currency',
+  currency: 'THB',
+  maximumFractionDigits: 0,
+});
+
+function toNonNegativeAmount(value: number | string): number {
+  const amount = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new TypeError('Course decision facts require a valid non-negative price');
+  }
+  return amount;
+}
+
+function toCount(value: number | null | undefined): number {
+  return Number.isFinite(value) && Number(value) > 0 ? Math.floor(Number(value)) : 0;
+}
+
+function toTimestamp(value: Date | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = value.getTime();
+  return Number.isFinite(timestamp) ? timestamp : Number.NaN;
+}
+
+function toIsoString(value: Date | null | undefined): string | null {
+  const timestamp = toTimestamp(value);
+  return timestamp !== null && Number.isFinite(timestamp)
+    ? new Date(timestamp).toISOString()
+    : null;
+}
+
+function getPromotionStatus(
+  promotion: CourseDecisionSource['promotion'],
+  nowTimestamp: number,
+): CourseDecisionFacts['promotion']['status'] {
+  if (!promotion) return 'none';
+
+  const startsAt = toTimestamp(promotion.startsAt);
+  const endsAt = toTimestamp(promotion.endsAt);
+  if (
+    (startsAt !== null && !Number.isFinite(startsAt)) ||
+    (endsAt !== null && !Number.isFinite(endsAt))
+  ) {
+    return 'inactive';
+  }
+  if (endsAt !== null && endsAt < nowTimestamp) return 'expired';
+  if (startsAt !== null && startsAt > nowTimestamp) return 'future';
+  return 'active';
+}
+
+function getVerifiedReview(
+  review: VerifiedCourseReviewSummary | null | undefined,
+): CourseDecisionFacts['evidence']['verifiedReview'] {
+  if (!review) return null;
+  const average = typeof review.average === 'number' ? review.average : Number(review.average);
+  const count = toCount(review.count);
+  if (!Number.isFinite(average) || average < 1 || average > 5 || count === 0) return null;
+  return { average, count };
+}
+
+function unavailableAction(): CourseAcquisitionActionDescriptor {
+  return { kind: 'unavailable', label: 'ยังไม่เปิดรับสมัคร', href: null };
+}
+
+export function deriveCourseDecisionFacts(
+  source: CourseDecisionSource,
+  options: { now: Date },
+): CourseDecisionFacts {
+  const regularPrice = toNonNegativeAmount(source.regularPrice);
+  const nowTimestamp = options.now.getTime();
+  if (!Number.isFinite(nowTimestamp)) {
+    throw new TypeError('Course decision facts require a valid current time');
+  }
+
+  const promotionStatus = getPromotionStatus(source.promotion, nowTimestamp);
+  const isPromotionActive = promotionStatus === 'active';
+  const effectivePrice = isPromotionActive && source.promotion
+    ? toNonNegativeAmount(source.promotion.price)
+    : regularPrice;
+  const discountPercent =
+    isPromotionActive && regularPrice > 0 && effectivePrice < regularPrice
+      ? Math.round((1 - effectivePrice / regularPrice) * 100)
+      : null;
+  const promotionEndsAt = isPromotionActive ? toIsoString(source.promotion?.endsAt) : null;
+  const lessonCount = toCount(source.lessonCount);
+  const readiness = lessonCount > 0 ? 'ready' : 'preparing';
+  const courseHref = `/courses/${source.slug}`;
+  const unavailable = unavailableAction();
+  const acquisitionAction: CourseAcquisitionActionDescriptor = effectivePrice === 0
+    ? { kind: 'enroll-free', label: 'ลงทะเบียนเรียนฟรี', href: null }
+    : { kind: 'start-checkout', label: 'สมัครคอร์สนี้', href: null };
+
+  return {
+    readiness,
+    price: {
+      regular: regularPrice,
+      effective: effectivePrice,
+      regularFormatted: thbFormatter.format(regularPrice),
+      effectiveFormatted: thbFormatter.format(effectivePrice),
+      isFree: effectivePrice === 0,
+      discountPercent,
+    },
+    promotion: {
+      status: promotionStatus,
+      isActive: isPromotionActive,
+      endsAt: promotionEndsAt,
+      label: discountPercent === null
+        ? null
+        : `โปรโมชั่น ลด ${discountPercent}%${promotionEndsAt ? ` ถึง ${new Date(promotionEndsAt).toLocaleDateString('th-TH', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Asia/Bangkok' })}` : ''}`,
+    },
+    evidence: {
+      lessonCount,
+      knownDurationSeconds: toCount(source.knownDurationSeconds) || null,
+      freePreviewCount: Math.min(toCount(source.freePreviewCount), lessonCount),
+      instructorName: source.instructor?.name?.trim() || null,
+      verifiedReview: getVerifiedReview(source.verifiedReview),
+    },
+    actions: {
+      discovery: { kind: 'view-details', label: 'ดูรายละเอียด', href: courseHref },
+      visitor: readiness === 'ready' ? acquisitionAction : unavailable,
+      member: readiness === 'ready' ? acquisitionAction : unavailable,
+      buyer: { kind: 'review-payment', label: 'ตรวจสอบการชำระเงิน', href: '/dashboard/payments' },
+      learner: { kind: 'continue-learning', label: 'เข้าเรียน / เรียนต่อ', href: `${courseHref}/learn` },
+    },
+  };
+}

--- a/tests/components/course-card.test.tsx
+++ b/tests/components/course-card.test.tsx
@@ -1,6 +1,21 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 import CourseCard from '@/components/course/CourseCard';
+import {
+  deriveCourseDecisionFacts,
+  type CourseDecisionSource,
+} from '@/lib/course-decision-facts';
+
+const NOW = new Date('2026-09-01T05:00:00.000Z');
+
+function decisionFacts(overrides: Partial<CourseDecisionSource> = {}) {
+  return deriveCourseDecisionFacts({
+    slug: 'react-nextjs-masterclass',
+    regularPrice: 1990,
+    lessonCount: 12,
+    ...overrides,
+  }, { now: NOW });
+}
 
 const baseProps = {
   id: 'course-1',
@@ -8,19 +23,20 @@ const baseProps = {
   slug: 'react-nextjs-masterclass',
   description: 'สร้างเว็บแอปพลิเคชันจากพื้นฐานไปจนถึงการใช้งานจริง',
   thumbnailUrl: null,
-  price: 1990,
-  instructorName: null,
-  lessonCount: 12,
+  decisionFacts: decisionFacts(),
 } as const;
 
-describe('CourseCard decision evidence', () => {
+describe('shared Home and Catalog CourseCard decision evidence', () => {
   it('renders truthful optional metadata and keeps one course link', () => {
     const html = renderToStaticMarkup(
       <CourseCard
         {...baseProps}
-        instructorName="Miler"
-        totalDurationSeconds={5460}
-        hasFreePreview
+        decisionFacts={decisionFacts({
+          instructor: { name: 'Miler' },
+          knownDurationSeconds: 5460,
+          freePreviewCount: 1,
+          verifiedReview: { average: 4.8, count: 24 },
+        })}
         tags={[{ id: 'tag-1', name: 'React', slug: 'react' }]}
       />,
     );
@@ -29,7 +45,8 @@ describe('CourseCard decision evidence', () => {
     expect(html).toContain('1 ชม. 31 นาที');
     expect(html).toContain('มีบทเรียนทดลอง');
     expect(html).toContain('สอนโดย Miler');
-    expect(html).toContain('ทดลองฟรี');
+    expect(html).toContain('4.8 · 24 รีวิว');
+    expect(html).toContain('ดูรายละเอียด');
     expect(html.match(/<a\b/g)).toHaveLength(1);
   });
 
@@ -39,7 +56,7 @@ describe('CourseCard decision evidence', () => {
     expect(html).not.toContain('ชม.');
     expect(html).not.toContain('มีบทเรียนทดลอง');
     expect(html).not.toContain('สอนโดย');
-    expect(html).toContain('ดูคอร์ส');
+    expect(html).toContain('ดูรายละเอียด');
   });
 
   it('uses existing course data for missing media without implying a real thumbnail', () => {
@@ -70,8 +87,7 @@ describe('CourseCard decision evidence', () => {
     const html = renderToStaticMarkup(
       <CourseCard
         {...baseProps}
-        promoPrice={1490}
-        isPromoActive
+        decisionFacts={decisionFacts({ promotion: { price: 1490 } })}
       />,
     );
 
@@ -81,9 +97,22 @@ describe('CourseCard decision evidence', () => {
   });
 
   it('uses a restrained free-price treatment', () => {
-    const html = renderToStaticMarkup(<CourseCard {...baseProps} price={0} />);
+    const html = renderToStaticMarkup(
+      <CourseCard {...baseProps} decisionFacts={decisionFacts({ regularPrice: 0 })} />,
+    );
 
     expect(html).toContain('aria-label="ราคา ฟรี"');
     expect(html).toContain('>ฟรี</strong>');
+  });
+
+  it('keeps a preparing course discoverable without presenting an enrollment price', () => {
+    const html = renderToStaticMarkup(
+      <CourseCard {...baseProps} decisionFacts={decisionFacts({ lessonCount: 0 })} />,
+    );
+
+    expect(html).toContain('กำลังเตรียมเนื้อหา');
+    expect(html).toContain('ยังไม่เปิดลงทะเบียน');
+    expect(html).toContain('ดูรายละเอียด');
+    expect(html).not.toContain('aria-label="ราคา');
   });
 });

--- a/tests/components/course-detail-client.test.tsx
+++ b/tests/components/course-detail-client.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
 import CourseDetailClient, { CourseDetailProvider } from '@/components/course/CourseDetailClient';
+import { deriveCourseDecisionFacts } from '@/lib/course-decision-facts';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -13,14 +14,18 @@ vi.mock('next-auth/react', () => ({
 
 describe('course detail enrollment presentation', () => {
   it('does not render a purchase action for a course with no lessons', () => {
+    const decisionFacts = deriveCourseDecisionFacts({
+      slug: 'course-one',
+      regularPrice: 1290,
+      promotion: { price: 990 },
+      lessonCount: 0,
+    }, { now: new Date('2026-09-01T05:00:00.000Z') });
     const html = renderToStaticMarkup(
       <CourseDetailProvider>
         <CourseDetailClient
           courseId="course-1"
           courseSlug="course-one"
-          price={990}
-          originalPrice={1290}
-          courseReady={false}
+          decisionFacts={decisionFacts}
           renderMode="button"
         />
       </CourseDetailProvider>,
@@ -29,5 +34,27 @@ describe('course detail enrollment presentation', () => {
     expect(html).toContain('คอร์สกำลังเตรียมเนื้อหา');
     expect(html).toContain('ยังไม่เปิดรับสมัคร');
     expect(html).not.toContain('฿990');
+  });
+
+  it('keeps the learning recovery action for an already enrolled learner', () => {
+    const decisionFacts = deriveCourseDecisionFacts({
+      slug: 'course-one',
+      regularPrice: 1290,
+      lessonCount: 0,
+    }, { now: new Date('2026-09-01T05:00:00.000Z') });
+    const html = renderToStaticMarkup(
+      <CourseDetailProvider initialStatus="enrolled">
+        <CourseDetailClient
+          courseId="course-1"
+          courseSlug="course-one"
+          decisionFacts={decisionFacts}
+          renderMode="button"
+        />
+      </CourseDetailProvider>,
+    );
+
+    expect(html).toContain('เข้าเรียน / เรียนต่อ');
+    expect(html).toContain('href="/courses/course-one/learn"');
+    expect(html).not.toContain('ยังไม่เปิดรับสมัคร');
   });
 });

--- a/tests/lib/course-decision-facts.test.ts
+++ b/tests/lib/course-decision-facts.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveCourseDecisionFacts } from '@/lib/course-decision-facts';
+
+const NOW = new Date('2026-09-01T05:00:00.000Z');
+
+function courseSource(overrides: Partial<Parameters<typeof deriveCourseDecisionFacts>[0]> = {}) {
+  return {
+    slug: 'typescript-foundations',
+    regularPrice: '1990.00',
+    lessonCount: 12,
+    ...overrides,
+  };
+}
+
+describe('ProductDecisionFacts for Course', () => {
+  it.each([
+    ['exact start', new Date('2026-09-01T05:00:00.000Z'), new Date('2026-09-02T05:00:00.000Z')],
+    ['exact end', new Date('2026-08-31T05:00:00.000Z'), new Date('2026-09-01T05:00:00.000Z')],
+  ])('uses the promotional price at the inclusive %s boundary', (_name, startsAt, endsAt) => {
+    const facts = deriveCourseDecisionFacts(
+      courseSource({ promotion: { price: '1490.00', startsAt, endsAt } }),
+      { now: NOW },
+    );
+
+    expect(facts.promotion.status).toBe('active');
+    expect(facts.price).toMatchObject({
+      regular: 1990,
+      effective: 1490,
+      discountPercent: 25,
+    });
+  });
+
+  it.each([
+    ['future', new Date('2026-09-02T05:00:00.000Z'), null, 'future'],
+    ['expired', null, new Date('2026-08-31T05:00:00.000Z'), 'expired'],
+  ] as const)('ignores a %s promotion', (_name, startsAt, endsAt, status) => {
+    const facts = deriveCourseDecisionFacts(
+      courseSource({ promotion: { price: '1490.00', startsAt, endsAt } }),
+      { now: NOW },
+    );
+
+    expect(facts.promotion.status).toBe(status);
+    expect(facts.price.effective).toBe(1990);
+  });
+
+  it('supports an active promotion that makes the course free', () => {
+    const facts = deriveCourseDecisionFacts(
+      courseSource({ promotion: { price: '0.00' } }),
+      { now: NOW },
+    );
+
+    expect(facts.price).toMatchObject({ effective: 0, isFree: true, discountPercent: 100 });
+    expect(facts.actions.visitor.kind).toBe('enroll-free');
+    expect(facts.actions.member.kind).toBe('enroll-free');
+  });
+
+  it('does not turn an invalid authoritative price into a free-course action', () => {
+    expect(() => deriveCourseDecisionFacts(
+      courseSource({ promotion: { price: 'not-a-price' } }),
+      { now: NOW },
+    )).toThrowError('Course decision facts require a valid non-negative price');
+  });
+
+  it('keeps a zero-lesson course discoverable without a new enrollment or checkout action', () => {
+    const facts = deriveCourseDecisionFacts(courseSource({ lessonCount: 0 }), { now: NOW });
+
+    expect(facts.readiness).toBe('preparing');
+    expect(facts.actions.discovery).toEqual({
+      kind: 'view-details',
+      label: 'ดูรายละเอียด',
+      href: '/courses/typescript-foundations',
+    });
+    expect([
+      facts.actions.visitor.kind,
+      facts.actions.member.kind,
+      facts.actions.buyer.kind,
+      facts.actions.learner.kind,
+    ]).toEqual(['unavailable', 'unavailable', 'review-payment', 'continue-learning']);
+  });
+
+  it('returns state-aware actions without granting access from presentation', () => {
+    const facts = deriveCourseDecisionFacts(courseSource(), { now: NOW });
+
+    expect(facts.actions.visitor).toMatchObject({ kind: 'start-checkout', href: null });
+    expect(facts.actions.member).toMatchObject({ kind: 'start-checkout', href: null });
+    expect(facts.actions.buyer).toEqual({
+      kind: 'review-payment',
+      label: 'ตรวจสอบการชำระเงิน',
+      href: '/dashboard/payments',
+    });
+    expect(facts.actions.learner).toEqual({
+      kind: 'continue-learning',
+      label: 'เข้าเรียน / เรียนต่อ',
+      href: '/courses/typescript-foundations/learn',
+    });
+  });
+
+  it('includes only explicit linked instructor and verified review evidence', () => {
+    const facts = deriveCourseDecisionFacts(
+      courseSource({
+        instructor: { name: '  Miler  ' },
+        verifiedReview: { average: '4.8', count: 24 },
+      }),
+      { now: NOW },
+    );
+    const missingEvidence = deriveCourseDecisionFacts(
+      courseSource({
+        instructor: { name: '   ' },
+        verifiedReview: { average: 5, count: 0 },
+      }),
+      { now: NOW },
+    );
+
+    expect(facts.evidence.instructorName).toBe('Miler');
+    expect(facts.evidence.verifiedReview).toEqual({ average: 4.8, count: 24 });
+    expect(missingEvidence.evidence.instructorName).toBeNull();
+    expect(missingEvidence.evidence.verifiedReview).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add one pure CourseDecisionFacts interface for effective price, promotion boundaries, readiness, verified evidence, and actor-aware actions
- migrate the shared Home/Catalog CourseCard and Course Detail presentation to consume the same facts
- keep zero-lesson courses discoverable while blocking new acquisition, without removing buyer recovery or learner continuation

## Verification
- npm run test -- --run: 132 files, 800 tests passed
- npm run lint: passed
- npx tsc --noEmit: passed
- npm run build: passed, 93 routes
- git diff --check: passed

## Risk
- no schema or migration changes
- no payment, enrollment, coupon, webhook, or fulfillment authority changes

Closes #36