### PR TITLE
feat: protect member dashboard learning state

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,132 +1,52 @@
-import { redirect } from 'next/navigation';
-import Link from 'next/link';
-import Image from 'next/image';
 import type { Metadata } from 'next';
-import { auth } from '@/lib/auth';
-import Navbar from '@/components/layout/Navbar';
+import Image from 'next/image';
+import Link from 'next/link';
+
 import Footer from '@/components/layout/Footer';
-import { db } from '@/lib/db';
-import { enrollments, courses, lessons, lessonProgress, certificates, payments } from '@/lib/db/schema';
-import { selectContinuationLesson, sortCoursesByLearningActivity } from '@/lib/learning-continuation';
-import { eq, desc, count, and, inArray, isNull } from 'drizzle-orm';
+import Navbar from '@/components/layout/Navbar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from '@/components/ui/empty';
 import { Progress } from '@/components/ui/progress';
+import { getDashboardLearning } from '@/lib/dashboard-learning';
+import { requireMember } from '@/lib/member-access';
 
 export const metadata: Metadata = {
-    title: 'แดชบอร์ด',
-    description: 'ติดตามความก้าวหน้าและจัดการคอร์สเรียนของคุณ',
+  title: 'แดชบอร์ด',
+  description: 'ติดตามความก้าวหน้าและจัดการคอร์สเรียนของคุณ',
 };
 
 export const dynamic = 'force-dynamic';
 
-async function getUserEnrollments(userId: string) {
-  // Optimized query: Get enrollments with courses in a single query
-  const userEnrollments = await db
-    .select({
-      enrollment: enrollments,
-      course: courses,
-    })
-    .from(enrollments)
-    .innerJoin(courses, eq(enrollments.courseId, courses.id))
-    .where(eq(enrollments.userId, userId))
-    .orderBy(desc(enrollments.enrolledAt));
-
-  if (userEnrollments.length === 0) return [];
-
-  // Get all course IDs
-  const courseIds = userEnrollments.map(e => e.course.id);
-
-  // Read the ordered curriculum and this learner's matching progress without N+1 queries.
-  const [courseLessons, courseProgress] = await Promise.all([
-    db
-      .select({
-        id: lessons.id,
-        courseId: lessons.courseId,
-        orderIndex: lessons.orderIndex,
-      })
-      .from(lessons)
-      .where(inArray(lessons.courseId, courseIds)),
-    db
-      .select({
-        courseId: lessons.courseId,
-        lessonId: lessonProgress.lessonId,
-        completed: lessonProgress.completed,
-        watchTimeSeconds: lessonProgress.watchTimeSeconds,
-        lastWatchedAt: lessonProgress.lastWatchedAt,
-      })
-      .from(lessonProgress)
-      .innerJoin(lessons, eq(lessonProgress.lessonId, lessons.id))
-      .where(
-        and(
-          eq(lessonProgress.userId, userId),
-          inArray(lessons.courseId, courseIds),
-        )
-      ),
-  ]);
-
-  const lessonsByCourse = new Map<string, typeof courseLessons>();
-  const progressByCourse = new Map<string, typeof courseProgress>();
-
-  for (const lesson of courseLessons) {
-    const list = lessonsByCourse.get(lesson.courseId) ?? [];
-    list.push(lesson);
-    lessonsByCourse.set(lesson.courseId, list);
-  }
-
-  for (const progress of courseProgress) {
-    const list = progressByCourse.get(progress.courseId) ?? [];
-    list.push(progress);
-    progressByCourse.set(progress.courseId, list);
-  }
-
-  const enrichedEnrollments = userEnrollments.map(({ enrollment, course }) => {
-    const orderedLessons = lessonsByCourse.get(course.id) ?? [];
-    const progress = progressByCourse.get(course.id) ?? [];
-    const totalLessons = orderedLessons.length;
-    const completedLessons = progress.filter(item => item.completed).length;
-    const progressPercent = totalLessons > 0 ? Math.round((completedLessons / totalLessons) * 100) : 0;
-    const continuationLesson = selectContinuationLesson(orderedLessons, progress);
-
-    return {
-      ...enrollment,
-      course: {
-        ...course,
-        lessonCount: totalLessons,
-      },
-      completedLessons,
-      progressPercent,
-      continuationLessonId: continuationLesson?.id ?? null,
-      progress,
-    };
-  });
-
-  return sortCoursesByLearningActivity(enrichedEnrollments);
+function thumbnailSrc(value: string) {
+  return value.startsWith('http') || value.startsWith('/') ? value : `https://${value}`;
 }
 
 export default async function DashboardPage() {
-  const session = await auth();
+  const member = await requireMember('/dashboard');
+  const dashboard = await getDashboardLearning(member.id);
+  const { primary, remaining, summary } = dashboard;
 
-  if (!session?.user) {
-    redirect('/login');
-  }
-
-  const [userEnrollments, [certCount], [paymentCount]] = await Promise.all([
-    getUserEnrollments(session.user.id),
-    db.select({ count: count() }).from(certificates)
-      .where(and(eq(certificates.userId, session.user.id), isNull(certificates.revokedAt))),
-    db.select({ count: count() }).from(payments)
-      .where(eq(payments.userId, session.user.id)),
-  ]);
-  const certificateCount = certCount?.count || 0;
-  const totalPayments = paymentCount?.count || 0;
-  const completedCourses = userEnrollments.filter((enrollment) => enrollment.completedAt).length;
-  const activeCourses = userEnrollments.filter((enrollment) => !enrollment.completedAt).length;
-  const primaryEnrollment = userEnrollments.find((enrollment) => !enrollment.completedAt) ?? userEnrollments[0] ?? null;
-  const remainingEnrollments = primaryEnrollment
-    ? userEnrollments.filter((enrollment) => enrollment.id !== primaryEnrollment.id)
-    : [];
+  const metrics = [
+    { label: 'คอร์สทั้งหมด', value: summary.courseCount },
+    { label: 'กำลังเรียน', value: summary.activeCourseCount },
+    { label: 'เรียนจบแล้ว', value: summary.completedCourseCount },
+    { label: 'ใบรับรองที่ใช้งานได้', value: summary.activeCertificateCount },
+  ];
 
   return (
     <>
@@ -135,54 +55,165 @@ export default async function DashboardPage() {
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <header className="flex flex-col gap-6 border-b pb-8 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <h1 className="text-4xl font-bold tracking-tight">สวัสดี, {session.user.name || 'นักเรียน'}</h1>
-              <p className="mt-3 max-w-2xl leading-7 text-muted-foreground">กลับมาเรียนต่อจากคอร์สล่าสุด หรือตรวจสอบความคืบหน้าทั้งหมดของคุณ</p>
+              <h1 className="text-4xl font-bold tracking-tight">
+                สวัสดี, {member.name || 'สมาชิก'}
+              </h1>
+              <p className="mt-3 max-w-2xl leading-7 text-muted-foreground">
+                กลับมาเรียนต่อจากจุดล่าสุด หรือตรวจสอบสถานะการเรียนทั้งหมดในบัญชีของคุณ
+              </p>
             </div>
-            <nav className="flex flex-wrap gap-2" aria-label="เมนูบัญชีผู้เรียน">
-              <Button asChild variant="outline"><Link href="/dashboard/certificates">ใบรับรอง <Badge variant="secondary">{certificateCount}</Badge></Link></Button>
-              <Button asChild variant="outline"><Link href="/dashboard/payments">การชำระเงิน <Badge variant="secondary">{totalPayments}</Badge></Link></Button>
-              <Button asChild variant="outline"><Link href="/settings">ตั้งค่าบัญชี</Link></Button>
+            <nav className="flex flex-wrap gap-2" aria-label="เมนูบัญชีสมาชิก">
+              <Button asChild variant="outline">
+                <Link href="/dashboard/certificates">
+                  ใบรับรอง <Badge variant="secondary">{summary.activeCertificateCount}</Badge>
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/dashboard/payments">
+                  การชำระเงิน <Badge variant="secondary">{summary.paymentCount}</Badge>
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/settings">ตั้งค่าบัญชี</Link>
+              </Button>
             </nav>
           </header>
 
-          <section className="my-8 grid grid-cols-2 gap-3 lg:grid-cols-4 [&_div]:rounded-xl [&_div]:border [&_div]:bg-card [&_div]:p-5 [&_span]:block [&_span]:text-sm [&_span]:text-muted-foreground [&_strong]:mt-2 [&_strong]:block [&_strong]:text-3xl" aria-label="สรุปการเรียน">
-            <div><span>คอร์สทั้งหมด</span><strong>{userEnrollments.length}</strong></div><div><span>กำลังเรียน</span><strong>{activeCourses}</strong></div><div><span>เรียนจบแล้ว</span><strong>{completedCourses}</strong></div><div><span>ใบรับรอง</span><strong>{certificateCount}</strong></div>
+          {primary.course ? (
+            <section className="mt-10" aria-labelledby="dashboard-next-action-title">
+              <p className="text-sm font-semibold uppercase tracking-[0.16em] text-primary">
+                สิ่งที่ควรทำต่อ
+              </p>
+              <h2 className="mt-2 text-2xl font-bold" id="dashboard-next-action-title">
+                {primary.enrollment === 'completed' ? 'ตรวจสอบผลลัพธ์ล่าสุด' : 'เดินหน้าจากจุดล่าสุด'}
+              </h2>
+              <Card className="mt-5 py-0">
+                <div className="grid lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                  <div className="relative min-h-64 bg-slate-950">
+                    {primary.course.thumbnailUrl ? (
+                      <Image
+                        className="object-cover"
+                        src={thumbnailSrc(primary.course.thumbnailUrl)}
+                        alt={primary.course.title}
+                        fill
+                        priority
+                        sizes="(max-width: 1024px) 100vw, 42vw"
+                      />
+                    ) : (
+                      <div className="flex h-full min-h-64 flex-col items-center justify-center text-white">
+                        <span className="text-4xl font-bold">MD</span>
+                        <small>Learning</small>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col py-7">
+                    <CardHeader>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={primary.enrollment === 'completed' ? 'default' : 'secondary'}>
+                          {primary.status.label}
+                        </Badge>
+                        <span className="text-sm text-muted-foreground">
+                          {primary.progress.completedLessons}/{primary.progress.totalLessons} บท
+                        </span>
+                      </div>
+                      <CardTitle className="mt-2 text-2xl">{primary.course.title}</CardTitle>
+                      <CardDescription>{primary.status.description}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="mt-6">
+                      <Progress
+                        value={primary.progress.percent}
+                        aria-label={`ความคืบหน้า ${primary.progress.percent}%`}
+                      />
+                      <p className="mt-2 text-right text-sm font-medium">
+                        {primary.progress.percent}%
+                      </p>
+                    </CardContent>
+                    <CardFooter className="mt-5">
+                      <Button asChild>
+                        <Link href={primary.action.href}>
+                          {primary.action.label} <span aria-hidden="true">→</span>
+                        </Link>
+                      </Button>
+                    </CardFooter>
+                  </div>
+                </div>
+              </Card>
+            </section>
+          ) : (
+            <section className="mt-10" aria-labelledby="dashboard-empty-title">
+              <Empty className="border bg-card">
+                <EmptyHeader>
+                  <EmptyTitle>
+                    <h2 id="dashboard-empty-title">{primary.status.label}</h2>
+                  </EmptyTitle>
+                  <EmptyDescription>
+                    {primary.status.description}
+                  </EmptyDescription>
+                </EmptyHeader>
+                <EmptyContent>
+                  <Button asChild>
+                    <Link href={primary.action.href}>
+                      {primary.action.label} <span aria-hidden="true">→</span>
+                    </Link>
+                  </Button>
+                </EmptyContent>
+              </Empty>
+            </section>
+          )}
+
+          <section className="mt-8" aria-label="สรุปการเรียน">
+            <dl className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+              {metrics.map((metric) => (
+                <div className="rounded-xl border bg-card p-5" key={metric.label}>
+                  <dt className="text-sm text-muted-foreground">{metric.label}</dt>
+                  <dd className="mt-2 text-3xl font-bold">{metric.value}</dd>
+                </div>
+              ))}
+            </dl>
           </section>
 
-          {primaryEnrollment ? (
-            <>
-              <section className="mt-10" aria-labelledby="dashboard-continue-title">
-                <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
-                  <div><p>Next action</p><h2 id="dashboard-continue-title">{primaryEnrollment.completedAt ? 'ทบทวนคอร์สล่าสุด' : 'เรียนต่อจากคอร์สล่าสุด'}</h2></div>
-                  <span>{primaryEnrollment.completedLessons} / {primaryEnrollment.course.lessonCount} บทเรียน</span>
+          {primary.course && (
+            <section className="mt-12" aria-labelledby="dashboard-courses-title">
+              <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+                <h2 className="text-2xl font-bold" id="dashboard-courses-title">คอร์สของฉัน</h2>
+                <Button asChild variant="outline">
+                  <Link href="/courses">ดูคอร์สเพิ่มเติม</Link>
+                </Button>
+              </div>
+              {remaining.length > 0 ? (
+                <div className="grid gap-3">
+                  {remaining.map((item, index) => item.course && (
+                    <Card key={item.course.slug} size="sm">
+                      <CardContent>
+                        <Link
+                          href={item.action.href}
+                          className="grid gap-4 sm:grid-cols-[2.5rem_minmax(0,1fr)_12rem_auto] sm:items-center"
+                        >
+                          <span className="text-xs font-semibold text-muted-foreground">
+                            {String(index + 2).padStart(2, '0')}
+                          </span>
+                          <span>
+                            <strong className="block">{item.course.title}</strong>
+                            <span className="text-sm text-muted-foreground">{item.status.label}</span>
+                          </span>
+                          <Progress
+                            value={item.progress.percent}
+                            aria-label={`ความคืบหน้า ${item.progress.percent}%`}
+                          />
+                          <Badge variant={item.enrollment === 'completed' ? 'default' : 'secondary'}>
+                            {item.enrollment === 'completed' ? 'เรียนจบแล้ว' : `${item.progress.percent}%`}
+                          </Badge>
+                        </Link>
+                      </CardContent>
+                    </Card>
+                  ))}
                 </div>
-                <Card className="overflow-hidden"><Link href={primaryEnrollment.continuationLessonId ? `/courses/${primaryEnrollment.course.slug}/learn/${primaryEnrollment.continuationLessonId}` : `/courses/${primaryEnrollment.course.slug}/learn`} className="grid lg:grid-cols-2">
-                  <div className="relative min-h-64 bg-slate-950">
-                    {primaryEnrollment.course.thumbnailUrl ? <Image className="object-cover" src={primaryEnrollment.course.thumbnailUrl.startsWith('http') ? primaryEnrollment.course.thumbnailUrl : `https://${primaryEnrollment.course.thumbnailUrl}`} alt={primaryEnrollment.course.title} fill priority sizes="(max-width: 900px) 100vw, 48vw" /> : <div className="flex h-full min-h-64 flex-col items-center justify-center text-white"><span className="text-4xl font-bold">MD</span><small>Learning</small></div>}
-                  </div>
-                  <CardContent className="flex flex-col justify-center p-7">
-                    <Badge className="w-fit">{primaryEnrollment.progressPercent === 100 ? 'เรียนจบแล้ว' : 'กำลังเรียน'} · {primaryEnrollment.progressPercent}%</Badge>
-                    <h3 className="mt-4 text-2xl font-semibold tracking-tight">{primaryEnrollment.course.title}</h3>
-                    <Progress className="mt-6" value={primaryEnrollment.progressPercent} aria-label={`ความคืบหน้า ${primaryEnrollment.progressPercent}%`} />
-                    <div className="mt-6 flex items-center justify-between font-semibold text-primary"><span>{primaryEnrollment.completedAt ? 'เปิดคอร์สอีกครั้ง' : 'ไปยังบทเรียนถัดไป'}</span><span aria-hidden="true">→</span></div>
-                  </CardContent>
-                </Link></Card>
-              </section>
-
-              <section className="mt-12" aria-labelledby="dashboard-courses-title">
-                <div className="mb-5 flex items-end justify-between gap-3"><h2 className="text-2xl font-bold" id="dashboard-courses-title">คอร์สของฉัน</h2><Button asChild variant="outline"><Link href="/courses">ดูคอร์สเพิ่มเติม</Link></Button></div>
-                {remainingEnrollments.length > 0 ? <div className="grid gap-3">{remainingEnrollments.map((enrollment, index) => (
-                  <Link key={enrollment.id} href={enrollment.continuationLessonId ? `/courses/${enrollment.course.slug}/learn/${enrollment.continuationLessonId}` : `/courses/${enrollment.course.slug}/learn`} className="grid gap-3 rounded-xl border bg-card p-5 transition hover:border-primary/40 sm:grid-cols-[2.5rem_minmax(0,1fr)_12rem_auto] sm:items-center">
-                    <span className="text-xs font-semibold text-muted-foreground">{String(index + 2).padStart(2, '0')}</span>
-                    <div><strong className="block">{enrollment.course.title}</strong><span className="text-sm text-muted-foreground">{enrollment.completedLessons} / {enrollment.course.lessonCount} บทเรียน</span></div>
-                    <Progress value={enrollment.progressPercent} aria-label={`ความคืบหน้า ${enrollment.progressPercent}%`} />
-                    <Badge variant={enrollment.progressPercent === 100 ? 'default' : 'secondary'}>{enrollment.progressPercent === 100 ? 'เรียนจบแล้ว' : `${enrollment.progressPercent}%`}</Badge>
-                  </Link>
-                ))}</div> : <p className="rounded-xl border border-dashed p-6 text-muted-foreground">คอร์สที่ลงทะเบียนทั้งหมดแสดงอยู่ด้านบนแล้ว</p>}
-              </section>
-            </>
-          ) : (
-            <Card className="py-10 text-center" aria-labelledby="dashboard-empty-title"><CardContent className="mx-auto max-w-xl"><h2 className="text-2xl font-bold" id="dashboard-empty-title">เริ่มจากคอร์สที่ตรงกับสิ่งที่คุณอยากสร้าง</h2><p className="mt-3 text-muted-foreground">ดูผลลัพธ์ เนื้อหา และระดับราคาของแต่ละคอร์สก่อนเลือกเส้นทางแรก</p><Button asChild className="mt-6"><Link href="/courses">ดูคอร์สทั้งหมด <span aria-hidden="true">→</span></Link></Button></CardContent></Card>
+              ) : (
+                <p className="rounded-xl border border-dashed p-6 text-muted-foreground">
+                  คอร์สที่ลงทะเบียนทั้งหมดแสดงอยู่ด้านบนแล้ว
+                </p>
+              )}
+            </section>
           )}
         </div>
       </main>

--- a/src/lib/dashboard-learning.ts
+++ b/src/lib/dashboard-learning.ts
@@ -1,0 +1,193 @@
+import 'server-only';
+
+import { and, count, eq, inArray, isNull } from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import {
+  certificates,
+  courses,
+  enrollments,
+  lessonProgress,
+  lessons,
+  payments,
+} from '@/lib/db/schema';
+import {
+  deriveLearningPresentation,
+  type LearningPresentation,
+  type LearningPresentationSource,
+} from '@/lib/learning-presentation';
+import { sortCoursesByLearningActivity } from '@/lib/learning-continuation';
+
+type DashboardLearningRead = {
+  enrollments: LearningPresentationSource[];
+  activeCertificateCount: number;
+  paymentCount: number;
+};
+
+export type DashboardLearningStore = {
+  read(memberId: string): Promise<DashboardLearningRead>;
+};
+
+export type DashboardLearning = {
+  summary: {
+    courseCount: number;
+    activeCourseCount: number;
+    completedCourseCount: number;
+    activeCertificateCount: number;
+    paymentCount: number;
+  };
+  primary: LearningPresentation;
+  remaining: LearningPresentation[];
+};
+
+const databaseDashboardLearningStore: DashboardLearningStore = {
+  async read(memberId) {
+    const [enrollmentRows, [certificateCount], [paymentCount]] = await Promise.all([
+      db
+        .select({
+          courseId: courses.id,
+          courseTitle: courses.title,
+          courseSlug: courses.slug,
+          courseThumbnailUrl: courses.thumbnailUrl,
+          enrolledAt: enrollments.enrolledAt,
+          completedAt: enrollments.completedAt,
+        })
+        .from(enrollments)
+        .innerJoin(courses, eq(enrollments.courseId, courses.id))
+        .where(eq(enrollments.userId, memberId)),
+      db
+        .select({ count: count() })
+        .from(certificates)
+        .where(and(
+          eq(certificates.userId, memberId),
+          isNull(certificates.revokedAt),
+        )),
+      db
+        .select({ count: count() })
+        .from(payments)
+        .where(eq(payments.userId, memberId)),
+    ]);
+
+    if (enrollmentRows.length === 0) {
+      return {
+        enrollments: [],
+        activeCertificateCount: certificateCount?.count ?? 0,
+        paymentCount: paymentCount?.count ?? 0,
+      };
+    }
+
+    const courseIds = enrollmentRows.map((row) => row.courseId);
+    const [lessonRows, progressRows, certificateRows] = await Promise.all([
+      db
+        .select({
+          id: lessons.id,
+          courseId: lessons.courseId,
+          title: lessons.title,
+          orderIndex: lessons.orderIndex,
+        })
+        .from(lessons)
+        .where(inArray(lessons.courseId, courseIds)),
+      db
+        .select({
+          courseId: lessons.courseId,
+          lessonId: lessonProgress.lessonId,
+          completed: lessonProgress.completed,
+          watchTimeSeconds: lessonProgress.watchTimeSeconds,
+          lastWatchedAt: lessonProgress.lastWatchedAt,
+        })
+        .from(lessonProgress)
+        .innerJoin(lessons, eq(lessonProgress.lessonId, lessons.id))
+        .where(and(
+          eq(lessonProgress.userId, memberId),
+          inArray(lessons.courseId, courseIds),
+        )),
+      db
+        .select({
+          courseId: certificates.courseId,
+          revokedAt: certificates.revokedAt,
+        })
+        .from(certificates)
+        .where(and(
+          eq(certificates.userId, memberId),
+          inArray(certificates.courseId, courseIds),
+        )),
+    ]);
+
+    const lessonsByCourse = new Map<string, typeof lessonRows>();
+    for (const lesson of lessonRows) {
+      const courseLessons = lessonsByCourse.get(lesson.courseId) ?? [];
+      courseLessons.push(lesson);
+      lessonsByCourse.set(lesson.courseId, courseLessons);
+    }
+
+    const progressByCourse = new Map<string, typeof progressRows>();
+    for (const progress of progressRows) {
+      const courseProgress = progressByCourse.get(progress.courseId) ?? [];
+      courseProgress.push(progress);
+      progressByCourse.set(progress.courseId, courseProgress);
+    }
+
+    const certificateByCourse = new Map<string, (typeof certificateRows)[number]>();
+    for (const certificate of certificateRows) {
+      const current = certificateByCourse.get(certificate.courseId);
+      if (!current || (current.revokedAt && !certificate.revokedAt)) {
+        certificateByCourse.set(certificate.courseId, certificate);
+      }
+    }
+
+    return {
+      enrollments: enrollmentRows.map((row) => ({
+        course: {
+          id: row.courseId,
+          title: row.courseTitle,
+          slug: row.courseSlug,
+          thumbnailUrl: row.courseThumbnailUrl,
+        },
+        enrollment: {
+          enrolledAt: row.enrolledAt,
+          completedAt: row.completedAt,
+        },
+        lessons: lessonsByCourse.get(row.courseId) ?? [],
+        progress: progressByCourse.get(row.courseId) ?? [],
+        certificate: certificateByCourse.get(row.courseId) ?? null,
+      })),
+      activeCertificateCount: certificateCount?.count ?? 0,
+      paymentCount: paymentCount?.count ?? 0,
+    };
+  },
+};
+
+export async function getDashboardLearning(
+  memberId: string,
+  store: DashboardLearningStore = databaseDashboardLearningStore,
+): Promise<DashboardLearning> {
+  const source = await store.read(memberId);
+  const orderedSources = sortCoursesByLearningActivity(
+    source.enrollments.map((enrollment) => ({
+      enrollment,
+      enrolledAt: enrollment.enrollment.enrolledAt,
+      progress: enrollment.progress,
+    })),
+  ).map(({ enrollment }) => enrollment);
+  const presentations = orderedSources.map(deriveLearningPresentation);
+  const primaryIndex = presentations.findIndex((item) => item.enrollment === 'active');
+  const selectedIndex = primaryIndex >= 0 ? primaryIndex : presentations.length > 0 ? 0 : -1;
+  const primary = selectedIndex >= 0
+    ? presentations[selectedIndex]
+    : deriveLearningPresentation(null);
+  const remaining = selectedIndex >= 0
+    ? presentations.filter((_, index) => index !== selectedIndex)
+    : [];
+
+  return {
+    summary: {
+      courseCount: presentations.length,
+      activeCourseCount: presentations.filter((item) => item.enrollment === 'active').length,
+      completedCourseCount: presentations.filter((item) => item.enrollment === 'completed').length,
+      activeCertificateCount: source.activeCertificateCount,
+      paymentCount: source.paymentCount,
+    },
+    primary,
+    remaining,
+  };
+}

--- a/src/lib/learning-presentation.ts
+++ b/src/lib/learning-presentation.ts
@@ -1,0 +1,196 @@
+import 'server-only';
+
+import {
+  selectContinuationLesson,
+  type ContinuationProgress,
+} from '@/lib/learning-continuation';
+
+export type LearningPresentationSource = {
+  course: {
+    id: string;
+    title: string;
+    slug: string;
+    thumbnailUrl: string | null;
+  };
+  enrollment: {
+    enrolledAt: Date | null;
+    completedAt: Date | null;
+  };
+  lessons: Array<{
+    id: string;
+    title: string;
+    orderIndex: number;
+  }>;
+  progress: ContinuationProgress[];
+  certificate: {
+    revokedAt: Date | null;
+  } | null;
+};
+
+type CoursePresentation = Omit<LearningPresentationSource['course'], 'id'>;
+
+export type LearningPresentation = {
+  enrollment: 'none' | 'active' | 'completed';
+  course: CoursePresentation | null;
+  progress: {
+    completedLessons: number;
+    totalLessons: number;
+    percent: number;
+  };
+  continuation: 'start' | 'resume' | 'review' | 'none';
+  certificate: 'not_eligible' | 'missing' | 'active' | 'revoked';
+  status: {
+    label: string;
+    description: string;
+  };
+  action: {
+    kind: 'view-catalog' | 'view-course' | 'start' | 'resume' | 'review' | 'view-certificates';
+    label: string;
+    href: string;
+  };
+};
+
+const NO_ENROLLMENT: LearningPresentation = {
+  enrollment: 'none',
+  course: null,
+  progress: {
+    completedLessons: 0,
+    totalLessons: 0,
+    percent: 0,
+  },
+  continuation: 'none',
+  certificate: 'not_eligible',
+  status: {
+    label: 'ยังไม่มีคอร์สในการเรียนของฉัน',
+    description: 'เลือกดูรายละเอียดและบทเรียนของแต่ละคอร์สก่อนเริ่มเส้นทางแรก',
+  },
+  action: {
+    kind: 'view-catalog',
+    label: 'ดูคอร์สทั้งหมด',
+    href: '/courses',
+  },
+};
+
+export function deriveLearningPresentation(
+  source: LearningPresentationSource | null,
+): LearningPresentation {
+  if (!source) return NO_ENROLLMENT;
+
+  const course: CoursePresentation = {
+    title: source.course.title,
+    slug: source.course.slug,
+    thumbnailUrl: source.course.thumbnailUrl,
+  };
+  const lessonIds = new Set(source.lessons.map((lesson) => lesson.id));
+  const relevantProgress = source.progress.filter((item) => lessonIds.has(item.lessonId));
+  const totalLessons = source.lessons.length;
+  const completedLessons = new Set(
+    relevantProgress.filter((item) => item.completed).map((item) => item.lessonId),
+  ).size;
+  const percent = totalLessons > 0
+    ? Math.round((completedLessons / totalLessons) * 100)
+    : 0;
+  const courseHref = `/courses/${source.course.slug}`;
+  const certificate = source.certificate
+    ? source.certificate.revokedAt ? 'revoked' : 'active'
+    : source.enrollment.completedAt ? 'missing' : 'not_eligible';
+
+  if (source.enrollment.completedAt) {
+    const label = certificate === 'active'
+      ? 'เรียนจบแล้ว · ใบรับรองพร้อม'
+      : certificate === 'revoked'
+        ? 'เรียนจบแล้ว · ใบรับรองถูกเพิกถอน'
+        : 'เรียนจบแล้ว · ยังไม่พบใบรับรอง';
+    const description = certificate === 'active'
+      ? 'การเรียนจบและใบรับรองที่ยังมีผลถูกบันทึกแยกกันเรียบร้อยแล้ว'
+      : certificate === 'revoked'
+        ? 'การเรียนจบยังคงอยู่ แต่ใบรับรองรายการนี้ถูกเพิกถอนแล้ว'
+        : 'การเรียนจบถูกบันทึกแล้ว แต่ยังไม่พบใบรับรองในบัญชี';
+    const actionLabel = certificate === 'active'
+      ? 'ดูและแชร์ใบรับรอง'
+      : certificate === 'revoked'
+        ? 'ดูสถานะใบรับรอง'
+        : 'ตรวจสอบสถานะใบรับรอง';
+
+    return {
+      enrollment: 'completed',
+      course,
+      progress: { completedLessons, totalLessons, percent },
+      continuation: 'review',
+      certificate,
+      status: { label, description },
+      action: {
+        kind: 'view-certificates',
+        label: actionLabel,
+        href: '/dashboard/certificates',
+      },
+    };
+  }
+
+  if (totalLessons === 0) {
+    return {
+      enrollment: 'active',
+      course,
+      progress: { completedLessons, totalLessons, percent },
+      continuation: 'none',
+      certificate,
+      status: {
+        label: 'คอร์สนี้ยังไม่มีบทเรียนที่เปิดให้เรียน',
+        description: 'สิทธิ์เรียนยังอยู่ในบัญชี แต่ยังไม่มีบทเรียนให้เริ่มในตอนนี้',
+      },
+      action: { kind: 'view-course', label: 'ดูรายละเอียดคอร์ส', href: courseHref },
+    };
+  }
+
+  if (completedLessons === totalLessons && !source.enrollment.completedAt) {
+    return {
+      enrollment: 'active',
+      course,
+      progress: { completedLessons, totalLessons, percent },
+      continuation: 'review',
+      certificate,
+      status: {
+        label: 'เรียนครบแล้ว · กำลังยืนยันการจบ',
+        description: 'ความคืบหน้าครบทุกบทแล้ว แต่ระบบยังไม่บันทึกการเรียนจบอย่างเป็นทางการ',
+      },
+      action: {
+        kind: 'review',
+        label: 'เปิดคอร์สเพื่อตรวจสถานะ',
+        href: `${courseHref}/learn`,
+      },
+    };
+  }
+
+  const continuationLesson = selectContinuationLesson(source.lessons, relevantProgress);
+  const hasLearningActivity = relevantProgress.some((item) => (
+    item.completed === true
+    || (item.watchTimeSeconds ?? 0) > 0
+    || Boolean(item.lastWatchedAt)
+  ));
+  const continuation = hasLearningActivity ? 'resume' : 'start';
+
+  return {
+    enrollment: 'active',
+    course,
+    progress: { completedLessons, totalLessons, percent },
+    continuation,
+    certificate,
+    status: {
+      label: hasLearningActivity
+        ? `กำลังเรียน · ${completedLessons}/${totalLessons} บท`
+        : 'พร้อมเริ่มเรียน',
+      description: hasLearningActivity
+        ? `เรียนจบแล้ว ${completedLessons} จาก ${totalLessons} บท สามารถกลับมาเรียนต่อได้`
+        : 'สิทธิ์เรียนพร้อมแล้ว เริ่มจากบทแรกได้ทันที',
+    },
+    action: continuationLesson
+      ? {
+          kind: continuation,
+          label: continuation === 'start'
+            ? 'เริ่มบทแรก'
+            : `เรียนต่อ: ${source.lessons.find((lesson) => lesson.id === continuationLesson.id)?.title ?? source.course.title}`,
+          href: `${courseHref}/learn`,
+        }
+      : { kind: 'view-course', label: 'ดูรายละเอียดคอร์ส', href: courseHref },
+  };
+}

--- a/src/lib/member-access.ts
+++ b/src/lib/member-access.ts
@@ -1,0 +1,26 @@
+import 'server-only';
+
+import { cache } from 'react';
+import { redirect } from 'next/navigation';
+
+import { auth } from '@/lib/auth';
+import { createAuthReturnHref } from '@/lib/safe-auth-return';
+
+export type MemberAccess = Readonly<{
+  id: string;
+  name: string | null;
+}>;
+
+export const requireMember = cache(async (returnPath: string): Promise<MemberAccess> => {
+  const session = await auth();
+  const memberId = session?.user?.id;
+
+  if (!memberId) {
+    redirect(createAuthReturnHref('/login', returnPath));
+  }
+
+  return {
+    id: memberId,
+    name: session.user.name?.trim() || null,
+  };
+});

--- a/tests/components/dashboard-member-access.test.tsx
+++ b/tests/components/dashboard-member-access.test.tsx
@@ -1,0 +1,76 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getDashboardLearning, requireMember } = vi.hoisted(() => ({
+  getDashboardLearning: vi.fn(),
+  requireMember: vi.fn(),
+}));
+
+vi.mock('@/lib/member-access', () => ({ requireMember }));
+vi.mock('@/lib/dashboard-learning', () => ({ getDashboardLearning }));
+vi.mock('@/components/layout/Navbar', () => ({
+  default: () => <div data-layout="navbar" />,
+}));
+vi.mock('@/components/layout/Footer', () => ({
+  default: () => <div data-layout="footer" />,
+}));
+
+import DashboardPage from '@/app/dashboard/page';
+
+describe('DashboardPage member access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('authorizes the exact route before starting a private read', async () => {
+    requireMember.mockRejectedValueOnce(new Error('NEXT_REDIRECT'));
+
+    await expect(DashboardPage()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(requireMember).toHaveBeenCalledWith('/dashboard');
+    expect(getDashboardLearning).not.toHaveBeenCalled();
+  });
+
+  it('renders the next action before summary metrics from the minimal projection', async () => {
+    requireMember.mockResolvedValueOnce({ id: 'member-1', name: 'ไมเลอร์' });
+    getDashboardLearning.mockResolvedValueOnce({
+      summary: {
+        courseCount: 1,
+        activeCourseCount: 1,
+        completedCourseCount: 0,
+        activeCertificateCount: 0,
+        paymentCount: 2,
+      },
+      primary: {
+        enrollment: 'active',
+        course: {
+          id: 'course-1',
+          title: 'TypeScript ที่ใช้ได้จริง',
+          slug: 'typescript',
+          thumbnailUrl: null,
+        },
+        progress: { completedLessons: 1, totalLessons: 4, percent: 25 },
+        continuation: 'resume',
+        certificate: 'not_eligible',
+        status: {
+          label: 'กำลังเรียน · 1/4 บท',
+          description: 'เรียนจบแล้ว 1 จาก 4 บท สามารถกลับมาเรียนต่อได้',
+        },
+        action: {
+          kind: 'resume',
+          label: 'เรียนต่อ: Generics',
+          href: '/courses/typescript/learn',
+        },
+      },
+      remaining: [],
+    });
+
+    const html = renderToStaticMarkup(await DashboardPage());
+
+    expect(getDashboardLearning).toHaveBeenCalledWith('member-1');
+    expect(html).toContain('สวัสดี, ไมเลอร์');
+    expect(html).toContain('เรียนต่อ: Generics');
+    expect(html.indexOf('สิ่งที่ควรทำต่อ')).toBeLessThan(html.indexOf('สรุปการเรียน'));
+    expect(html).not.toContain('member-1');
+  });
+});

--- a/tests/lib/dashboard-learning-empty.test.ts
+++ b/tests/lib/dashboard-learning-empty.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getDashboardLearning,
+  type DashboardLearningStore,
+} from '@/lib/dashboard-learning';
+
+describe('getDashboardLearning without enrollment', () => {
+  it('returns the canonical member presentation and preserves account counts', async () => {
+    const store: DashboardLearningStore = {
+      read: async () => ({
+        enrollments: [],
+        activeCertificateCount: 0,
+        paymentCount: 2,
+      }),
+    };
+
+    const dashboard = await getDashboardLearning('member-without-enrollment', store);
+
+    expect(dashboard).toEqual({
+      summary: {
+        courseCount: 0,
+        activeCourseCount: 0,
+        completedCourseCount: 0,
+        activeCertificateCount: 0,
+        paymentCount: 2,
+      },
+      primary: {
+        enrollment: 'none',
+        course: null,
+        progress: { completedLessons: 0, totalLessons: 0, percent: 0 },
+        continuation: 'none',
+        certificate: 'not_eligible',
+        status: {
+          label: 'ยังไม่มีคอร์สในการเรียนของฉัน',
+          description: 'เลือกดูรายละเอียดและบทเรียนของแต่ละคอร์สก่อนเริ่มเส้นทางแรก',
+        },
+        action: {
+          kind: 'view-catalog',
+          label: 'ดูคอร์สทั้งหมด',
+          href: '/courses',
+        },
+      },
+      remaining: [],
+    });
+  });
+});

--- a/tests/lib/dashboard-learning.test.ts
+++ b/tests/lib/dashboard-learning.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getDashboardLearning,
+  type DashboardLearningStore,
+} from '@/lib/dashboard-learning';
+
+describe('getDashboardLearning', () => {
+  it('returns a minimal presentation without private source fields', async () => {
+    const store: DashboardLearningStore = {
+      read: vi.fn().mockResolvedValue({
+        enrollments: [
+          {
+            course: {
+              id: 'course-active',
+              title: 'Active Course',
+              slug: 'active-course',
+              thumbnailUrl: null,
+            },
+            enrollment: {
+              enrolledAt: new Date('2026-08-20T00:00:00.000Z'),
+              completedAt: null,
+            },
+            lessons: [
+              { id: 'private-lesson-id', title: 'บทเรียนถัดไป', orderIndex: 1 },
+            ],
+            progress: [
+              {
+                lessonId: 'private-lesson-id',
+                completed: false,
+                watchTimeSeconds: 45,
+                lastWatchedAt: new Date('2026-09-01T00:00:00.000Z'),
+              },
+            ],
+            certificate: null,
+          },
+          {
+            course: {
+              id: 'course-completed',
+              title: 'Completed Course',
+              slug: 'completed-course',
+              thumbnailUrl: null,
+            },
+            enrollment: {
+              enrolledAt: new Date('2026-07-01T00:00:00.000Z'),
+              completedAt: new Date('2026-07-20T00:00:00.000Z'),
+            },
+            lessons: [],
+            progress: [],
+            certificate: {
+              revokedAt: new Date('2026-08-01T00:00:00.000Z'),
+            },
+          },
+        ],
+        activeCertificateCount: 0,
+        paymentCount: 7,
+      }),
+    };
+
+    const dashboard = await getDashboardLearning('private-member-id', store);
+
+    expect(store.read).toHaveBeenCalledWith('private-member-id');
+    expect(dashboard).toMatchObject({
+      summary: {
+        courseCount: 2,
+        activeCourseCount: 1,
+        completedCourseCount: 1,
+        activeCertificateCount: 0,
+        paymentCount: 7,
+      },
+      primary: {
+        enrollment: 'active',
+        course: { slug: 'active-course' },
+        action: { label: 'เรียนต่อ: บทเรียนถัดไป' },
+      },
+      remaining: [
+        {
+          enrollment: 'completed',
+          course: { slug: 'completed-course' },
+          certificate: 'revoked',
+        },
+      ],
+    });
+
+    const serialized = JSON.stringify(dashboard);
+    expect(serialized).not.toContain('private-member-id');
+    expect(serialized).not.toContain('course-active');
+    expect(serialized).not.toContain('course-completed');
+    expect(serialized).not.toContain('private-lesson-id');
+    expect(serialized).not.toContain('2026-09-01');
+  });
+});

--- a/tests/lib/learning-presentation-completion.test.ts
+++ b/tests/lib/learning-presentation-completion.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveLearningPresentation,
+  type LearningPresentationSource,
+} from '@/lib/learning-presentation';
+
+const baseSource: Omit<LearningPresentationSource, 'certificate'> = {
+  course: {
+    id: 'course-1',
+    title: 'TypeScript Foundations',
+    slug: 'typescript',
+    thumbnailUrl: null,
+  },
+  enrollment: {
+    enrolledAt: new Date('2026-08-01T00:00:00.000Z'),
+    completedAt: new Date('2026-08-10T00:00:00.000Z'),
+  },
+  lessons: [
+    { id: 'lesson-1', title: 'เริ่มต้น', orderIndex: 1 },
+    { id: 'lesson-2', title: 'Generics', orderIndex: 2 },
+    { id: 'lesson-3', title: 'Workshop ใหม่', orderIndex: 3 },
+  ],
+  progress: [
+    {
+      lessonId: 'lesson-1',
+      completed: true,
+      watchTimeSeconds: 300,
+      lastWatchedAt: new Date('2026-08-02T00:00:00.000Z'),
+    },
+    {
+      lessonId: 'lesson-2',
+      completed: true,
+      watchTimeSeconds: 300,
+      lastWatchedAt: new Date('2026-08-03T00:00:00.000Z'),
+    },
+  ],
+};
+
+describe('LearningPresentation completion and certificate facts', () => {
+  it('keeps authoritative completion separate from current progress and certificate status', () => {
+    const missing = deriveLearningPresentation({ ...baseSource, certificate: null });
+    const active = deriveLearningPresentation({
+      ...baseSource,
+      certificate: { revokedAt: null },
+    });
+    const revoked = deriveLearningPresentation({
+      ...baseSource,
+      certificate: {
+        revokedAt: new Date('2026-08-20T00:00:00.000Z'),
+      },
+    });
+
+    expect(missing).toMatchObject({
+      enrollment: 'completed',
+      progress: { completedLessons: 2, totalLessons: 3, percent: 67 },
+      continuation: 'review',
+      certificate: 'missing',
+      status: { label: 'เรียนจบแล้ว · ยังไม่พบใบรับรอง' },
+      action: {
+        kind: 'view-certificates',
+        label: 'ตรวจสอบสถานะใบรับรอง',
+        href: '/dashboard/certificates',
+      },
+    });
+    expect(active).toMatchObject({
+      enrollment: 'completed',
+      certificate: 'active',
+      status: { label: 'เรียนจบแล้ว · ใบรับรองพร้อม' },
+      action: { kind: 'view-certificates', label: 'ดูและแชร์ใบรับรอง' },
+    });
+    expect(revoked).toMatchObject({
+      enrollment: 'completed',
+      certificate: 'revoked',
+      status: { label: 'เรียนจบแล้ว · ใบรับรองถูกเพิกถอน' },
+      action: { kind: 'view-certificates', label: 'ดูสถานะใบรับรอง' },
+    });
+  });
+});

--- a/tests/lib/learning-presentation-progress.test.ts
+++ b/tests/lib/learning-presentation-progress.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveLearningPresentation,
+  type LearningPresentationSource,
+} from '@/lib/learning-presentation';
+
+const lessons = [
+  { id: 'lesson-1', title: 'เริ่มต้น TypeScript', orderIndex: 1 },
+  { id: 'lesson-2', title: 'Generics', orderIndex: 2 },
+  { id: 'lesson-3', title: 'Workshop', orderIndex: 3 },
+];
+
+function source(progress: LearningPresentationSource['progress']): LearningPresentationSource {
+  return {
+    course: {
+      id: 'course-1',
+      title: 'TypeScript Foundations',
+      slug: 'typescript',
+      thumbnailUrl: null,
+    },
+    enrollment: {
+      enrolledAt: new Date('2026-08-01T00:00:00.000Z'),
+      completedAt: null,
+    },
+    lessons,
+    progress,
+    certificate: null,
+  };
+}
+
+describe('LearningPresentation progress states', () => {
+  it('derives start, resume, and completion-pending actions without treating 100% as completion', () => {
+    const starting = deriveLearningPresentation(source([]));
+    const partial = deriveLearningPresentation(source([
+      {
+        lessonId: 'lesson-1',
+        completed: true,
+        watchTimeSeconds: 300,
+        lastWatchedAt: new Date('2026-08-02T00:00:00.000Z'),
+      },
+      {
+        lessonId: 'lesson-2',
+        completed: false,
+        watchTimeSeconds: 90,
+        lastWatchedAt: new Date('2026-08-03T00:00:00.000Z'),
+      },
+    ]));
+    const awaitingCompletion = deriveLearningPresentation(source(
+      lessons.map((lesson) => ({
+        lessonId: lesson.id,
+        completed: true,
+        watchTimeSeconds: 300,
+        lastWatchedAt: new Date('2026-08-04T00:00:00.000Z'),
+      })),
+    ));
+
+    expect(starting).toMatchObject({
+      enrollment: 'active',
+      progress: { completedLessons: 0, totalLessons: 3, percent: 0 },
+      continuation: 'start',
+      certificate: 'not_eligible',
+      status: { label: 'พร้อมเริ่มเรียน' },
+      action: {
+        kind: 'start',
+        label: 'เริ่มบทแรก',
+        href: '/courses/typescript/learn',
+      },
+    });
+    expect(partial).toMatchObject({
+      enrollment: 'active',
+      progress: { completedLessons: 1, totalLessons: 3, percent: 33 },
+      continuation: 'resume',
+      status: { label: 'กำลังเรียน · 1/3 บท' },
+      action: {
+        kind: 'resume',
+        label: 'เรียนต่อ: Generics',
+        href: '/courses/typescript/learn',
+      },
+    });
+    expect(awaitingCompletion).toMatchObject({
+      enrollment: 'active',
+      progress: { completedLessons: 3, totalLessons: 3, percent: 100 },
+      continuation: 'review',
+      certificate: 'not_eligible',
+      status: { label: 'เรียนครบแล้ว · กำลังยืนยันการจบ' },
+      action: {
+        kind: 'review',
+        label: 'เปิดคอร์สเพื่อตรวจสถานะ',
+        href: '/courses/typescript/learn',
+      },
+    });
+  });
+});

--- a/tests/lib/learning-presentation.test.ts
+++ b/tests/lib/learning-presentation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveLearningPresentation } from '@/lib/learning-presentation';
+
+describe('LearningPresentation', () => {
+  it('keeps a member without enrollment distinct from a learner', () => {
+    const presentation = deriveLearningPresentation(null);
+
+    expect(presentation).toEqual({
+      enrollment: 'none',
+      course: null,
+      progress: {
+        completedLessons: 0,
+        totalLessons: 0,
+        percent: 0,
+      },
+      continuation: 'none',
+      certificate: 'not_eligible',
+      status: {
+        label: 'ยังไม่มีคอร์สในการเรียนของฉัน',
+        description: 'เลือกดูรายละเอียดและบทเรียนของแต่ละคอร์สก่อนเริ่มเส้นทางแรก',
+      },
+      action: {
+        kind: 'view-catalog',
+        label: 'ดูคอร์สทั้งหมด',
+        href: '/courses',
+      },
+    });
+  });
+});

--- a/tests/lib/member-access.test.ts
+++ b/tests/lib/member-access.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { authMock, redirectMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('next/navigation', () => ({ redirect: redirectMock }));
+
+import { requireMember } from '@/lib/member-access';
+
+describe('requireMember', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redirectMock.mockImplementation((href: string) => {
+      throw new Error(`REDIRECT:${href}`);
+    });
+  });
+
+  it('redirects an unauthenticated private request with its exact safe return path', async () => {
+    authMock.mockResolvedValue(null);
+
+    await expect(requireMember('/dashboard/payments')).rejects.toThrow(
+      'REDIRECT:/login?callbackUrl=%2Fdashboard%2Fpayments',
+    );
+    expect(redirectMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns only the member identity needed by downstream private reads', async () => {
+    authMock.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        name: 'Miler',
+        email: 'private@example.com',
+        role: 'admin',
+        sessionVersion: 9,
+      },
+    });
+
+    await expect(requireMember('/dashboard')).resolves.toEqual({
+      id: 'user-1',
+      name: 'Miler',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared server-only member guard with an exact safe login return
- derive minimal Dashboard learning presentation for empty, active, completed, and certificate states
- authorize before private reads and render the next learning action before summary metrics
- keep internal member, course, lesson, certificate, and activity fields out of the presentation DTO

## Verification

- `npm run lint`
- `npx tsc --noEmit`
- `npm run test -- --run` (146 files, 836 tests)
- `npm run build`
- `git diff --check`

Closes #39
