### PR TITLE
feat(payments): add exact attempt presentation

### DIFF
--- a/src/lib/payment-presentation.ts
+++ b/src/lib/payment-presentation.ts
@@ -1,0 +1,391 @@
+import 'server-only';
+
+import { PROMPTPAY_INTENT_TTL_MS } from '@/lib/promptpay-intent';
+
+export type PaymentTarget = {
+  type: 'course' | 'bundle';
+  id: string;
+  title: string;
+  href: string;
+};
+
+export type ServerPaymentAttempt = {
+  id: string;
+  userId: string | null;
+  courseId: string | null;
+  bundleId: string | null;
+  itemTitle: string | null;
+  amount: string;
+  currency: string;
+  method: 'stripe' | 'promptpay' | 'bank_transfer';
+  status: 'pending' | 'verifying' | 'completed' | 'failed' | 'refunded';
+  createdAt: Date | null;
+};
+
+export type PaymentPresentationSource =
+  | {
+      kind: 'exact-attempt';
+      ownerId: string;
+      expectedAttemptId: string;
+      target: PaymentTarget;
+      attempt: ServerPaymentAttempt | null;
+      access: { enrolledCount: number; totalCount: number };
+    }
+  | {
+      kind: 'cancelled-return';
+      target: PaymentTarget;
+      access: { enrolledCount: number; totalCount: number };
+    };
+
+type PaymentState =
+  | 'pending'
+  | 'verifying'
+  | 'completed-ready'
+  | 'completed-access-pending'
+  | 'failed'
+  | 'refunded'
+  | 'unconfirmed'
+  | 'cancelled-return';
+
+type RecoveryKind =
+  | 'restart'
+  | 'refresh'
+  | 'contact'
+  | 'view-product'
+  | 'view-history'
+  | 'continue-learning';
+
+export type PaymentPresentation = {
+  target: Omit<PaymentTarget, 'title'> & { title: string | null };
+  quote: {
+    amountDue: string;
+    amountFormatted: string;
+    currency: 'THB';
+  } | null;
+  attempt: {
+    id: string;
+    method: ServerPaymentAttempt['method'];
+    rawStatus: ServerPaymentAttempt['status'];
+    createdAt: string | null;
+    expiresAt: string | null;
+  } | null;
+  payment: {
+    state: PaymentState;
+    isConfirmed: boolean;
+    label: string;
+    heading: string;
+    description: string;
+    preventDuplicatePayment: boolean;
+  };
+  access: {
+    state: 'none' | 'partial' | 'ready';
+    enrolledCount: number;
+    totalCount: number;
+  };
+  recovery: {
+    kind: RecoveryKind;
+    label: string;
+    href: string;
+  };
+};
+
+const PAYMENT_METHODS: ReadonlyArray<ServerPaymentAttempt['method']> = [
+  'stripe',
+  'promptpay',
+  'bank_transfer',
+];
+const PAYMENT_STATUSES: ReadonlyArray<ServerPaymentAttempt['status']> = [
+  'pending',
+  'verifying',
+  'completed',
+  'failed',
+  'refunded',
+];
+const thbFormatter = new Intl.NumberFormat('th-TH', {
+  style: 'currency',
+  currency: 'THB',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function isExactTarget(attempt: ServerPaymentAttempt, target: PaymentTarget) {
+  if (target.type === 'course') {
+    return attempt.courseId === target.id && attempt.bundleId === null;
+  }
+  return attempt.bundleId === target.id && attempt.courseId === null;
+}
+
+function normalizeAmount(amount: string) {
+  const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(amount.trim());
+  if (!match) return null;
+
+  const normalized = `${match[1]}.${(match[2] ?? '').padEnd(2, '0')}`;
+  if (BigInt(match[1]) === BigInt(0) && BigInt(match[2] ?? '0') === BigInt(0)) {
+    return null;
+  }
+  return normalized;
+}
+
+function deriveAccess(access: PaymentPresentationSource['access']) {
+  if (
+    !Number.isInteger(access.enrolledCount)
+    || !Number.isInteger(access.totalCount)
+    || access.enrolledCount < 0
+    || access.totalCount < 1
+    || access.enrolledCount > access.totalCount
+  ) {
+    throw new TypeError('Payment presentation requires valid access counts');
+  }
+
+  return {
+    state: access.enrolledCount === 0
+      ? 'none'
+      : access.enrolledCount === access.totalCount
+        ? 'ready'
+        : 'partial',
+    ...access,
+  } as const;
+}
+
+function unconfirmedPresentation(
+  source: PaymentPresentationSource,
+  access: PaymentPresentation['access'],
+): PaymentPresentation {
+  return {
+    target: source.target,
+    quote: null,
+    attempt: null,
+    payment: {
+      state: 'unconfirmed',
+      isConfirmed: false,
+      label: 'ยังยืนยันรายการนี้ไม่ได้',
+      heading: 'ยังยืนยันรายการนี้ไม่ได้',
+      description: 'ระบบยังยืนยันรายการชำระเงินนี้ไม่ได้ จึงยังไม่แสดงว่าได้รับเงินหรือเพิ่มสิทธิ์เรียนแล้ว',
+      preventDuplicatePayment: true,
+    },
+    access,
+    recovery: {
+      kind: 'view-history',
+      label: 'ดูประวัติการชำระเงิน',
+      href: '/dashboard/payments',
+    },
+  };
+}
+
+function promptPayExpiry(attempt: ServerPaymentAttempt) {
+  if (attempt.method !== 'promptpay' || !attempt.createdAt) return null;
+  const createdAt = attempt.createdAt.getTime();
+  if (!Number.isFinite(createdAt)) return null;
+  return new Date(createdAt + PROMPTPAY_INTENT_TTL_MS);
+}
+
+function describePayment(
+  attempt: ServerPaymentAttempt,
+  access: PaymentPresentation['access'],
+  targetHref: string,
+  now: Date,
+): Pick<PaymentPresentation, 'payment' | 'recovery'> {
+  if (attempt.status === 'pending') {
+    if (attempt.method === 'promptpay') {
+      const expiresAt = promptPayExpiry(attempt);
+      const isExpired = expiresAt === null || expiresAt.getTime() <= now.getTime();
+      if (isExpired) {
+        return {
+          payment: {
+            state: 'pending',
+            isConfirmed: false,
+            label: 'รายการหมดเวลา',
+            heading: 'รายการพร้อมเพย์หมดเวลาแล้ว',
+            description: 'ยังไม่มีการยืนยันการชำระเงินจากรายการนี้ หากโอนเงินแล้วอย่าชำระซ้ำและติดต่อพร้อมเลขอ้างอิง',
+            preventDuplicatePayment: false,
+          },
+          recovery: { kind: 'restart', label: 'เริ่มรายการใหม่', href: targetHref },
+        };
+      }
+      return {
+        payment: {
+          state: 'pending',
+          isConfirmed: false,
+          label: 'รอแนบสลิป',
+          heading: 'รายการนี้ยังรอหลักฐานการชำระเงิน',
+          description: 'หากโอนเงินแล้วอย่าชำระซ้ำ กรุณาติดต่อพร้อมเลขอ้างอิงจนกว่าจะมี resume contract ที่ตรวจ owner ได้',
+          preventDuplicatePayment: true,
+        },
+        recovery: {
+          kind: 'contact',
+          label: 'ติดต่อพร้อมเลขอ้างอิง',
+          href: 'mailto:milerdev.official@gmail.com',
+        },
+      };
+    }
+
+    if (attempt.method === 'bank_transfer') {
+      return {
+        payment: {
+          state: 'pending',
+          isConfirmed: false,
+          label: 'รอตรวจสอบการโอนเงิน',
+          heading: 'ยังไม่มีการยืนยันการชำระเงิน',
+          description: 'หากโอนเงินแล้วอย่าชำระซ้ำ กรุณาติดต่อพร้อมเลขอ้างอิงเพื่อตรวจสอบรายการ',
+          preventDuplicatePayment: true,
+        },
+        recovery: {
+          kind: 'contact',
+          label: 'ติดต่อพร้อมเลขอ้างอิง',
+          href: 'mailto:milerdev.official@gmail.com',
+        },
+      };
+    }
+
+    return {
+      payment: {
+        state: 'pending',
+        isConfirmed: false,
+        label: 'ยังชำระไม่เสร็จ',
+        heading: 'ยังไม่มีการยืนยันการชำระเงิน',
+        description: 'รายการนี้ยังชำระไม่เสร็จ และยังไม่ได้เพิ่มสิทธิ์เรียน',
+        preventDuplicatePayment: false,
+      },
+      recovery: { kind: 'restart', label: 'กลับไปเลือกวิธีชำระเงิน', href: targetHref },
+    };
+  }
+
+  if (attempt.status === 'verifying') {
+    return {
+      payment: {
+        state: 'verifying',
+        isConfirmed: false,
+        label: 'กำลังตรวจสอบสลิป',
+        heading: 'กำลังตรวจสอบการชำระเงิน',
+        description: 'ระบบรับรายการไว้ตรวจสอบแล้ว อย่าชำระหรือส่งหลักฐานซ้ำ',
+        preventDuplicatePayment: true,
+      },
+      recovery: { kind: 'refresh', label: 'ตรวจสถานะอีกครั้ง', href: '/dashboard/payments' },
+    };
+  }
+
+  if (attempt.status === 'completed') {
+    if (access.state === 'ready') {
+      return {
+        payment: {
+          state: 'completed-ready',
+          isConfirmed: true,
+          label: 'ชำระแล้ว · พร้อมเรียน',
+          heading: 'ชำระแล้ว พร้อมเริ่มเรียน',
+          description: 'การชำระเงินได้รับการยืนยันและสิทธิ์เรียนพร้อมแล้ว',
+          preventDuplicatePayment: true,
+        },
+        recovery: { kind: 'continue-learning', label: 'ไปการเรียนของฉัน', href: '/dashboard' },
+      };
+    }
+    return {
+      payment: {
+        state: 'completed-access-pending',
+        isConfirmed: true,
+        label: 'ชำระแล้ว · กำลังเปิดสิทธิ์',
+        heading: 'ชำระแล้ว กำลังเปิดสิทธิ์',
+        description: 'การชำระเงินได้รับการยืนยันแล้ว แต่สิทธิ์เรียนยังไม่ครบ อย่าชำระซ้ำ',
+        preventDuplicatePayment: true,
+      },
+      recovery: { kind: 'refresh', label: 'ตรวจสิทธิ์อีกครั้ง', href: '/dashboard/payments' },
+    };
+  }
+
+  if (attempt.status === 'failed') {
+    return {
+      payment: {
+        state: 'failed',
+        isConfirmed: false,
+        label: 'ชำระเงินไม่สำเร็จ',
+        heading: 'รายการนี้ไม่สำเร็จ',
+        description: 'ยังไม่มีการยืนยันการชำระเงินและยังไม่ได้เพิ่มสิทธิ์เรียนจากรายการนี้',
+        preventDuplicatePayment: false,
+      },
+      recovery: { kind: 'restart', label: 'กลับไปเลือกวิธีชำระเงิน', href: targetHref },
+    };
+  }
+
+  return {
+    payment: {
+      state: 'refunded',
+      isConfirmed: false,
+      label: 'คืนเงินแล้ว',
+      heading: 'รายการนี้คืนเงินแล้ว',
+      description: 'รายการนี้ถูกบันทึกว่าได้คืนเงินแล้ว กรุณาดูรายละเอียดสินค้าหรือติดต่อพร้อมเลขอ้างอิง',
+      preventDuplicatePayment: true,
+    },
+    recovery: { kind: 'view-product', label: 'ดูรายละเอียดสินค้า', href: targetHref },
+  };
+}
+
+export function derivePaymentPresentation(
+  source: PaymentPresentationSource,
+  options: { now: Date },
+): PaymentPresentation {
+  if (!Number.isFinite(options.now.getTime())) {
+    throw new TypeError('Payment presentation requires a valid current time');
+  }
+
+  const access = deriveAccess(source.access);
+  if (source.kind === 'cancelled-return') {
+    return {
+      target: source.target,
+      quote: null,
+      attempt: null,
+      payment: {
+        state: 'cancelled-return',
+        isConfirmed: false,
+        label: 'ยกเลิกการชำระแล้ว',
+        heading: 'ยกเลิกการชำระแล้ว',
+        description: 'ยังไม่มีการยืนยันการชำระเงินและยังไม่ได้เพิ่มสิทธิ์เรียน',
+        preventDuplicatePayment: false,
+      },
+      access,
+      recovery: {
+        kind: 'restart',
+        label: 'เลือกวิธีชำระเงินใหม่',
+        href: source.target.href,
+      },
+    };
+  }
+
+  const { attempt } = source;
+  const amountDue = attempt ? normalizeAmount(attempt.amount) : null;
+  const createdAtTimestamp = attempt?.createdAt?.getTime();
+  if (
+    !attempt
+    || !source.expectedAttemptId
+    || attempt.id !== source.expectedAttemptId
+    || attempt.userId !== source.ownerId
+    || !isExactTarget(attempt, source.target)
+    || attempt.currency !== 'THB'
+    || !PAYMENT_METHODS.includes(attempt.method)
+    || !PAYMENT_STATUSES.includes(attempt.status)
+    || amountDue === null
+    || (createdAtTimestamp !== undefined && !Number.isFinite(createdAtTimestamp))
+  ) {
+    return unconfirmedPresentation(source, access);
+  }
+
+  const description = describePayment(attempt, access, source.target.href, options.now);
+  return {
+    target: {
+      ...source.target,
+      title: attempt.itemTitle?.trim() || null,
+    },
+    quote: {
+      amountDue,
+      amountFormatted: thbFormatter.format(Number(amountDue)),
+      currency: 'THB',
+    },
+    attempt: {
+      id: attempt.id,
+      method: attempt.method,
+      rawStatus: attempt.status,
+      createdAt: attempt.createdAt?.toISOString() ?? null,
+      expiresAt: promptPayExpiry(attempt)?.toISOString() ?? null,
+    },
+    ...description,
+    access,
+  };
+}

--- a/tests/lib/payment-presentation-cancelled.test.ts
+++ b/tests/lib/payment-presentation-cancelled.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { derivePaymentPresentation } from '@/lib/payment-presentation';
+
+describe('PaymentPresentation cancelled return', () => {
+  it('keeps selected product context without inventing an attempt or current-price proof', () => {
+    const presentation = derivePaymentPresentation({
+      kind: 'cancelled-return',
+      target: {
+        type: 'course',
+        id: 'course-1',
+        title: 'TypeScript Foundations',
+        href: '/courses/typescript',
+      },
+      access: { enrolledCount: 0, totalCount: 1 },
+    }, { now: new Date('2026-09-02T07:00:00.000Z') });
+
+    expect(presentation).toMatchObject({
+      target: { type: 'course', id: 'course-1', title: 'TypeScript Foundations' },
+      quote: null,
+      attempt: null,
+      payment: {
+        state: 'cancelled-return',
+        isConfirmed: false,
+        label: 'ยกเลิกการชำระแล้ว',
+        preventDuplicatePayment: false,
+      },
+      recovery: {
+        kind: 'restart',
+        label: 'เลือกวิธีชำระเงินใหม่',
+        href: '/courses/typescript',
+      },
+    });
+  });
+});

--- a/tests/lib/payment-presentation-consumers.test.ts
+++ b/tests/lib/payment-presentation-consumers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  derivePaymentPresentation,
+  type ServerPaymentAttempt,
+} from '@/lib/payment-presentation';
+
+const NOW = new Date('2026-09-02T07:00:00.000Z');
+
+describe('PaymentPresentation representative consumers', () => {
+  it('keeps a confirmed Bundle payment separate from partial access readiness', () => {
+    const presentation = derivePaymentPresentation({
+      kind: 'exact-attempt',
+      ownerId: 'user-1',
+      expectedAttemptId: 'payment-bundle-1',
+      target: {
+        type: 'bundle',
+        id: 'bundle-1',
+        title: 'ชื่อ Bundle ปัจจุบัน',
+        href: '/bundles/full-stack',
+      },
+      attempt: {
+        id: 'payment-bundle-1',
+        userId: 'user-1',
+        courseId: null,
+        bundleId: 'bundle-1',
+        itemTitle: 'Full Stack Bundle ตอนที่ซื้อ',
+        amount: '4990.00',
+        currency: 'THB',
+        method: 'stripe',
+        status: 'completed',
+        createdAt: new Date('2026-09-02T06:55:00.000Z'),
+      },
+      access: { enrolledCount: 2, totalCount: 3 },
+    }, { now: NOW });
+
+    expect(presentation).toMatchObject({
+      target: { type: 'bundle', title: 'Full Stack Bundle ตอนที่ซื้อ' },
+      quote: { amountDue: '4990.00' },
+      payment: { state: 'completed-access-pending', isConfirmed: true },
+      access: { state: 'partial', enrolledCount: 2, totalCount: 3 },
+      recovery: { kind: 'refresh' },
+    });
+  });
+
+  it('lets payment history present each same-product attempt by its own immutable identity and amount', () => {
+    const attempts: ServerPaymentAttempt[] = [
+      {
+        id: 'payment-old',
+        userId: 'user-1',
+        courseId: 'course-1',
+        bundleId: null,
+        itemTitle: 'TypeScript รอบราคาเดิม',
+        amount: '990.00',
+        currency: 'THB',
+        method: 'stripe',
+        status: 'completed',
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+      },
+      {
+        id: 'payment-new',
+        userId: 'user-1',
+        courseId: 'course-1',
+        bundleId: null,
+        itemTitle: 'TypeScript รอบราคาปัจจุบัน',
+        amount: '1290.00',
+        currency: 'THB',
+        method: 'stripe',
+        status: 'pending',
+        createdAt: new Date('2026-09-02T06:55:00.000Z'),
+      },
+    ];
+
+    const presentations = attempts.map((attempt) => derivePaymentPresentation({
+      kind: 'exact-attempt',
+      ownerId: 'user-1',
+      expectedAttemptId: attempt.id,
+      target: {
+        type: 'course',
+        id: 'course-1',
+        title: 'ชื่อคอร์สใน catalog วันนี้',
+        href: '/courses/typescript',
+      },
+      attempt,
+      access: { enrolledCount: attempt.status === 'completed' ? 1 : 0, totalCount: 1 },
+    }, { now: NOW }));
+
+    expect(presentations.map((presentation) => ({
+      id: presentation.attempt?.id,
+      amount: presentation.quote?.amountDue,
+      title: presentation.target.title,
+      state: presentation.payment.state,
+    }))).toEqual([
+      {
+        id: 'payment-old',
+        amount: '990.00',
+        title: 'TypeScript รอบราคาเดิม',
+        state: 'completed-ready',
+      },
+      {
+        id: 'payment-new',
+        amount: '1290.00',
+        title: 'TypeScript รอบราคาปัจจุบัน',
+        state: 'pending',
+      },
+    ]);
+  });
+});

--- a/tests/lib/payment-presentation-statuses.test.ts
+++ b/tests/lib/payment-presentation-statuses.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  derivePaymentPresentation,
+  type ServerPaymentAttempt,
+} from '@/lib/payment-presentation';
+
+const NOW = new Date('2026-09-02T07:00:00.000Z');
+
+function present({
+  status,
+  method = 'stripe',
+  createdAt = new Date('2026-09-02T06:55:00.000Z'),
+  enrolledCount = 0,
+  totalCount = 1,
+}: {
+  status: ServerPaymentAttempt['status'];
+  method?: ServerPaymentAttempt['method'];
+  createdAt?: Date | null;
+  enrolledCount?: number;
+  totalCount?: number;
+}) {
+  return derivePaymentPresentation({
+    kind: 'exact-attempt',
+    ownerId: 'user-1',
+    expectedAttemptId: 'payment-1',
+    target: {
+      type: 'course',
+      id: 'course-1',
+      title: 'ชื่อปัจจุบัน',
+      href: '/courses/typescript',
+    },
+    attempt: {
+      id: 'payment-1',
+      userId: 'user-1',
+      courseId: 'course-1',
+      bundleId: null,
+      itemTitle: 'TypeScript ตอนที่ซื้อ',
+      amount: '1990.00',
+      currency: 'THB',
+      method,
+      status,
+      createdAt,
+    },
+    access: { enrolledCount, totalCount },
+  }, { now: NOW });
+}
+
+describe('PaymentPresentation status matrix', () => {
+  it('distinguishes active and expired PromptPay pending attempts', () => {
+    const active = present({ status: 'pending', method: 'promptpay' });
+    const expired = present({
+      status: 'pending',
+      method: 'promptpay',
+      createdAt: new Date('2026-09-02T06:00:00.000Z'),
+    });
+
+    expect(active).toMatchObject({
+      attempt: { expiresAt: '2026-09-02T07:25:00.000Z' },
+      payment: {
+        state: 'pending',
+        label: 'รอแนบสลิป',
+        preventDuplicatePayment: true,
+      },
+      recovery: { kind: 'contact', label: 'ติดต่อพร้อมเลขอ้างอิง' },
+    });
+    expect(expired).toMatchObject({
+      payment: {
+        state: 'pending',
+        label: 'รายการหมดเวลา',
+        preventDuplicatePayment: false,
+      },
+      recovery: { kind: 'restart', label: 'เริ่มรายการใหม่' },
+    });
+  });
+
+  it.each([
+    ['verifying', 0, 'verifying', false, 'กำลังตรวจสอบสลิป', true, 'refresh'],
+    ['completed', 1, 'completed-ready', true, 'ชำระแล้ว · พร้อมเรียน', true, 'continue-learning'],
+    ['completed', 0, 'completed-access-pending', true, 'ชำระแล้ว · กำลังเปิดสิทธิ์', true, 'refresh'],
+    ['failed', 0, 'failed', false, 'ชำระเงินไม่สำเร็จ', false, 'restart'],
+    ['refunded', 0, 'refunded', false, 'คืนเงินแล้ว', true, 'view-product'],
+  ] as const)(
+    'maps %s with access count %s to a distinct descriptor and recovery',
+    (status, enrolledCount, state, isConfirmed, label, preventDuplicatePayment, recoveryKind) => {
+      const presentation = present({ status, enrolledCount });
+
+      expect(presentation.payment).toMatchObject({
+        state,
+        isConfirmed,
+        label,
+        preventDuplicatePayment,
+      });
+      expect(presentation.recovery.kind).toBe(recoveryKind);
+    },
+  );
+});

--- a/tests/lib/payment-presentation-validation.test.ts
+++ b/tests/lib/payment-presentation-validation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  derivePaymentPresentation,
+  type ServerPaymentAttempt,
+} from '@/lib/payment-presentation';
+
+const NOW = new Date('2026-09-02T07:00:00.000Z');
+
+function deriveWithAttempt(attemptOverride: Partial<ServerPaymentAttempt>) {
+  return derivePaymentPresentation({
+    kind: 'exact-attempt',
+    ownerId: 'user-1',
+    expectedAttemptId: 'payment-course-1',
+    target: {
+      type: 'course',
+      id: 'course-1',
+      title: 'ชื่อคอร์สปัจจุบัน',
+      href: '/courses/typescript',
+    },
+    attempt: {
+      id: 'payment-course-1',
+      userId: 'user-1',
+      courseId: 'course-1',
+      bundleId: null,
+      itemTitle: 'TypeScript Foundations ตอนที่ซื้อ',
+      amount: '990.00',
+      currency: 'THB',
+      method: 'stripe',
+      status: 'pending',
+      createdAt: new Date('2026-09-02T06:55:00.000Z'),
+      ...attemptOverride,
+    },
+    access: { enrolledCount: 0, totalCount: 1 },
+  }, { now: NOW });
+}
+
+describe('PaymentPresentation exact-attempt validation', () => {
+  it.each([
+    ['attempt identity', { id: 'payment-other' }],
+    ['owner', { userId: 'user-other' }],
+    ['target', { courseId: 'course-other' }],
+    ['amount', { amount: 'not-an-amount' }],
+    ['currency', { currency: 'USD' }],
+  ] satisfies Array<[string, Partial<ServerPaymentAttempt>]>) (
+    'does not expose an attempt when its %s is not server-valid',
+    (_, attemptOverride) => {
+      const presentation = deriveWithAttempt(attemptOverride);
+
+      expect(presentation).toMatchObject({
+        quote: null,
+        attempt: null,
+        payment: {
+          state: 'unconfirmed',
+          isConfirmed: false,
+          label: 'ยังยืนยันรายการนี้ไม่ได้',
+          preventDuplicatePayment: true,
+        },
+        recovery: {
+          kind: 'view-history',
+          href: '/dashboard/payments',
+        },
+      });
+    },
+  );
+
+  it('rejects a method outside the server schema instead of displaying it', () => {
+    const presentation = deriveWithAttempt({
+      method: 'client-invented' as ServerPaymentAttempt['method'],
+    });
+
+    expect(presentation.payment.state).toBe('unconfirmed');
+    expect(presentation.attempt).toBeNull();
+  });
+});

--- a/tests/lib/payment-presentation.test.ts
+++ b/tests/lib/payment-presentation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { derivePaymentPresentation } from '@/lib/payment-presentation';
+
+const NOW = new Date('2026-09-02T07:00:00.000Z');
+
+describe('PaymentPresentation', () => {
+  it('presents the exact pending Stripe Course attempt without claiming payment or access', () => {
+    const presentation = derivePaymentPresentation({
+      kind: 'exact-attempt',
+      ownerId: 'user-1',
+      expectedAttemptId: 'payment-course-1',
+      target: {
+        type: 'course',
+        id: 'course-1',
+        title: 'ชื่อคอร์สปัจจุบัน',
+        href: '/courses/typescript',
+      },
+      attempt: {
+        id: 'payment-course-1',
+        userId: 'user-1',
+        courseId: 'course-1',
+        bundleId: null,
+        itemTitle: 'TypeScript Foundations ตอนที่ซื้อ',
+        amount: '990.00',
+        currency: 'THB',
+        method: 'stripe',
+        status: 'pending',
+        createdAt: new Date('2026-09-02T06:55:00.000Z'),
+      },
+      access: { enrolledCount: 0, totalCount: 1 },
+    }, { now: NOW });
+
+    expect(presentation).toMatchObject({
+      target: {
+        type: 'course',
+        id: 'course-1',
+        title: 'TypeScript Foundations ตอนที่ซื้อ',
+      },
+      quote: {
+        amountDue: '990.00',
+        amountFormatted: '฿990.00',
+        currency: 'THB',
+      },
+      attempt: {
+        id: 'payment-course-1',
+        method: 'stripe',
+        rawStatus: 'pending',
+      },
+      payment: {
+        state: 'pending',
+        isConfirmed: false,
+        label: 'ยังชำระไม่เสร็จ',
+        preventDuplicatePayment: false,
+      },
+      access: { state: 'none', enrolledCount: 0, totalCount: 1 },
+      recovery: {
+        kind: 'restart',
+        label: 'กลับไปเลือกวิธีชำระเงิน',
+        href: '/courses/typescript',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a server-only `PaymentPresentation` module for exact payment attempts
- separate payment confirmation from Course and Bundle access readiness
- derive contextual Thai descriptors and recovery actions for pending, verifying, completed-ready, completed-access-pending, failed, refunded, unconfirmed, and cancelled-return states
- validate attempt identity, owner, target, amount, currency, and method before exposing immutable attempt facts
- add representative Course, Bundle, and payment-history contract coverage

## Safety

- no provider, fulfillment, enrollment, refund, or analytics authority changes
- no latest-payment or current-price fallback is accepted as exact-attempt proof
- no schema or migration changes
- presentation module is pure and server-only

## Verification

- PaymentPresentation contracts: 16 passed
- full Vitest suite: 139 files, 827 tests passed
- ESLint passed
- TypeScript strict check passed
- Next.js production build passed (93 pages)
- `git diff --check` and UTF-8/mojibake audit passed

Closes #38
