### PR TITLE
feat(bundles): centralize decision facts

### DIFF
--- a/src/app/bundles/[slug]/page.tsx
+++ b/src/app/bundles/[slug]/page.tsx
@@ -5,12 +5,13 @@ import BundleEnrollButton from '@/components/bundle/BundleEnrollButton';
 import Footer from '@/components/layout/Footer';
 import Navbar from '@/components/layout/Navbar';
 import { auth } from '@/lib/auth';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
 import { db } from '@/lib/db';
 import { bundleCourses, bundles, courses, enrollments, lessons } from '@/lib/db/schema';
 import { getExcerpt } from '@/lib/sanitize';
 import { requirePublishedBundleCourses } from '@/lib/bundle-commerce';
 import { absoluteUrl, serializeJsonLd, SITE_URL } from '@/lib/seo';
-import { and, asc, count, eq } from 'drizzle-orm';
+import { and, asc, count, eq, inArray } from 'drizzle-orm';
 import AnalyticsViewEvent from '@/components/analytics/AnalyticsViewEvent';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
@@ -43,6 +44,9 @@ async function getBundle(slug: string) {
       courseTitle: courses.title,
       courseSlug: courses.slug,
       coursePrice: courses.price,
+      coursePromoPrice: courses.promoPrice,
+      coursePromoStartsAt: courses.promoStartsAt,
+      coursePromoEndsAt: courses.promoEndsAt,
       courseThumbnail: courses.thumbnailUrl,
       courseDescription: courses.description,
       courseStatus: courses.status,
@@ -71,30 +75,47 @@ async function getBundle(slug: string) {
     }),
   );
 
-  const totalOriginalPrice = coursesWithLessons.reduce(
-    (sum, course) => sum + parseFloat(course.coursePrice || '0'),
-    0,
-  );
-
   return {
     ...bundle,
     courses: coursesWithLessons,
-    courseCount: coursesWithLessons.length,
-    totalOriginalPrice,
-    discount: totalOriginalPrice > 0
-      ? Math.round((1 - parseFloat(bundle.price) / totalOriginalPrice) * 100)
-      : 0,
   };
+}
+
+function getBundleDecisionFacts(
+  bundle: NonNullable<Awaited<ReturnType<typeof getBundle>>>,
+  options: { now: Date; ownedCourseIds?: ReadonlySet<string> },
+) {
+  return deriveBundleDecisionFacts({
+    slug: bundle.slug,
+    price: bundle.price,
+    courses: bundle.courses.map((course) => ({
+      id: course.courseId,
+      title: course.courseTitle,
+      slug: course.courseSlug,
+      orderIndex: course.orderIndex,
+      regularPrice: course.coursePrice,
+      promotion: course.coursePromoPrice === null
+        ? null
+        : {
+            price: course.coursePromoPrice,
+            startsAt: course.coursePromoStartsAt,
+            endsAt: course.coursePromoEndsAt,
+          },
+      lessonCount: course.lessonCount,
+      owned: options.ownedCourseIds?.has(course.courseId) ?? false,
+    })),
+  }, { now: options.now });
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const bundle = await getBundle(slug);
   if (!bundle) return { title: 'ไม่พบ Bundle' };
+  const decisionFacts = getBundleDecisionFacts(bundle, { now: new Date() });
 
   const description = bundle.description
     ? getExcerpt(bundle.description, 160)
-    : `รวม ${bundle.courseCount} คอร์สในราคาพิเศษ ลด ${bundle.discount}%`;
+    : `รวม ${decisionFacts.evidence.courseCount} คอร์สในชุดเดียว ${decisionFacts.price.comparison.label}`;
   const thumbnailUrl = normalizeUrl(bundle.thumbnailUrl);
 
   return {
@@ -126,13 +147,23 @@ export default async function BundleDetailPage({ params }: Props) {
 
   if (!bundle) notFound();
 
-  const bundlePrice = parseFloat(bundle.price);
-  const savings = bundle.totalOriginalPrice - bundlePrice;
-  const totalLessons = bundle.courses.reduce((sum, course) => sum + course.lessonCount, 0);
-  const bundleReady = bundle.courses.length > 0 && bundle.courses.every((course) => course.lessonCount > 0);
+  const session = await auth();
+  let ownedCourseIds = new Set<string>();
+  if (session?.user && bundle.courses.length > 0) {
+    const enrollmentRows = await db
+      .select({ courseId: enrollments.courseId })
+      .from(enrollments)
+      .where(and(
+        eq(enrollments.userId, session.user.id),
+        inArray(enrollments.courseId, bundle.courses.map((course) => course.courseId)),
+      ));
+    ownedCourseIds = new Set(enrollmentRows.map((enrollment) => enrollment.courseId));
+  }
+  const decisionFacts = getBundleDecisionFacts(bundle, { now: new Date(), ownedCourseIds });
+  const courseContentById = new Map(bundle.courses.map((course) => [course.courseId, course]));
   const bundleDescription = bundle.description
     ? getExcerpt(bundle.description, 160)
-    : `รวม ${bundle.courseCount} คอร์สในราคาพิเศษ ลด ${bundle.discount}%`;
+    : `รวม ${decisionFacts.evidence.courseCount} คอร์สในชุดเดียว ${decisionFacts.price.comparison.label}`;
   const bundleThumbnailUrl = normalizeUrl(bundle.thumbnailUrl);
   const productJsonLd = {
     '@context': 'https://schema.org',
@@ -146,15 +177,15 @@ export default async function BundleDetailPage({ params }: Props) {
     brand: { '@id': `${SITE_URL}/#organization` },
     offers: {
       '@type': 'Offer',
-      price: bundle.price,
+      price: decisionFacts.price.bundle,
       priceCurrency: 'THB',
-      availability: bundleReady ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
+      availability: decisionFacts.readiness === 'ready' ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
       url: absoluteUrl(`/bundles/${slug}`),
     },
-    hasPart: bundle.courses.map((course) => ({
+    hasPart: decisionFacts.courses.map((course) => ({
       '@type': 'Course',
-      name: course.courseTitle,
-      url: absoluteUrl(`/courses/${course.courseSlug}`),
+      name: course.title,
+      url: absoluteUrl(`/courses/${course.slug}`),
     })),
   };
   const breadcrumbJsonLd = {
@@ -166,25 +197,6 @@ export default async function BundleDetailPage({ params }: Props) {
       { '@type': 'ListItem', position: 3, name: bundle.title, item: absoluteUrl(`/bundles/${slug}`) },
     ],
   };
-
-  let allEnrolled = false;
-  const session = await auth();
-  if (session?.user) {
-    const checks = await Promise.all(
-      bundle.courses.map(async (course) => {
-        const [enrollment] = await db
-          .select()
-          .from(enrollments)
-          .where(and(
-            eq(enrollments.userId, session.user.id),
-            eq(enrollments.courseId, course.courseId),
-          ))
-          .limit(1);
-        return !!enrollment;
-      }),
-    );
-    allEnrolled = checks.every(Boolean);
-  }
 
   return (
     <>
@@ -205,7 +217,7 @@ export default async function BundleDetailPage({ params }: Props) {
 
             <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_28rem] lg:items-end">
               <div>
-                <Badge variant="outline">LEARNING PATH / {String(bundle.courseCount).padStart(2, '0')} COURSES</Badge>
+                <Badge variant="outline">LEARNING PATH / {String(decisionFacts.evidence.courseCount).padStart(2, '0')} COURSES</Badge>
                 <h1 className="mt-5 max-w-4xl text-4xl font-bold tracking-tight sm:text-5xl">{bundle.title}</h1>
                 {bundle.description ? <p className="mt-5 max-w-3xl text-lg leading-8 text-muted-foreground">{bundle.description}</p> : null}
               </div>
@@ -213,19 +225,23 @@ export default async function BundleDetailPage({ params }: Props) {
               <dl className="grid grid-cols-2 gap-3" aria-label={'ข้อมูลชุดคอร์ส'}>
                 <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
                   <dt className="text-sm text-muted-foreground">คอร์ส</dt>
-                  <dd className="text-lg font-semibold">{bundle.courseCount}</dd>
+                  <dd className="text-lg font-semibold">{decisionFacts.evidence.courseCount}</dd>
                 </div>
                 <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
                   <dt className="text-sm text-muted-foreground">บทเรียน</dt>
-                  <dd className="text-lg font-semibold">{totalLessons}</dd>
+                  <dd className="text-lg font-semibold">{decisionFacts.evidence.totalLessons}</dd>
                 </div>
                 <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
                   <dt className="text-sm text-muted-foreground">ราคาชุด</dt>
-                  <dd className="text-lg font-semibold">{bundlePrice === 0 ? 'ฟรี' : `฿${bundlePrice.toLocaleString()}`}</dd>
+                  <dd className="text-lg font-semibold">{decisionFacts.price.isFree ? 'ฟรี' : decisionFacts.price.bundleFormatted}</dd>
                 </div>
                 <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
-                  <dt className="text-sm text-muted-foreground">ส่วนลด</dt>
-                  <dd className="text-lg font-semibold">{bundle.discount > 0 ? `${bundle.discount}%` : '—'}</dd>
+                  <dt className="text-sm text-muted-foreground">เทียบซื้อแยกวันนี้</dt>
+                  <dd className="text-lg font-semibold">
+                    {decisionFacts.price.comparison.kind === 'savings'
+                      ? `${decisionFacts.price.comparison.percent}%`
+                      : decisionFacts.price.comparison.kind === 'equal' ? 'เท่ากัน' : 'ซื้อแยกถูกกว่า'}
+                  </dd>
                 </div>
               </dl>
             </div>
@@ -243,12 +259,13 @@ export default async function BundleDetailPage({ params }: Props) {
               </div>
 
               <ol className="grid gap-5">
-                {bundle.courses.map((course, index) => {
-                  const thumbnail = normalizeUrl(course.courseThumbnail);
+                {decisionFacts.courses.map((course, index) => {
+                  const courseContent = courseContentById.get(course.id);
+                  const thumbnail = normalizeUrl(courseContent?.courseThumbnail ?? null);
                   return (
-                    <li key={course.courseId}>
+                    <li key={course.id}>
                       <Card className="overflow-hidden transition hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md">
-                      <Link className="grid sm:grid-cols-[12rem_minmax(0,1fr)]" href={`/courses/${course.courseSlug}`}>
+                      <Link className="grid sm:grid-cols-[12rem_minmax(0,1fr)]" href={`/courses/${course.slug}`}>
                         <div
                           className="flex min-h-40 items-start bg-slate-900 bg-cover bg-center p-4"
                           style={thumbnail ? { backgroundImage: `url(${thumbnail})` } : undefined}
@@ -261,12 +278,15 @@ export default async function BundleDetailPage({ params }: Props) {
                             <span>คอร์สที่ {index + 1}</span>
                             <span>{course.lessonCount} บทเรียน</span>
                           </div>
-                          <h3 className="text-xl font-semibold tracking-tight">{course.courseTitle}</h3>
-                          {course.courseDescription ? (
-                            <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">{getExcerpt(course.courseDescription, 120)}</p>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-xl font-semibold tracking-tight">{course.title}</h3>
+                            {course.owned ? <Badge variant="secondary">มีสิทธิ์เรียนแล้ว</Badge> : null}
+                          </div>
+                          {courseContent?.courseDescription ? (
+                            <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">{getExcerpt(courseContent.courseDescription, 120)}</p>
                           ) : null}
                           <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t pt-4 text-sm">
-                            <span>ราคาปกติ ฿{parseFloat(course.coursePrice).toLocaleString()}</span>
+                            <span>ซื้อแยกวันนี้ {course.price.effectiveFormatted}</span>
                             <strong>ดูรายละเอียด <span aria-hidden={true}>→</span></strong>
                           </div>
                         </div>
@@ -286,28 +306,30 @@ export default async function BundleDetailPage({ params }: Props) {
                 <CardContent className="flex flex-col gap-6">
                 <div className="rounded-lg bg-muted p-5">
                   <span className="text-sm text-muted-foreground">ราคาชุดคอร์ส</span>
-                  <strong className="mt-1 block text-3xl tracking-tight">{bundlePrice === 0 ? 'ฟรี' : `฿${bundlePrice.toLocaleString()}`}</strong>
-                  {bundle.totalOriginalPrice > bundlePrice ? (
-                    <p className="mt-2 grid gap-1 text-sm">
-                      <span className="text-muted-foreground line-through">จาก ฿{bundle.totalOriginalPrice.toLocaleString()}</span>
-                      <b className="text-primary">ประหยัด ฿{savings.toLocaleString()} ({bundle.discount}%)</b>
-                    </p>
-                  ) : null}
+                  <strong className="mt-1 block text-3xl tracking-tight">{decisionFacts.price.isFree ? 'ฟรี' : decisionFacts.price.bundleFormatted}</strong>
+                  <p className="mt-2 flex flex-col gap-1 text-sm">
+                    <span className="text-muted-foreground">ซื้อแยกวันนี้ {decisionFacts.price.separateCurrentFormatted}</span>
+                    <b className={decisionFacts.price.comparison.kind === 'savings' ? 'text-primary' : undefined}>
+                      {decisionFacts.price.comparison.label}
+                    </b>
+                  </p>
                 </div>
 
                 <dl className="grid gap-3 text-sm [&_div]:flex [&_div]:justify-between [&_div]:gap-4 [&_dt]:text-muted-foreground [&_dd]:font-medium">
-                  <div><dt>คอร์สทั้งหมด</dt><dd>{bundle.courseCount} คอร์ส</dd></div>
-                  <div><dt>เนื้อหาทั้งหมด</dt><dd>{totalLessons} บทเรียน</dd></div>
+                  <div><dt>คอร์สทั้งหมด</dt><dd>{decisionFacts.evidence.courseCount} คอร์ส</dd></div>
+                  <div><dt>เนื้อหาทั้งหมด</dt><dd>{decisionFacts.evidence.totalLessons} บทเรียน</dd></div>
                   <div><dt>Certificate</dt><dd>ทุกคอร์ส</dd></div>
                   <div><dt>การเข้าถึง</dt><dd>ตลอดชีพ</dd></div>
                 </dl>
 
                 <BundleEnrollButton
                   bundleId={bundle.id}
-                  price={bundlePrice}
                   bundleSlug={bundle.slug}
-                  allEnrolled={allEnrolled}
-                  available={bundleReady}
+                  decisionFacts={{
+                    price: decisionFacts.price,
+                    ownership: decisionFacts.ownership,
+                    actions: decisionFacts.actions,
+                  }}
                 />
                 </CardContent>
                 <CardFooter><p className="text-xs leading-5 text-muted-foreground">ตรวจสอบคอร์สและยอดชำระก่อนยืนยัน ระบบจะเปิดสิทธิ์หลังการชำระเงินได้รับการตรวจสอบแล้ว</p></CardFooter>

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -2,11 +2,11 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
+import BundleCard from '@/components/bundle/BundleCard';
 import CourseCard from '@/components/course/CourseCard';
 import CourseCatalogFilters from '@/components/course/CourseCatalogFilters';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Empty,
   EmptyContent,
@@ -16,6 +16,11 @@ import {
 } from '@/components/ui/empty';
 import { db } from '@/lib/db';
 import { bundles, bundleCourses, courses, courseTags, lessons, tags, users } from '@/lib/db/schema';
+import {
+  deriveBundleDecisionFacts,
+  type BundleCourseDecisionSource,
+  type BundleDecisionFacts,
+} from '@/lib/bundle-decision-facts';
 import { deriveCourseDecisionFacts, type CourseDecisionFacts } from '@/lib/course-decision-facts';
 import { and, asc, count, desc, eq, gt, like, sql } from 'drizzle-orm';
 
@@ -52,13 +57,8 @@ interface CourseListItem {
 interface BundleItem {
   id: string;
   title: string;
-  slug: string;
   description: string | null;
-  price: string;
-  courseCount: number;
-  totalOriginalPrice: number;
-  discount: number;
-  courses: { courseTitle: string }[];
+  decisionFacts: BundleDecisionFacts;
 }
 
 function getSingleParam(value: string | string[] | undefined): string {
@@ -103,6 +103,14 @@ async function getAllTags(): Promise<Tag[]> {
 }
 
 async function getPublishedBundles(): Promise<BundleItem[]> {
+  const lessonStatsSubquery = db
+    .select({
+      courseId: lessons.courseId,
+      lessonCount: count().as('bundle_lesson_count'),
+    })
+    .from(lessons)
+    .groupBy(lessons.courseId)
+    .as('bundle_lesson_stats');
   const rows = await db
     .select({
       id: bundles.id,
@@ -111,13 +119,20 @@ async function getPublishedBundles(): Promise<BundleItem[]> {
       description: bundles.description,
       price: bundles.price,
       createdAt: bundles.createdAt,
+      courseId: courses.id,
       courseTitle: courses.title,
+      courseSlug: courses.slug,
       coursePrice: courses.price,
+      coursePromoPrice: courses.promoPrice,
+      coursePromoStartsAt: courses.promoStartsAt,
+      coursePromoEndsAt: courses.promoEndsAt,
+      courseLessonCount: sql<number>`COALESCE(${lessonStatsSubquery.lessonCount}, 0)`.as('bundle_course_lesson_count'),
       orderIndex: bundleCourses.orderIndex,
     })
     .from(bundles)
     .leftJoin(bundleCourses, eq(bundles.id, bundleCourses.bundleId))
     .leftJoin(courses, eq(bundleCourses.courseId, courses.id))
+    .leftJoin(lessonStatsSubquery, eq(courses.id, lessonStatsSubquery.courseId))
     .where(eq(bundles.status, 'published'))
     .orderBy(asc(bundles.createdAt), asc(bundleCourses.orderIndex));
 
@@ -127,8 +142,7 @@ async function getPublishedBundles(): Promise<BundleItem[]> {
     slug: string;
     description: string | null;
     price: string;
-    courses: { courseTitle: string }[];
-    totalOriginalPrice: number;
+    courses: BundleCourseDecisionSource[];
   }>();
 
   for (const row of rows) {
@@ -139,23 +153,44 @@ async function getPublishedBundles(): Promise<BundleItem[]> {
       description: row.description,
       price: row.price,
       courses: [],
-      totalOriginalPrice: 0,
     };
 
-    if (row.courseTitle) {
-      existing.courses.push({ courseTitle: row.courseTitle });
-      existing.totalOriginalPrice += parseFloat(row.coursePrice || '0');
+    if (
+      row.courseId
+      && row.courseTitle
+      && row.courseSlug
+      && row.coursePrice !== null
+    ) {
+      existing.courses.push({
+        id: row.courseId,
+        title: row.courseTitle,
+        slug: row.courseSlug,
+        orderIndex: row.orderIndex,
+        regularPrice: row.coursePrice,
+        promotion: row.coursePromoPrice === null
+          ? null
+          : {
+              price: row.coursePromoPrice,
+              startsAt: row.coursePromoStartsAt,
+              endsAt: row.coursePromoEndsAt,
+            },
+        lessonCount: Number(row.courseLessonCount) || 0,
+      });
     }
 
     bundleMap.set(row.id, existing);
   }
 
+  const now = new Date();
   return Array.from(bundleMap.values()).map((bundle) => ({
-    ...bundle,
-    courseCount: bundle.courses.length,
-    discount: bundle.totalOriginalPrice > 0
-      ? Math.round((1 - parseFloat(bundle.price) / bundle.totalOriginalPrice) * 100)
-      : 0,
+    id: bundle.id,
+    title: bundle.title,
+    description: bundle.description,
+    decisionFacts: deriveBundleDecisionFacts({
+      slug: bundle.slug,
+      price: bundle.price,
+      courses: bundle.courses,
+    }, { now }),
   }));
 }
 
@@ -385,7 +420,16 @@ export default async function CoursesPage({ searchParams }: Props) {
           <section className="border-t bg-background py-14 sm:py-20" aria-labelledby="courses-bundles-title">
             <div className="container">
               <header className="mb-8 grid gap-4 md:grid-cols-[1fr_auto] md:items-end"><div><h2 id="courses-bundles-title" className="text-3xl font-semibold tracking-[-.03em] sm:text-4xl">ถ้าอยากเรียนต่อเนื่อง ลองดูแบบชุด</h2><p className="mt-2 text-sm leading-6 text-muted-foreground">รวมคอร์สที่ต่อเนื่องกันไว้ในเส้นทางเดียว พร้อมราคาที่เปรียบเทียบได้ชัดเจน</p></div><Badge variant="secondary">{bundlesList.length} เส้นทาง</Badge></header>
-              <div className="grid gap-5 lg:grid-cols-2">{bundlesList.map((bundle) => <Link key={bundle.id} href={`/bundles/${bundle.slug}`} className="group rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30"><Card className="h-full"><CardHeader><div className="flex items-center justify-between gap-3"><Badge>Bundle · {bundle.courseCount} คอร์ส</Badge>{bundle.discount > 0 ? <Badge variant="destructive">ประหยัด {bundle.discount}%</Badge> : null}</div><CardTitle className="mt-3 text-2xl group-hover:text-primary">{bundle.title}</CardTitle>{bundle.description ? <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">{bundle.description}</p> : null}</CardHeader><CardContent><div className="flex flex-col gap-2 border-y py-4 text-sm">{bundle.courses.slice(0, 2).map((course, index) => <p key={`${bundle.id}-${index}`}>{String(index + 1).padStart(2, '0')} · {course.courseTitle}</p>)}{bundle.courses.length > 2 ? <p className="text-muted-foreground">+{bundle.courses.length - 2} คอร์ส</p> : null}</div><div className="mt-5 flex items-end justify-between gap-4"><div><strong className="text-2xl">฿{parseFloat(bundle.price).toLocaleString()}</strong><s className="ml-2 text-sm text-muted-foreground">฿{bundle.totalOriginalPrice.toLocaleString()}</s></div><span className="text-sm font-semibold text-primary">ดูรายละเอียด →</span></div></CardContent></Card></Link>)}</div>
+              <div className="grid gap-5 lg:grid-cols-2">
+                {bundlesList.map((bundle) => (
+                  <BundleCard
+                    key={bundle.id}
+                    title={bundle.title}
+                    description={bundle.description}
+                    decisionFacts={bundle.decisionFacts}
+                  />
+                ))}
+              </div>
             </div>
           </section>
         ) : null}

--- a/src/components/bundle/BundleCard.tsx
+++ b/src/components/bundle/BundleCard.tsx
@@ -1,0 +1,64 @@
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import type { BundleDecisionFacts } from '@/lib/bundle-decision-facts';
+
+type BundleCardProps = {
+  title: string;
+  description: string | null;
+  decisionFacts: BundleDecisionFacts;
+};
+
+export default function BundleCard({ title, description, decisionFacts }: BundleCardProps) {
+  const { comparison } = decisionFacts.price;
+
+  return (
+    <Link
+      href={decisionFacts.actions.discovery.href}
+      className="group block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30"
+    >
+      <Card className="h-full">
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Badge>Bundle · {decisionFacts.evidence.courseCount} คอร์ส</Badge>
+            {decisionFacts.readiness === 'preparing' ? (
+              <Badge variant="secondary">กำลังเตรียมเนื้อหา</Badge>
+            ) : (
+              <Badge variant={comparison.kind === 'savings' ? 'destructive' : 'outline'}>
+                {comparison.label}
+              </Badge>
+            )}
+          </div>
+          <CardTitle className="mt-3 text-2xl group-hover:text-primary">{title}</CardTitle>
+          {description ? (
+            <p className="line-clamp-2 text-sm leading-6 text-muted-foreground">{description}</p>
+          ) : null}
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-2 border-y py-4 text-sm">
+            {decisionFacts.courses.slice(0, 2).map((course, index) => (
+              <p key={course.id}>{String(index + 1).padStart(2, '0')} · {course.title}</p>
+            ))}
+            {decisionFacts.courses.length > 2 ? (
+              <p className="text-muted-foreground">+{decisionFacts.courses.length - 2} คอร์ส</p>
+            ) : null}
+          </div>
+        </CardContent>
+        <CardFooter className="flex-wrap justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <strong className="text-2xl">
+              {decisionFacts.price.isFree ? 'ฟรี' : decisionFacts.price.bundleFormatted}
+            </strong>
+            <span className="text-xs text-muted-foreground">
+              ซื้อแยกวันนี้ {decisionFacts.price.separateCurrentFormatted}
+            </span>
+          </div>
+          <span className="text-sm font-semibold text-primary">
+            {decisionFacts.actions.discovery.label} <span aria-hidden="true">→</span>
+          </span>
+        </CardFooter>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/bundle/BundleEnrollButton.tsx
+++ b/src/components/bundle/BundleEnrollButton.tsx
@@ -18,13 +18,17 @@ import { Spinner } from '@/components/ui/spinner';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { trackClientAnalyticsEvent } from '@/components/analytics/analytics-client';
 import { useProductExposureId } from '@/components/analytics/AnalyticsViewEvent';
+import type { BundleDecisionFacts } from '@/lib/bundle-decision-facts';
+
+type BundleEnrollmentDecisionFacts = Pick<
+  BundleDecisionFacts,
+  'price' | 'ownership' | 'actions'
+>;
 
 interface BundleEnrollButtonProps {
   bundleId: string;
-  price: number;
   bundleSlug: string;
-  allEnrolled?: boolean;
-  available?: boolean;
+  decisionFacts: BundleEnrollmentDecisionFacts;
 }
 
 type PaymentStep = 'idle' | 'method' | 'transfer' | 'verifying';
@@ -44,11 +48,10 @@ export const BUNDLE_PAYMENT_CONTRACT = {
 
 export default function BundleEnrollButton({
   bundleId,
-  price,
   bundleSlug,
-  allEnrolled = false,
-  available = true,
+  decisionFacts,
 }: BundleEnrollButtonProps) {
+  const price = decisionFacts.price.bundle;
   const router = useRouter();
   const session = useSession()?.data;
   const exposureId = useProductExposureId();
@@ -255,34 +258,48 @@ export default function BundleEnrollButton({
     resetSlipState();
   };
 
-  if (enrolled || allEnrolled) {
+  const renderOwnershipNotice = () => decisionFacts.ownership.disclosure ? (
+    <Alert>
+      <CircleAlert aria-hidden="true" />
+      <AlertTitle>มีบางคอร์สอยู่ในบัญชีแล้ว</AlertTitle>
+      <AlertDescription>{decisionFacts.ownership.disclosure}</AlertDescription>
+    </Alert>
+  ) : null;
+
+  if (enrolled || decisionFacts.ownership.status === 'complete') {
     return (
       <Button asChild className="w-full">
-        <Link href="/dashboard">
+        <Link href={decisionFacts.actions.complete.href}>
           <CircleCheck data-icon="inline-start" aria-hidden="true" />
-          ลงทะเบียนครบแล้ว — เข้าเรียน
+          {decisionFacts.actions.complete.label}
         </Link>
       </Button>
     );
   }
 
-  if (!available) {
+  if (decisionFacts.actions.acquisition.kind === 'unavailable') {
     return (
-      <Empty className="border">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <CircleAlert aria-hidden="true" />
-          </EmptyMedia>
-          <EmptyTitle>Bundle นี้กำลังเตรียมเนื้อหา</EmptyTitle>
-          <EmptyDescription>จะเปิดรับสมัครเมื่อทุกคอร์สใน Bundle มีบทเรียนพร้อมแล้ว</EmptyDescription>
-        </EmptyHeader>
-        <Button type="button" className="w-full" disabled>ยังไม่เปิดรับสมัคร</Button>
-      </Empty>
+      <div className="flex flex-col gap-4">
+        {renderOwnershipNotice()}
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <CircleAlert aria-hidden="true" />
+            </EmptyMedia>
+            <EmptyTitle>Bundle นี้กำลังเตรียมเนื้อหา</EmptyTitle>
+            <EmptyDescription>จะเปิดรับสมัครเมื่อทุกคอร์สใน Bundle มีบทเรียนพร้อมแล้ว</EmptyDescription>
+          </EmptyHeader>
+          <Button type="button" className="w-full" disabled>{decisionFacts.actions.acquisition.label}</Button>
+        </Empty>
+      </div>
     );
   }
 
   return (
     <>
+      {decisionFacts.ownership.disclosure ? (
+        <div className="mb-4">{renderOwnershipNotice()}</div>
+      ) : null}
       <Button
         ref={enrollmentTriggerRef}
         className="w-full"
@@ -294,24 +311,45 @@ export default function BundleEnrollButton({
         {loading && <Spinner data-icon="inline-start" aria-hidden="true" />}
         {loading
           ? 'กำลังดำเนินการ...'
-          : price === 0
-            ? 'ลงทะเบียน Bundle ฟรี'
-            : `ซื้อ Bundle ฿${price.toLocaleString()}`}
+          : decisionFacts.actions.acquisition.label}
       </Button>
 
       <DialogShell
         isOpen={paymentStep === 'method'}
         onClose={() => setPaymentStep('idle')}
         title={'เลือกช่องทางชำระเงิน'}
-        description={<span>ยอดชำระ <strong>฿{price.toLocaleString()}</strong></span>}
+        description={<span>ยอดชำระ <strong>{decisionFacts.price.bundleFormatted}</strong></span>}
         body={(
-          <ToggleGroup
+          <div className="flex flex-col gap-4" data-payment-step="method">
+            <Card size="sm">
+              <CardHeader>
+                <CardTitle>ตรวจสอบรายการ Bundle</CardTitle>
+                <CardDescription>ยอดนี้อ้างอิงราคาซื้อแยกของแต่ละคอร์ส ณ ตอนนี้</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <dl className="grid gap-3 text-sm">
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-muted-foreground">ซื้อแยกวันนี้</dt>
+                    <dd>{decisionFacts.price.separateCurrentFormatted}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-muted-foreground">ราคา Bundle</dt>
+                    <dd><strong>{decisionFacts.price.bundleFormatted}</strong></dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-muted-foreground">เปรียบเทียบ</dt>
+                    <dd><strong>{decisionFacts.price.comparison.label}</strong></dd>
+                  </div>
+                </dl>
+              </CardContent>
+            </Card>
+            {renderOwnershipNotice()}
+            <ToggleGroup
             type="single"
             orientation="vertical"
             variant="outline"
             className="w-full"
             aria-label="ช่องทางชำระเงิน"
-            data-payment-step="method"
             onValueChange={(value) => {
               if (value === 'promptpay') void handlePromptPayPayment();
               if (value === 'stripe') {
@@ -343,7 +381,8 @@ export default function BundleEnrollButton({
                 <span>ชำระผ่าน Stripe (Visa, Mastercard)</span>
               </span>
             </ToggleGroupItem>
-          </ToggleGroup>
+            </ToggleGroup>
+          </div>
         )}
         dismissOnBackdrop={true}
         returnFocusRef={enrollmentTriggerRef}

--- a/src/lib/bundle-decision-facts.ts
+++ b/src/lib/bundle-decision-facts.ts
@@ -1,0 +1,258 @@
+import {
+  deriveCourseDecisionFacts,
+  type CourseDecisionSource,
+} from '@/lib/course-decision-facts';
+
+type BundleAcquisitionActionDescriptor = {
+  kind: 'enroll-free' | 'start-checkout' | 'unavailable';
+  label: string;
+  href: null;
+};
+
+type LinkedBundleActionDescriptor = {
+  kind: 'view-details' | 'continue-learning';
+  label: string;
+  href: string;
+};
+
+export type BundleCourseDecisionSource = {
+  id: string;
+  title: string;
+  slug: string;
+  orderIndex: number | null;
+  regularPrice: number | string;
+  promotion?: CourseDecisionSource['promotion'];
+  lessonCount: number;
+  owned?: boolean;
+};
+
+export type BundleDecisionSource = {
+  slug: string;
+  price: number | string;
+  courses: BundleCourseDecisionSource[];
+};
+
+export type BundlePriceComparison = {
+  kind: 'savings' | 'equal' | 'more-expensive';
+  amount: number;
+  amountFormatted: string;
+  percent: number | null;
+  label: string;
+};
+
+export type BundleDecisionFacts = {
+  readiness: 'ready' | 'preparing';
+  price: {
+    bundle: number;
+    bundleFormatted: string;
+    separateCurrent: number;
+    separateCurrentFormatted: string;
+    isFree: boolean;
+    comparison: BundlePriceComparison;
+  };
+  evidence: {
+    courseCount: number;
+    totalLessons: number;
+  };
+  courses: Array<{
+    id: string;
+    title: string;
+    slug: string;
+    orderIndex: number;
+    readiness: 'ready' | 'preparing';
+    lessonCount: number;
+    owned: boolean;
+    price: {
+      regular: number;
+      effective: number;
+      regularFormatted: string;
+      effectiveFormatted: string;
+      hasActiveDiscount: boolean;
+    };
+  }>;
+  ownership: {
+    status: 'none' | 'partial' | 'complete';
+    ownedCount: number;
+    ownedCourses: Array<{ id: string; title: string; slug: string }>;
+    disclosure: string | null;
+  };
+  actions: {
+    discovery: LinkedBundleActionDescriptor;
+    acquisition: BundleAcquisitionActionDescriptor;
+    complete: LinkedBundleActionDescriptor;
+  };
+};
+
+const thbFormatter = new Intl.NumberFormat('th-TH', {
+  style: 'currency',
+  currency: 'THB',
+  maximumFractionDigits: 0,
+});
+
+function toNonNegativeAmount(value: number | string): number {
+  const amount = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new TypeError('Bundle decision facts require a valid non-negative price');
+  }
+  return amount;
+}
+
+function toCurrencyUnits(amount: number): number {
+  return Math.round(amount * 100);
+}
+
+function fromCurrencyUnits(amount: number): number {
+  return amount / 100;
+}
+
+function normalizeOrderIndex(orderIndex: number | null, inputIndex: number): number {
+  if (orderIndex === null) return inputIndex;
+  if (!Number.isInteger(orderIndex) || orderIndex < 0) {
+    throw new TypeError('Bundle decision facts require a valid course order');
+  }
+  return orderIndex;
+}
+
+function comparisonFor(bundlePrice: number, separateCurrent: number): BundlePriceComparison {
+  const differenceUnits = toCurrencyUnits(separateCurrent) - toCurrencyUnits(bundlePrice);
+  const amount = fromCurrencyUnits(Math.abs(differenceUnits));
+  const amountFormatted = thbFormatter.format(amount);
+
+  if (differenceUnits > 0) {
+    const percent = separateCurrent > 0
+      ? Math.round((differenceUnits / toCurrencyUnits(separateCurrent)) * 100)
+      : null;
+    return {
+      kind: 'savings',
+      amount,
+      amountFormatted,
+      percent,
+      label: `ประหยัด ${amountFormatted}${percent === null ? '' : ` (${percent}%)`}`,
+    };
+  }
+
+  if (differenceUnits < 0) {
+    return {
+      kind: 'more-expensive',
+      amount,
+      amountFormatted,
+      percent: null,
+      label: `ซื้อแยกวันนี้ถูกกว่า ${amountFormatted}`,
+    };
+  }
+
+  return {
+    kind: 'equal',
+    amount: 0,
+    amountFormatted: thbFormatter.format(0),
+    percent: null,
+    label: 'ราคาเท่ากับซื้อแยกวันนี้',
+  };
+}
+
+export function deriveBundleDecisionFacts(
+  source: BundleDecisionSource,
+  options: { now: Date },
+): BundleDecisionFacts {
+  const bundlePrice = toNonNegativeAmount(source.price);
+  if (!Number.isFinite(options.now.getTime())) {
+    throw new TypeError('Bundle decision facts require a valid current time');
+  }
+
+  const orderedSources = source.courses
+    .map((course, inputIndex) => ({
+      course: { ...course, orderIndex: normalizeOrderIndex(course.orderIndex, inputIndex) },
+      inputIndex,
+    }))
+    .sort((left, right) => (
+      left.course.orderIndex - right.course.orderIndex || left.inputIndex - right.inputIndex
+    ));
+
+  const courses = orderedSources.map(({ course }) => {
+    const decisionFacts = deriveCourseDecisionFacts({
+      slug: course.slug,
+      regularPrice: course.regularPrice,
+      promotion: course.promotion,
+      lessonCount: course.lessonCount,
+    }, options);
+
+    return {
+      id: course.id,
+      title: course.title,
+      slug: course.slug,
+      orderIndex: course.orderIndex,
+      readiness: decisionFacts.readiness,
+      lessonCount: decisionFacts.evidence.lessonCount,
+      owned: course.owned === true,
+      price: {
+        regular: decisionFacts.price.regular,
+        effective: decisionFacts.price.effective,
+        regularFormatted: decisionFacts.price.regularFormatted,
+        effectiveFormatted: decisionFacts.price.effectiveFormatted,
+        hasActiveDiscount: decisionFacts.price.discountPercent !== null,
+      },
+    };
+  });
+
+  const separateCurrentUnits = courses.reduce(
+    (total, course) => total + toCurrencyUnits(course.price.effective),
+    0,
+  );
+  const separateCurrent = fromCurrencyUnits(separateCurrentUnits);
+  const comparison = comparisonFor(bundlePrice, separateCurrent);
+  const readiness = courses.length > 0 && courses.every((course) => course.readiness === 'ready')
+    ? 'ready'
+    : 'preparing';
+  const ownedCourses = courses
+    .filter((course) => course.owned)
+    .map(({ id, title, slug }) => ({ id, title, slug }));
+  const ownershipStatus = ownedCourses.length === 0
+    ? 'none'
+    : ownedCourses.length === courses.length
+      ? 'complete'
+      : 'partial';
+  const bundleFormatted = thbFormatter.format(bundlePrice);
+  const acquisition = readiness === 'preparing'
+    ? { kind: 'unavailable', label: 'ยังไม่เปิดรับสมัคร', href: null } as const
+    : bundlePrice === 0
+      ? { kind: 'enroll-free', label: 'ลงทะเบียน Bundle ฟรี', href: null } as const
+      : { kind: 'start-checkout', label: `ซื้อ Bundle ${bundleFormatted}`, href: null } as const;
+
+  return {
+    readiness,
+    price: {
+      bundle: bundlePrice,
+      bundleFormatted,
+      separateCurrent,
+      separateCurrentFormatted: thbFormatter.format(separateCurrent),
+      isFree: bundlePrice === 0,
+      comparison,
+    },
+    evidence: {
+      courseCount: courses.length,
+      totalLessons: courses.reduce((total, course) => total + course.lessonCount, 0),
+    },
+    courses,
+    ownership: {
+      status: ownershipStatus,
+      ownedCount: ownedCourses.length,
+      ownedCourses,
+      disclosure: ownershipStatus === 'partial'
+        ? `คุณมีสิทธิ์เรียนแล้ว ${ownedCourses.length} จาก ${courses.length} คอร์ส (${ownedCourses.map((course) => course.title).join(', ')}) ราคาชุดไม่หักมูลค่าคอร์สที่มีอยู่ ยอดยังเป็น ${bundleFormatted}`
+        : null,
+    },
+    actions: {
+      discovery: {
+        kind: 'view-details',
+        label: 'ดูรายละเอียด',
+        href: `/bundles/${source.slug}`,
+      },
+      acquisition,
+      complete: {
+        kind: 'continue-learning',
+        label: 'ลงทะเบียนครบแล้ว — เข้าเรียน',
+        href: '/dashboard',
+      },
+    },
+  };
+}

--- a/tests/components/bundle-card.test.tsx
+++ b/tests/components/bundle-card.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import BundleCard from '@/components/bundle/BundleCard';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
+
+function decisionFacts(overrides: {
+  bundlePrice?: string;
+  secondLessonCount?: number;
+} = {}) {
+  return deriveBundleDecisionFacts({
+    slug: 'full-stack',
+    price: overrides.bundlePrice ?? '1500.00',
+    courses: [
+      {
+        id: 'second',
+        title: 'Next.js',
+        slug: 'nextjs',
+        orderIndex: 20,
+        regularPrice: '1200.00',
+        lessonCount: overrides.secondLessonCount ?? 8,
+      },
+      {
+        id: 'first',
+        title: 'TypeScript',
+        slug: 'typescript',
+        orderIndex: 10,
+        regularPrice: '1000.00',
+        promotion: { price: '800.00' },
+        lessonCount: 6,
+      },
+    ],
+  }, { now: new Date('2026-09-02T05:00:00.000Z') });
+}
+
+describe('BundleCard', () => {
+  it('renders the authoritative Course order and current comparison facts', () => {
+    const html = renderToStaticMarkup(
+      <BundleCard
+        title="Full-stack path"
+        description="เรียนตามลำดับ"
+        decisionFacts={decisionFacts()}
+      />,
+    );
+
+    expect(html).toContain('ประหยัด ฿500 (25%)');
+    expect(html).toContain('ซื้อแยกวันนี้ ฿2,000');
+    expect(html.indexOf('TypeScript')).toBeLessThan(html.indexOf('Next.js'));
+    expect(html).not.toContain('รีวิว');
+  });
+
+  it('keeps an unready Bundle card discoverable without presenting savings as availability', () => {
+    const html = renderToStaticMarkup(
+      <BundleCard
+        title="Preparing path"
+        description={null}
+        decisionFacts={decisionFacts({ secondLessonCount: 0 })}
+      />,
+    );
+
+    expect(html).toContain('href="/bundles/full-stack"');
+    expect(html).toContain('กำลังเตรียมเนื้อหา');
+    expect(html).toContain('ดูรายละเอียด');
+  });
+});

--- a/tests/components/bundle-enroll-button.test.tsx
+++ b/tests/components/bundle-enroll-button.test.tsx
@@ -1,10 +1,43 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import BundleEnrollButton, { BUNDLE_PAYMENT_CONTRACT } from '@/components/bundle/BundleEnrollButton';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
 
 const push = vi.fn();
 const refresh = vi.fn();
 const quote = String.fromCharCode(34);
+
+function decisionFacts(options: {
+  price?: number;
+  ready?: boolean;
+  ownership?: 'none' | 'partial' | 'complete';
+} = {}) {
+  const ownership = options.ownership ?? 'none';
+  return deriveBundleDecisionFacts({
+    slug: 'full-stack',
+    price: options.price ?? 2490,
+    courses: [
+      {
+        id: 'course-1',
+        title: 'TypeScript',
+        slug: 'typescript',
+        orderIndex: 0,
+        regularPrice: 1800,
+        lessonCount: 8,
+        owned: ownership === 'partial' || ownership === 'complete',
+      },
+      {
+        id: 'course-2',
+        title: 'Next.js',
+        slug: 'nextjs',
+        orderIndex: 1,
+        regularPrice: 1700,
+        lessonCount: options.ready === false ? 0 : 10,
+        owned: ownership === 'complete',
+      },
+    ],
+  }, { now: new Date('2026-09-02T05:00:00.000Z') });
+}
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push, refresh }),
@@ -37,10 +70,10 @@ describe('bundle enrollment purchase contract', () => {
 
   it('renders paid and free enrollment as explicit task buttons', () => {
     const paid = renderToStaticMarkup(
-      <BundleEnrollButton bundleId={'bundle-1'} bundleSlug={'full-stack'} price={2490} />,
+      <BundleEnrollButton bundleId={'bundle-1'} bundleSlug={'full-stack'} decisionFacts={decisionFacts()} />,
     );
     const free = renderToStaticMarkup(
-      <BundleEnrollButton bundleId={'bundle-2'} bundleSlug={'starter'} price={0} />,
+      <BundleEnrollButton bundleId={'bundle-2'} bundleSlug={'starter'} decisionFacts={decisionFacts({ price: 0 })} />,
     );
 
     expect(paid).toContain('<button');
@@ -54,8 +87,7 @@ describe('bundle enrollment purchase contract', () => {
       <BundleEnrollButton
         bundleId={'bundle-1'}
         bundleSlug={'full-stack'}
-        price={2490}
-        allEnrolled={true}
+        decisionFacts={decisionFacts({ ownership: 'complete' })}
       />,
     );
 
@@ -66,11 +98,29 @@ describe('bundle enrollment purchase contract', () => {
 
   it('disables enrollment when any bundled course is not ready', () => {
     const html = renderToStaticMarkup(
-      <BundleEnrollButton bundleId={'bundle-1'} bundleSlug={'full-stack'} price={2490} available={false} />,
+      <BundleEnrollButton
+        bundleId={'bundle-1'}
+        bundleSlug={'full-stack'}
+        decisionFacts={decisionFacts({ ready: false })}
+      />,
     );
 
     expect(html).toContain('Bundle นี้กำลังเตรียมเนื้อหา');
     expect(html).toContain('disabled');
     expect(html).not.toContain('ซื้อ Bundle');
+  });
+
+  it('discloses partial ownership and preserves the full Bundle price', () => {
+    const html = renderToStaticMarkup(
+      <BundleEnrollButton
+        bundleId={'bundle-1'}
+        bundleSlug={'full-stack'}
+        decisionFacts={decisionFacts({ ownership: 'partial' })}
+      />,
+    );
+
+    expect(html).toContain('มีบางคอร์สอยู่ในบัญชีแล้ว');
+    expect(html).toContain('ราคาชุดไม่หักมูลค่าคอร์สที่มีอยู่');
+    expect(html).toContain('ซื้อ Bundle ฿2,490');
   });
 });

--- a/tests/components/bundle-enroll-interactions.test.tsx
+++ b/tests/components/bundle-enroll-interactions.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import BundleEnrollButton, {
   BUNDLE_PAYMENT_CONTRACT,
 } from '@/components/bundle/BundleEnrollButton';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
 
 vi.mock('next/image', () => ({ default: () => null }));
 vi.mock('next/navigation', () => ({
@@ -56,6 +57,28 @@ vi.mock('@/components/ui/Modal', () => ({
   ) : null,
 }));
 
+const DECISION_FACTS = deriveBundleDecisionFacts({
+  slug: 'full-stack',
+  price: 2490,
+  courses: [
+    {
+      id: 'course-1',
+      title: 'TypeScript',
+      slug: 'typescript',
+      orderIndex: 0,
+      regularPrice: 1800,
+      lessonCount: 8,
+    },
+    {
+      id: 'course-2',
+      title: 'Next.js',
+      slug: 'nextjs',
+      orderIndex: 1,
+      regularPrice: 1700,
+      lessonCount: 10,
+    },
+  ],
+}, { now: new Date('2026-09-02T05:00:00.000Z') });
 const jsonResponse = (body: unknown, ok = true) => ({
   ok,
   json: vi.fn().mockResolvedValue(body),
@@ -104,7 +127,7 @@ describe('bundle enrollment interactions', () => {
       <BundleEnrollButton
         bundleId="bundle-1"
         bundleSlug="full-stack"
-        price={2490}
+        decisionFacts={DECISION_FACTS}
       />,
     );
 
@@ -143,7 +166,7 @@ describe('bundle enrollment interactions', () => {
       <BundleEnrollButton
         bundleId="bundle-1"
         bundleSlug="full-stack"
-        price={2490}
+        decisionFacts={DECISION_FACTS}
       />,
     );
 
@@ -194,7 +217,7 @@ describe('bundle enrollment interactions', () => {
       <BundleEnrollButton
         bundleId="bundle-1"
         bundleSlug="full-stack"
-        price={2490}
+        decisionFacts={DECISION_FACTS}
       />,
     );
 
@@ -244,7 +267,7 @@ describe('bundle enrollment interactions', () => {
       <BundleEnrollButton
         bundleId="bundle-1"
         bundleSlug="full-stack"
-        price={2490}
+        decisionFacts={DECISION_FACTS}
       />,
     );
 
@@ -273,6 +296,25 @@ describe('bundle enrollment interactions', () => {
     });
   });
 
+  it('shows the shared current-price comparison before payment method selection', async () => {
+    const user = userEvent.setup();
+    render(
+      <BundleEnrollButton
+        bundleId="bundle-1"
+        bundleSlug="full-stack"
+        decisionFacts={DECISION_FACTS}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /2,490/ }));
+
+    const orderReview = screen.getByRole('dialog', { name: 'เลือกช่องทางชำระเงิน' });
+    expect(orderReview.textContent).toContain('ตรวจสอบรายการ Bundle');
+    expect(orderReview.textContent).toContain('ซื้อแยกวันนี้');
+    expect(orderReview.textContent).toContain('฿3,500');
+    expect(orderReview.textContent).toContain('ประหยัด ฿1,010 (29%)');
+  });
+
   it('preserves PromptPay intent and slip fields while locking verification', async () => {
     const verifyRequest = deferred<Response>();
     const fetchMock = vi.fn<
@@ -294,7 +336,7 @@ describe('bundle enrollment interactions', () => {
       <BundleEnrollButton
         bundleId="bundle-1"
         bundleSlug="full-stack"
-        price={2490}
+        decisionFacts={DECISION_FACTS}
       />,
     );
 

--- a/tests/lib/bundle-decision-facts.test.ts
+++ b/tests/lib/bundle-decision-facts.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveBundleDecisionFacts,
+  type BundleCourseDecisionSource,
+} from '@/lib/bundle-decision-facts';
+
+const NOW = new Date('2026-09-02T05:00:00.000Z');
+
+function course(
+  id: string,
+  orderIndex: number,
+  overrides: Partial<BundleCourseDecisionSource> = {},
+): BundleCourseDecisionSource {
+  return {
+    id,
+    title: `Course ${id}`,
+    slug: `course-${id}`,
+    orderIndex,
+    regularPrice: '1000.00',
+    lessonCount: 5,
+    ...overrides,
+  };
+}
+
+function bundleFacts(
+  price: number | string,
+  courses: BundleCourseDecisionSource[] = [course('a', 0), course('b', 1)],
+) {
+  return deriveBundleDecisionFacts({ slug: 'full-stack', price, courses }, { now: NOW });
+}
+
+describe('ProductDecisionFacts for Bundle', () => {
+  it('uses current effective Course prices and preserves the authoritative order', () => {
+    const facts = bundleFacts('1500.00', [
+      course('later', 20, { regularPrice: '1200.00' }),
+      course('first', 10, {
+        regularPrice: '1000.00',
+        promotion: {
+          price: '800.00',
+          startsAt: new Date('2026-09-01T05:00:00.000Z'),
+          endsAt: new Date('2026-09-03T05:00:00.000Z'),
+        },
+      }),
+    ]);
+
+    expect(facts.courses.map((item) => item.id)).toEqual(['first', 'later']);
+    expect(facts.courses[0]?.price).toMatchObject({ regular: 1000, effective: 800 });
+    expect(facts.price).toMatchObject({
+      bundle: 1500,
+      separateCurrent: 2000,
+      comparison: { kind: 'savings', amount: 500, percent: 25 },
+    });
+  });
+
+  it.each([
+    ['savings', '1500.00', 'savings', 500, 25],
+    ['equal', '2000.00', 'equal', 0, null],
+    ['more expensive', '2400.00', 'more-expensive', 400, null],
+  ] as const)('describes a %s comparison truthfully', (_name, price, kind, amount, percent) => {
+    const facts = bundleFacts(price);
+
+    expect(facts.price.comparison).toMatchObject({ kind, amount, percent });
+    expect(facts.price.comparison.label).toMatch(
+      kind === 'savings'
+        ? /ประหยัด/
+        : kind === 'equal'
+          ? /เท่ากับ/
+          : /ซื้อแยกวันนี้ถูกกว่า/,
+    );
+  });
+
+  it('keeps an unready Bundle discoverable without a new enrollment or checkout action', () => {
+    const facts = bundleFacts('1500.00', [
+      course('ready', 0),
+      course('preparing', 1, { lessonCount: 0 }),
+    ]);
+
+    expect(facts.readiness).toBe('preparing');
+    expect(facts.actions.discovery).toEqual({
+      kind: 'view-details',
+      label: 'ดูรายละเอียด',
+      href: '/bundles/full-stack',
+    });
+    expect(facts.actions.acquisition).toEqual({
+      kind: 'unavailable',
+      label: 'ยังไม่เปิดรับสมัคร',
+      href: null,
+    });
+  });
+
+  it('discloses partial ownership without changing the full Bundle price', () => {
+    const facts = bundleFacts('1500.00', [
+      course('owned', 0, { title: 'TypeScript', owned: true }),
+      course('new', 1, { title: 'Next.js' }),
+    ]);
+
+    expect(facts.ownership).toMatchObject({
+      status: 'partial',
+      ownedCount: 1,
+      ownedCourses: [{ id: 'owned', title: 'TypeScript', slug: 'course-owned' }],
+    });
+    expect(facts.ownership.disclosure).toContain('มีสิทธิ์เรียนแล้ว 1 จาก 2 คอร์ส');
+    expect(facts.ownership.disclosure).toContain('ราคาชุดไม่หักมูลค่าคอร์สที่มีอยู่');
+    expect(facts.ownership.disclosure).toContain(facts.price.bundleFormatted);
+    expect(facts.actions.acquisition.kind).toBe('start-checkout');
+  });
+
+  it('routes complete owners to learning and does not invent Bundle review evidence', () => {
+    const facts = bundleFacts('1500.00', [
+      course('a', 0, { owned: true }),
+      course('b', 1, { owned: true }),
+    ]);
+
+    expect(facts.ownership.status).toBe('complete');
+    expect(facts.actions.complete).toEqual({
+      kind: 'continue-learning',
+      label: 'ลงทะเบียนครบแล้ว — เข้าเรียน',
+      href: '/dashboard',
+    });
+    expect(facts.evidence).not.toHaveProperty('verifiedReview');
+    expect(facts).not.toHaveProperty('rating');
+  });
+});


### PR DESCRIPTION
## Summary

- add one pure Bundle decision module for included-course readiness, current effective separate-price comparison, truthful savings/equal/more-expensive states, authoritative ordering, and ownership
- migrate the catalog card, Bundle detail, and payment-method order review to consume the same server-derived facts
- disclose partial ownership and the full-price policy without changing payment, enrollment, or provider authority
- keep unready Bundles discoverable while preventing new enrollment or checkout actions

## Safety

- no schema or migration changes
- no payment/enrollment endpoint or provider contract changes
- no client-side entitlement or payment authority
- no fabricated Bundle rating or review evidence

## Verification

- `npm run test -- --run` — 134 files, 811 tests passed
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` — 93 pages generated
- `git diff --check`

Closes #37