### PR TITLE
feat(certificates): add idempotent repair projections

### DIFF
--- a/src/app/api/certificates/repair/route.ts
+++ b/src/app/api/certificates/repair/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { auth } from '@/lib/auth';
+import { repairOwnerCertificate } from '@/lib/certificate-credentials';
+import { checkRateLimit, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
+
+const repairSchema = z.object({
+  courseSlug: z.string().trim().min(1).max(255),
+}).strict();
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const rateLimit = checkRateLimit(
+    `certificate-repair:${session.user.id}`,
+    rateLimits.sensitive,
+  );
+  if (!rateLimit.success) return rateLimitResponse(rateLimit.resetTime);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid certificate repair request' }, { status: 400 });
+  }
+  const parsed = repairSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid certificate repair request' }, { status: 400 });
+  }
+
+  const result = await repairOwnerCertificate(
+    session.user.id,
+    parsed.data.courseSlug,
+  );
+  const status = result.kind === 'issued'
+    ? 201
+    : result.kind === 'revoked' || result.kind === 'not_completed'
+      ? 409
+      : result.kind === 'temporarily_unavailable'
+        ? 503
+        : 200;
+  return NextResponse.json({ result }, { status });
+}

--- a/src/app/api/certificates/route.ts
+++ b/src/app/api/certificates/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { logError } from '@/lib/error-handler';
-import { auth } from '@/lib/auth';
-import { db } from '@/lib/db';
-import { certificates } from '@/lib/db/schema';
-import { eq, and, isNull, desc } from 'drizzle-orm';
 
-// GET /api/certificates - Get current user's certificates
+import { auth } from '@/lib/auth';
+import { getOwnerCertificateCollection } from '@/lib/certificate-credentials';
+import { logError } from '@/lib/error-handler';
+
+// GET /api/certificates - Get the current owner's certificate projection.
 export async function GET() {
   try {
     const session = await auth();
@@ -13,20 +12,30 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const userCerts = await db
-      .select()
-      .from(certificates)
-      .where(
-        and(
-          eq(certificates.userId, session.user.id),
-          isNull(certificates.revokedAt)
-        )
-      )
-      .orderBy(desc(certificates.issuedAt));
+    const collection = await getOwnerCertificateCollection(session.user.id);
+    const legacyActiveCertificates = collection.items.flatMap((item) => (
+      item.kind === 'active'
+        ? [{
+          id: item.code,
+          certificateCode: item.code,
+          recipientName: item.recipientName,
+          courseTitle: item.courseTitle,
+          completedAt: item.completedAt,
+          issuedAt: item.issuedAt,
+        }]
+        : []
+    ));
 
-    return NextResponse.json({ certificates: userCerts });
+    return NextResponse.json({
+      collection,
+      // Temporary compatibility for the current dashboard. Issue #52 moves it
+      // to the status-aware collection and removes this active-only shape.
+      certificates: legacyActiveCertificates,
+    });
   } catch (error) {
-    logError(error instanceof Error ? error : new Error(String(error)), { action: 'Error fetching user certificates:' });
+    logError(error instanceof Error ? error : new Error(String(error)), {
+      action: 'certificate.collection.failed',
+    });
     return NextResponse.json({ error: 'เกิดข้อผิดพลาด' }, { status: 500 });
   }
 }

--- a/src/app/certificate/[code]/page.tsx
+++ b/src/app/certificate/[code]/page.tsx
@@ -5,9 +5,7 @@ import { BadgeCheck, CircleX } from 'lucide-react';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import CertificateCard from '@/components/certificate/CertificateCard';
-import { db } from '@/lib/db';
-import { certificates, courses } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { getPublicCertificateVerification } from '@/lib/certificate-credentials';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
 export const dynamic = 'force-dynamic';
@@ -17,41 +15,8 @@ interface Props {
 }
 
 const getCertificate = cache(async (code: string) => {
-  const [cert] = await db
-    .select({
-      id: certificates.id,
-      certificateCode: certificates.certificateCode,
-      recipientName: certificates.recipientName,
-      courseTitle: certificates.courseTitle,
-      completedAt: certificates.completedAt,
-      issuedAt: certificates.issuedAt,
-      revokedAt: certificates.revokedAt,
-      certificateTheme: certificates.certificateTheme,
-      certificateHeaderImage: certificates.certificateHeaderImage,
-      userId: certificates.userId,
-      courseId: certificates.courseId,
-    })
-    .from(certificates)
-    .where(eq(certificates.certificateCode, code))
-    .limit(1);
-
-  if (!cert) return null;
-
-  const [course] = await db
-    .select({ slug: courses.slug })
-    .from(courses)
-    .where(eq(courses.id, cert.courseId))
-    .limit(1);
-
-  return {
-    ...cert,
-    completedAt: cert.completedAt.toISOString(),
-    issuedAt: cert.issuedAt ? cert.issuedAt.toISOString() : null,
-    revokedAt: cert.revokedAt ? cert.revokedAt.toISOString() : null,
-    certificateTheme: cert.certificateTheme || null,
-    certificateHeaderImage: cert.certificateHeaderImage || null,
-    courseSlug: course?.slug || null,
-  };
+  const result = await getPublicCertificateVerification(code);
+  return result.kind === 'not_found' ? null : result.credential;
 });
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -90,6 +55,7 @@ export default async function CertificatePage({ params }: Props) {
   if (!cert) notFound();
 
   const isRevoked = !!cert.revokedAt;
+  const { code: certificateCode, ...certificateData } = cert;
 
   return (
     <>
@@ -110,7 +76,7 @@ export default async function CertificatePage({ params }: Props) {
               <AlertDescription>{isRevoked ? 'ใบรับรองนี้ถูกเพิกถอนแล้ว' : 'ใบรับรองนี้ตรวจสอบได้'}</AlertDescription>
             </Alert>
           </header>
-          <CertificateCard cert={cert} />
+          <CertificateCard cert={{ ...certificateData, certificateCode }} />
         </div>
       </main>
       <Footer />

--- a/src/app/dashboard/certificates/CertificateCollection.tsx
+++ b/src/app/dashboard/certificates/CertificateCollection.tsx
@@ -33,7 +33,6 @@ interface Certificate {
   courseTitle: string;
   completedAt: string;
   issuedAt: string;
-  courseId: string;
 }
 
 function formatDate(date: string) {

--- a/src/components/certificate/CertificateCard.tsx
+++ b/src/components/certificate/CertificateCard.tsx
@@ -17,7 +17,7 @@ interface CertificateData {
   issuedAt: string | null;
   revokedAt: string | null;
   courseSlug: string | null;
-  courseId: string;
+  courseId?: string;
   certificateTheme?: string | null;
   certificateHeaderImage?: string | null;
 }

--- a/src/lib/certificate-credentials.ts
+++ b/src/lib/certificate-credentials.ts
@@ -1,0 +1,284 @@
+import 'server-only';
+
+import { and, asc, eq } from 'drizzle-orm';
+
+import { ensureCompletedCertificate } from '@/lib/certificate';
+import { db } from '@/lib/db';
+import { certificates, courses, enrollments } from '@/lib/db/schema';
+import { logError } from '@/lib/error-handler';
+
+type OwnerEnrollmentFact = {
+  courseId: string;
+  courseTitle: string;
+  courseSlug: string;
+  enrolledAt: Date | null;
+  completedAt: Date | null;
+};
+
+type OwnerCertificateFact = {
+  courseId: string;
+  certificateCode: string;
+  recipientName: string;
+  courseTitle: string;
+  courseSlug: string;
+  completedAt: Date;
+  issuedAt: Date | null;
+  revokedAt: Date | null;
+};
+
+type PublicCertificateFact = Omit<OwnerCertificateFact, 'courseId'> & {
+  certificateTheme: string | null;
+  certificateHeaderImage: string | null;
+};
+
+export type CertificateProjectionStore = {
+  readOwner(memberId: string): Promise<{
+    enrollments: OwnerEnrollmentFact[];
+    certificates: OwnerCertificateFact[];
+  }>;
+  readPublic(code: string): Promise<PublicCertificateFact | null>;
+};
+
+type OwnerCertificateItem =
+  | {
+    kind: 'active' | 'revoked';
+    code: string;
+    recipientName: string;
+    courseTitle: string;
+    courseSlug: string;
+    completedAt: string;
+    issuedAt: string | null;
+  }
+  | {
+    kind: 'missing';
+    courseTitle: string;
+    courseSlug: string;
+    completedAt: string;
+  };
+
+export type PublicCertificateVerification =
+  | { kind: 'not_found' }
+  | {
+    kind: 'active' | 'revoked';
+    credential: {
+      code: string;
+      recipientName: string;
+      courseTitle: string;
+      courseSlug: string | null;
+      completedAt: string;
+      issuedAt: string | null;
+      revokedAt: string | null;
+      certificateTheme: string | null;
+      certificateHeaderImage: string | null;
+    };
+  };
+
+export type OwnerCertificateCollection = {
+  summary: {
+    activeCount: number;
+    revokedCount: number;
+    missingCount: number;
+    hasEnrollment: boolean;
+  };
+  items: OwnerCertificateItem[];
+};
+
+export type CertificateRecoveryResult =
+  | { kind: 'ready' | 'issued' | 'revoked'; code: string }
+  | { kind: 'not_completed' | 'temporarily_unavailable' };
+
+export type CertificateRepairAdapter = {
+  read(memberId: string, courseSlug: string): Promise<{
+    courseId: string;
+    completedAt: Date | null;
+    certificate: { code: string; revokedAt: Date | null } | null;
+  } | null>;
+  ensureCompleted(memberId: string, courseId: string): Promise<CertificateRecoveryResult>;
+};
+
+const databaseProjectionStore: CertificateProjectionStore = {
+  async readOwner(memberId) {
+    const [enrollmentRows, certificateRows] = await Promise.all([
+      db
+        .select({
+          courseId: courses.id,
+          courseTitle: courses.title,
+          courseSlug: courses.slug,
+          enrolledAt: enrollments.enrolledAt,
+          completedAt: enrollments.completedAt,
+        })
+        .from(enrollments)
+        .innerJoin(courses, eq(enrollments.courseId, courses.id))
+        .where(eq(enrollments.userId, memberId)),
+      db
+        .select({
+          courseId: certificates.courseId,
+          certificateCode: certificates.certificateCode,
+          recipientName: certificates.recipientName,
+          courseTitle: certificates.courseTitle,
+          courseSlug: courses.slug,
+          completedAt: certificates.completedAt,
+          issuedAt: certificates.issuedAt,
+          revokedAt: certificates.revokedAt,
+        })
+        .from(certificates)
+        .innerJoin(courses, eq(certificates.courseId, courses.id))
+        .where(eq(certificates.userId, memberId)),
+    ]);
+    return { enrollments: enrollmentRows, certificates: certificateRows };
+  },
+
+  async readPublic(code) {
+    const [certificate] = await db
+      .select({
+        certificateCode: certificates.certificateCode,
+        recipientName: certificates.recipientName,
+        courseTitle: certificates.courseTitle,
+        courseSlug: courses.slug,
+        completedAt: certificates.completedAt,
+        issuedAt: certificates.issuedAt,
+        revokedAt: certificates.revokedAt,
+        certificateTheme: certificates.certificateTheme,
+        certificateHeaderImage: certificates.certificateHeaderImage,
+      })
+      .from(certificates)
+      .innerJoin(courses, eq(certificates.courseId, courses.id))
+      .where(eq(certificates.certificateCode, code))
+      .limit(1);
+    return certificate ?? null;
+  },
+};
+
+const databaseRepairAdapter: CertificateRepairAdapter = {
+  async read(memberId, courseSlug) {
+    const [enrollment] = await db
+      .select({
+        courseId: courses.id,
+        completedAt: enrollments.completedAt,
+      })
+      .from(enrollments)
+      .innerJoin(courses, eq(enrollments.courseId, courses.id))
+      .where(and(
+        eq(enrollments.userId, memberId),
+        eq(courses.slug, courseSlug),
+      ))
+      .limit(1);
+    if (!enrollment) return null;
+
+    const [certificate] = await db
+      .select({
+        code: certificates.certificateCode,
+        revokedAt: certificates.revokedAt,
+      })
+      .from(certificates)
+      .where(and(
+        eq(certificates.userId, memberId),
+        eq(certificates.courseId, enrollment.courseId),
+      ))
+      .orderBy(asc(certificates.revokedAt))
+      .limit(1);
+    return {
+      ...enrollment,
+      certificate: certificate ?? null,
+    };
+  },
+
+  ensureCompleted: ensureCompletedCertificate,
+};
+
+function timestamp(value: Date | null) {
+  return value?.getTime() ?? 0;
+}
+
+export async function getOwnerCertificateCollection(
+  memberId: string,
+  store: CertificateProjectionStore = databaseProjectionStore,
+): Promise<OwnerCertificateCollection> {
+  const ownerFacts = await store.readOwner(memberId);
+  const certificateCourseIds = new Set(
+    ownerFacts.certificates.map((certificate) => certificate.courseId),
+  );
+  const credentials: OwnerCertificateItem[] = [...ownerFacts.certificates]
+    .sort((left, right) => (
+      (left.revokedAt ? 1 : 0) - (right.revokedAt ? 1 : 0)
+      || timestamp(right.issuedAt) - timestamp(left.issuedAt)
+    ))
+    .map((certificate) => ({
+      kind: certificate.revokedAt ? 'revoked' as const : 'active' as const,
+      code: certificate.certificateCode,
+      recipientName: certificate.recipientName,
+      courseTitle: certificate.courseTitle,
+      courseSlug: certificate.courseSlug,
+      completedAt: certificate.completedAt.toISOString(),
+      issuedAt: certificate.issuedAt?.toISOString() ?? null,
+    }));
+  const missing: OwnerCertificateItem[] = ownerFacts.enrollments
+    .filter((enrollment) => (
+      enrollment.completedAt
+      && !certificateCourseIds.has(enrollment.courseId)
+    ))
+    .sort((left, right) => timestamp(right.completedAt) - timestamp(left.completedAt))
+    .map((enrollment) => ({
+      kind: 'missing',
+      courseTitle: enrollment.courseTitle,
+      courseSlug: enrollment.courseSlug,
+      completedAt: enrollment.completedAt!.toISOString(),
+    }));
+
+  return {
+    summary: {
+      activeCount: credentials.filter((item) => item.kind === 'active').length,
+      revokedCount: credentials.filter((item) => item.kind === 'revoked').length,
+      missingCount: missing.length,
+      hasEnrollment: ownerFacts.enrollments.length > 0,
+    },
+    items: [...credentials, ...missing],
+  };
+}
+
+export async function getPublicCertificateVerification(
+  code: string,
+  store: CertificateProjectionStore = databaseProjectionStore,
+): Promise<PublicCertificateVerification> {
+  const certificate = await store.readPublic(code);
+  if (!certificate) return { kind: 'not_found' };
+
+  return {
+    kind: certificate.revokedAt ? 'revoked' : 'active',
+    credential: {
+      code: certificate.certificateCode,
+      recipientName: certificate.recipientName,
+      courseTitle: certificate.courseTitle,
+      courseSlug: certificate.courseSlug || null,
+      completedAt: certificate.completedAt.toISOString(),
+      issuedAt: certificate.issuedAt?.toISOString() ?? null,
+      revokedAt: certificate.revokedAt?.toISOString() ?? null,
+      certificateTheme: certificate.certificateTheme ?? null,
+      certificateHeaderImage: certificate.certificateHeaderImage ?? null,
+    },
+  };
+}
+
+export async function repairOwnerCertificate(
+  memberId: string,
+  courseSlug: string,
+  adapter: CertificateRepairAdapter = databaseRepairAdapter,
+): Promise<CertificateRecoveryResult> {
+  try {
+    const recoveryState = await adapter.read(memberId, courseSlug);
+    if (!recoveryState?.completedAt) return { kind: 'not_completed' };
+    if (recoveryState.certificate) {
+      return {
+        kind: recoveryState.certificate.revokedAt ? 'revoked' : 'ready',
+        code: recoveryState.certificate.code,
+      };
+    }
+
+    return await adapter.ensureCompleted(memberId, recoveryState.courseId);
+  } catch (error) {
+    logError(error instanceof Error ? error : new Error(String(error)), {
+      action: 'certificate.repair.failed',
+    });
+    return { kind: 'temporarily_unavailable' };
+  }
+}

--- a/src/lib/certificate.ts
+++ b/src/lib/certificate.ts
@@ -1,119 +1,205 @@
-import { db } from '@/lib/db';
-import { certificates, courses, users } from '@/lib/db/schema';
-import { eq, and } from 'drizzle-orm';
-import { createId } from '@paralleldrive/cuid2';
-import { sendCertificateEmail } from '@/lib/email';
-import { notify } from '@/lib/notify';
-import { logError } from '@/lib/error-handler';
+import 'server-only';
 
-/**
- * Generate a unique certificate code like "CERT-XXXX-XXXX"
- */
+import { createId } from '@paralleldrive/cuid2';
+import { and, asc, eq } from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import { certificates, courses, enrollments, users } from '@/lib/db/schema';
+import { isDuplicateKeyError } from '@/lib/db/safe-insert';
+import { sendCertificateEmail } from '@/lib/email';
+import { logError } from '@/lib/error-handler';
+import { notify } from '@/lib/notify';
+
+type CertificateRecord = typeof certificates.$inferSelect;
+type IssuanceAuthority = 'explicit_admin_intent' | 'verified_completion';
+
+type IssuanceOutcome =
+  | { kind: 'not_completed' }
+  | {
+    kind: 'ready' | 'revoked';
+    certificate: CertificateRecord;
+    isNew: false;
+  }
+  | {
+    kind: 'issued';
+    certificate: CertificateRecord;
+    isNew: true;
+    delivery: {
+      email: string | null;
+      name: string | null;
+      courseTitle: string;
+    };
+  };
+
+export type CompletedCertificateResult =
+  | { kind: 'ready' | 'issued' | 'revoked'; code: string }
+  | { kind: 'not_completed' };
+
+const MAX_CODE_ATTEMPTS = 5;
+
 function generateCertificateCode(): string {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
   let code = 'CERT-';
-  for (let i = 0; i < 4; i++) {
+  for (let index = 0; index < 4; index++) {
     code += chars.charAt(Math.floor(Math.random() * chars.length));
   }
   code += '-';
-  for (let i = 0; i < 4; i++) {
+  for (let index = 0; index < 4; index++) {
     code += chars.charAt(Math.floor(Math.random() * chars.length));
   }
   return code;
 }
 
-/**
- * Issue a certificate for a user who completed a course.
- * Returns the certificate if created, or existing certificate if already issued.
- */
-export async function issueCertificate(userId: string, courseId: string): Promise<{
-  certificate: typeof certificates.$inferSelect;
-  isNew: boolean;
-}> {
-  // Check if certificate already exists
-  const [existing] = await db
-    .select()
-    .from(certificates)
-    .where(
-      and(
-        eq(certificates.userId, userId),
-        eq(certificates.courseId, courseId)
-      )
-    )
-    .limit(1);
+async function issueCertificateWithAuthority(
+  userId: string,
+  courseId: string,
+  authority: IssuanceAuthority,
+): Promise<IssuanceOutcome> {
+  const outcome = await db.transaction(async (tx): Promise<IssuanceOutcome> => {
+    const [user] = await tx
+      .select({ name: users.name, email: users.email })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .for('update');
+    if (!user) throw new Error('Certificate subject not found');
 
-  if (existing) {
-    return { certificate: existing, isNew: false };
-  }
-
-  // Get user and course info
-  const [[user], [course]] = await Promise.all([
-    db.select({ name: users.name, email: users.email }).from(users).where(eq(users.id, userId)).limit(1),
-    db.select({ title: courses.title, certificateColor: courses.certificateColor, certificateHeaderImage: courses.certificateHeaderImage }).from(courses).where(eq(courses.id, courseId)).limit(1),
-  ]);
-
-  if (!user || !course) {
-    throw new Error('User or course not found');
-  }
-
-  // Generate unique code (retry if collision)
-  let certificateCode = generateCertificateCode();
-  let retries = 0;
-  const MAX_RETRIES = 5;
-  while (retries < MAX_RETRIES) {
-    const [exists] = await db
-      .select({ id: certificates.id })
+    const [existing] = await tx
+      .select()
       .from(certificates)
-      .where(eq(certificates.certificateCode, certificateCode))
+      .where(and(
+        eq(certificates.userId, userId),
+        eq(certificates.courseId, courseId),
+      ))
+      .orderBy(asc(certificates.revokedAt))
       .limit(1);
-    if (!exists) break;
-    certificateCode = generateCertificateCode();
-    retries++;
-    if (retries === MAX_RETRIES) {
-      throw new Error(`Failed to generate unique certificate code after ${MAX_RETRIES} retries`);
+    if (existing) {
+      return {
+        kind: existing.revokedAt ? 'revoked' : 'ready',
+        certificate: existing,
+        isNew: false,
+      };
     }
-  }
 
-  const id = createId();
-  const now = new Date();
+    let completedAt = new Date();
+    if (authority === 'verified_completion') {
+      const [enrollment] = await tx
+        .select({ completedAt: enrollments.completedAt })
+        .from(enrollments)
+        .where(and(
+          eq(enrollments.userId, userId),
+          eq(enrollments.courseId, courseId),
+        ))
+        .limit(1)
+        .for('update');
+      if (!enrollment?.completedAt) return { kind: 'not_completed' };
+      completedAt = enrollment.completedAt;
+    }
 
-  await db.insert(certificates).values({
-    id,
-    userId,
-    courseId,
-    certificateCode,
-    recipientName: user.name || 'ผู้เรียน',
-    courseTitle: course.title,
-    completedAt: now,
-    issuedAt: now,
-    certificateTheme: course.certificateColor || '#2563eb',
-    certificateHeaderImage: course.certificateHeaderImage || null,
+    const [course] = await tx
+      .select({
+        title: courses.title,
+        certificateColor: courses.certificateColor,
+        certificateHeaderImage: courses.certificateHeaderImage,
+      })
+      .from(courses)
+      .where(eq(courses.id, courseId))
+      .limit(1);
+    if (!course) throw new Error('Certificate course not found');
+
+    const id = createId();
+    const issuedAt = new Date();
+    let certificateCode = '';
+    for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
+      certificateCode = generateCertificateCode();
+      try {
+        await tx.insert(certificates).values({
+          id,
+          userId,
+          courseId,
+          certificateCode,
+          recipientName: user.name || 'ผู้เรียน',
+          courseTitle: course.title,
+          completedAt,
+          issuedAt,
+          certificateTheme: course.certificateColor || '#2563eb',
+          certificateHeaderImage: course.certificateHeaderImage || null,
+        });
+        break;
+      } catch (error) {
+        if (!isDuplicateKeyError(error) || attempt === MAX_CODE_ATTEMPTS - 1) {
+          throw error;
+        }
+      }
+    }
+
+    const [certificate] = await tx
+      .select()
+      .from(certificates)
+      .where(eq(certificates.id, id))
+      .limit(1);
+    if (!certificate) throw new Error('Certificate insert was not readable');
+
+    return {
+      kind: 'issued',
+      certificate,
+      isNew: true,
+      delivery: {
+        email: user.email,
+        name: user.name,
+        courseTitle: course.title,
+      },
+    };
   });
 
-  const [certificate] = await db
-    .select()
-    .from(certificates)
-    .where(eq(certificates.id, id))
-    .limit(1);
+  if (outcome.kind === 'issued') {
+    const { certificate, delivery } = outcome;
+    if (delivery.email) {
+      void sendCertificateEmail({
+        email: delivery.email,
+        name: delivery.name || 'ผู้เรียน',
+        courseName: delivery.courseTitle,
+        certificateCode: certificate.certificateCode,
+      }).catch((error) => logError(
+        error instanceof Error ? error : new Error(String(error)),
+        { action: 'certificate.email.failed' },
+      ));
+    }
 
-  // Send certificate email (non-blocking)
-  if (user.email) {
-    sendCertificateEmail({
-      email: user.email,
-      name: user.name || 'ผู้เรียน',
-      courseName: course.title,
-      certificateCode,
-    }).catch((err) => logError(err instanceof Error ? err : new Error(String(err)), { action: 'Failed to send certificate email' }));
+    void notify({
+      userId,
+      title: '🎓 ยินดีด้วย! คุณได้รับใบรับรอง',
+      message: `สำเร็จหลักสูตร "${delivery.courseTitle}"`,
+      type: 'success',
+      link: `/certificate/${certificate.certificateCode}`,
+    }).catch((error) => logError(
+      error instanceof Error ? error : new Error(String(error)),
+      { action: 'certificate.notification.failed' },
+    ));
   }
 
-  // Send in-app notification (non-blocking)
-  notify({
-    userId,
-    title: `🎓 ยินดีด้วย! คุณได้รับใบรับรอง`,
-    message: `สำเร็จหลักสูตร "${course.title}"`,
-    type: 'success',
-    link: `/certificate/${certificateCode}`,
-  }).catch((err) => logError(err instanceof Error ? err : new Error(String(err)), { action: 'Failed to send certificate notification' }));
+  return outcome;
+}
 
-  return { certificate, isNew: true };
+export async function issueCertificate(userId: string, courseId: string): Promise<{
+  certificate: CertificateRecord;
+  isNew: boolean;
+}> {
+  const outcome = await issueCertificateWithAuthority(userId, courseId, 'explicit_admin_intent');
+  if (outcome.kind === 'not_completed') {
+    throw new Error('Unexpected completion requirement for admin certificate issuance');
+  }
+  return { certificate: outcome.certificate, isNew: outcome.isNew };
+}
+
+export async function ensureCompletedCertificate(
+  userId: string,
+  courseId: string,
+): Promise<CompletedCertificateResult> {
+  const outcome = await issueCertificateWithAuthority(userId, courseId, 'verified_completion');
+  if (outcome.kind === 'not_completed') return outcome;
+  return {
+    kind: outcome.kind,
+    code: outcome.certificate.certificateCode,
+  };
 }

--- a/src/lib/learning-progress.ts
+++ b/src/lib/learning-progress.ts
@@ -3,7 +3,7 @@ import 'server-only';
 import { createId } from '@paralleldrive/cuid2';
 import { and, count, eq } from 'drizzle-orm';
 
-import { issueCertificate } from '@/lib/certificate';
+import { ensureCompletedCertificate } from '@/lib/certificate';
 import { db } from '@/lib/db';
 import {
   enrollments,
@@ -227,11 +227,11 @@ export async function updateLearningProgress(
 
   if (result.courseCompleted) {
     try {
-      const { isNew } = await issueCertificate(input.userId, result.courseId);
-      if (isNew) logEvent('certificate.issued');
+      const certificate = await ensureCompletedCertificate(input.userId, result.courseId);
+      if (certificate.kind === 'issued') logEvent('certificate.issued');
     } catch (error) {
       logError(error instanceof Error ? error : new Error(String(error)), {
-        action: '[Certificate] Error issuing',
+        action: 'certificate.issue.failed',
       });
     }
   }

--- a/tests/api/certificate-collection.test.ts
+++ b/tests/api/certificate-collection.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { authMock, getOwnerCertificateCollectionMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  getOwnerCertificateCollectionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('@/lib/certificate-credentials', () => ({
+  getOwnerCertificateCollection: getOwnerCertificateCollectionMock,
+}));
+
+import { GET } from '@/app/api/certificates/route';
+
+describe('GET /api/certificates', () => {
+  it('rejects an unauthenticated request before reading certificate data', async () => {
+    authMock.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(getOwnerCertificateCollectionMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the owner projection and a minimal active-only compatibility list', async () => {
+    authMock.mockResolvedValue({ user: { id: 'member-1' } });
+    getOwnerCertificateCollectionMock.mockResolvedValue({
+      summary: {
+        activeCount: 1,
+        revokedCount: 1,
+        missingCount: 1,
+        hasEnrollment: true,
+      },
+      items: [
+        {
+          kind: 'active',
+          code: 'CERT-ACTIVE',
+          recipientName: 'Learner',
+          courseTitle: 'TypeScript',
+          courseSlug: 'typescript',
+          completedAt: '2026-08-01T00:00:00.000Z',
+          issuedAt: '2026-08-02T00:00:00.000Z',
+        },
+        {
+          kind: 'revoked',
+          code: 'CERT-REVOKED',
+          recipientName: 'Learner',
+          courseTitle: 'React',
+          courseSlug: 'react',
+          completedAt: '2026-07-01T00:00:00.000Z',
+          issuedAt: '2026-07-02T00:00:00.000Z',
+        },
+        {
+          kind: 'missing',
+          courseTitle: 'Next.js',
+          courseSlug: 'nextjs',
+          completedAt: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(getOwnerCertificateCollectionMock).toHaveBeenCalledWith('member-1');
+    await expect(response.json()).resolves.toEqual({
+      collection: {
+        summary: {
+          activeCount: 1,
+          revokedCount: 1,
+          missingCount: 1,
+          hasEnrollment: true,
+        },
+        items: [
+          {
+            kind: 'active',
+            code: 'CERT-ACTIVE',
+            recipientName: 'Learner',
+            courseTitle: 'TypeScript',
+            courseSlug: 'typescript',
+            completedAt: '2026-08-01T00:00:00.000Z',
+            issuedAt: '2026-08-02T00:00:00.000Z',
+          },
+          {
+            kind: 'revoked',
+            code: 'CERT-REVOKED',
+            recipientName: 'Learner',
+            courseTitle: 'React',
+            courseSlug: 'react',
+            completedAt: '2026-07-01T00:00:00.000Z',
+            issuedAt: '2026-07-02T00:00:00.000Z',
+          },
+          {
+            kind: 'missing',
+            courseTitle: 'Next.js',
+            courseSlug: 'nextjs',
+            completedAt: '2026-06-01T00:00:00.000Z',
+          },
+        ],
+      },
+      certificates: [
+        {
+          id: 'CERT-ACTIVE',
+          certificateCode: 'CERT-ACTIVE',
+          recipientName: 'Learner',
+          courseTitle: 'TypeScript',
+          completedAt: '2026-08-01T00:00:00.000Z',
+          issuedAt: '2026-08-02T00:00:00.000Z',
+        },
+      ],
+    });
+  });
+});

--- a/tests/api/certificate-repair-outcome.test.ts
+++ b/tests/api/certificate-repair-outcome.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { authMock, checkRateLimitMock, repairOwnerCertificateMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+  repairOwnerCertificateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('@/lib/certificate-credentials', () => ({
+  repairOwnerCertificate: repairOwnerCertificateMock,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: checkRateLimitMock,
+  rateLimits: { sensitive: { maxRequests: 5, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(() => new Response(null, { status: 429 })),
+}));
+
+import { POST } from '@/app/api/certificates/repair/route';
+
+describe('POST /api/certificates/repair outcome', () => {
+  it('uses the session owner and returns a newly issued credential', async () => {
+    authMock.mockResolvedValue({ user: { id: 'member-1' } });
+    checkRateLimitMock.mockReturnValue({ success: true, resetTime: Date.now() + 60_000 });
+    repairOwnerCertificateMock.mockResolvedValue({
+      kind: 'issued',
+      code: 'CERT-REPAIRED',
+    });
+
+    const response = await POST(new Request('http://localhost/api/certificates/repair', {
+      method: 'POST',
+      body: JSON.stringify({ courseSlug: 'typescript' }),
+    }));
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      result: { kind: 'issued', code: 'CERT-REPAIRED' },
+    });
+    expect(repairOwnerCertificateMock).toHaveBeenCalledWith('member-1', 'typescript');
+  });
+});

--- a/tests/api/certificate-repair-rate-limit.test.ts
+++ b/tests/api/certificate-repair-rate-limit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { authMock, checkRateLimitMock, repairOwnerCertificateMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+  repairOwnerCertificateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('@/lib/certificate-credentials', () => ({
+  repairOwnerCertificate: repairOwnerCertificateMock,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: checkRateLimitMock,
+  rateLimits: { sensitive: { maxRequests: 5, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(() => new Response(null, { status: 429 })),
+}));
+
+import { POST } from '@/app/api/certificates/repair/route';
+
+describe('POST /api/certificates/repair rate limit', () => {
+  it('rate-limits the authenticated owner before parsing or repairing', async () => {
+    authMock.mockResolvedValue({ user: { id: 'member-1' } });
+    checkRateLimitMock.mockReturnValue({ success: false, resetTime: Date.now() + 60_000 });
+
+    const response = await POST(new Request('http://localhost/api/certificates/repair', {
+      method: 'POST',
+      body: JSON.stringify({ courseSlug: 'typescript' }),
+    }));
+
+    expect(response.status).toBe(429);
+    expect(checkRateLimitMock).toHaveBeenCalledWith(
+      'certificate-repair:member-1',
+      { maxRequests: 5, windowMs: 60_000 },
+    );
+    expect(repairOwnerCertificateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/certificate-repair-statuses.test.ts
+++ b/tests/api/certificate-repair-statuses.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { authMock, checkRateLimitMock, repairOwnerCertificateMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+  repairOwnerCertificateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('@/lib/certificate-credentials', () => ({
+  repairOwnerCertificate: repairOwnerCertificateMock,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: checkRateLimitMock,
+  rateLimits: { sensitive: { maxRequests: 5, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(() => new Response(null, { status: 429 })),
+}));
+
+import { POST } from '@/app/api/certificates/repair/route';
+
+describe('POST /api/certificates/repair statuses', () => {
+  it.each([
+    [{ kind: 'ready', code: 'CERT-READY' }, 200],
+    [{ kind: 'revoked', code: 'CERT-REVOKED' }, 409],
+    [{ kind: 'not_completed' }, 409],
+    [{ kind: 'temporarily_unavailable' }, 503],
+  ] as const)('maps %s to HTTP %s without inventing another state', async (result, status) => {
+    authMock.mockResolvedValue({ user: { id: 'member-1' } });
+    checkRateLimitMock.mockReturnValue({ success: true, resetTime: Date.now() + 60_000 });
+    repairOwnerCertificateMock.mockResolvedValue(result);
+
+    const response = await POST(new Request('http://localhost/api/certificates/repair', {
+      method: 'POST',
+      body: JSON.stringify({ courseSlug: 'typescript' }),
+    }));
+
+    expect(response.status).toBe(status);
+    await expect(response.json()).resolves.toEqual({ result });
+  });
+});

--- a/tests/api/certificate-repair-validation.test.ts
+++ b/tests/api/certificate-repair-validation.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { authMock, checkRateLimitMock, repairOwnerCertificateMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+  repairOwnerCertificateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('@/lib/certificate-credentials', () => ({
+  repairOwnerCertificate: repairOwnerCertificateMock,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: checkRateLimitMock,
+  rateLimits: { sensitive: { maxRequests: 5, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(() => new Response(null, { status: 429 })),
+}));
+
+import { POST } from '@/app/api/certificates/repair/route';
+
+describe('POST /api/certificates/repair validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.mockResolvedValue({ user: { id: 'member-1' } });
+    checkRateLimitMock.mockReturnValue({ success: true, resetTime: Date.now() + 60_000 });
+  });
+
+  it('accepts only a course slug and never trusts a client-supplied owner', async () => {
+    const response = await POST(new Request('http://localhost/api/certificates/repair', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ courseSlug: 'typescript', userId: 'other-member' }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(repairOwnerCertificateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/certificate-repair.test.ts
+++ b/tests/api/certificate-repair.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { authMock, checkRateLimitMock, repairOwnerCertificateMock } = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  checkRateLimitMock: vi.fn(),
+  repairOwnerCertificateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ auth: authMock }));
+vi.mock('@/lib/certificate-credentials', () => ({
+  repairOwnerCertificate: repairOwnerCertificateMock,
+}));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: checkRateLimitMock,
+  rateLimits: { sensitive: { maxRequests: 5, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(() => new Response(null, { status: 429 })),
+}));
+
+import { POST } from '@/app/api/certificates/repair/route';
+
+describe('POST /api/certificates/repair', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkRateLimitMock.mockReturnValue({ success: true, resetTime: Date.now() + 60_000 });
+  });
+
+  it('rejects an unauthenticated repair before reading or mutating certificate state', async () => {
+    authMock.mockResolvedValue(null);
+
+    const response = await POST(new Request('http://localhost/api/certificates/repair', {
+      method: 'POST',
+      body: JSON.stringify({ courseSlug: 'typescript' }),
+    }));
+
+    expect(response.status).toBe(401);
+    expect(checkRateLimitMock).not.toHaveBeenCalled();
+    expect(repairOwnerCertificateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/public-certificate-page.test.tsx
+++ b/tests/app/public-certificate-page.test.tsx
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+const { getPublicCertificateVerificationMock } = vi.hoisted(() => ({
+  getPublicCertificateVerificationMock: vi.fn(),
+}));
+
+vi.mock('@/lib/certificate-credentials', () => ({
+  getPublicCertificateVerification: getPublicCertificateVerificationMock,
+}));
+vi.mock('@/lib/db', () => ({ db: {} }));
+vi.mock('@/components/layout/Navbar', () => ({ default: () => <div data-layout="navbar" /> }));
+vi.mock('@/components/layout/Footer', () => ({ default: () => <div data-layout="footer" /> }));
+vi.mock('@/components/certificate/CertificateCard', () => ({
+  default: ({ cert }: { cert: Record<string, unknown> }) => (
+    <div data-certificate={JSON.stringify(cert)} />
+  ),
+}));
+
+import CertificatePage from '@/app/certificate/[code]/page';
+
+describe('public certificate page', () => {
+  it('renders from the minimal public verification projection', async () => {
+    getPublicCertificateVerificationMock.mockResolvedValue({
+      kind: 'active',
+      credential: {
+        code: 'CERT-PUBLIC',
+        recipientName: 'Learner',
+        courseTitle: 'TypeScript',
+        courseSlug: 'typescript',
+        completedAt: '2026-08-01T00:00:00.000Z',
+        issuedAt: '2026-08-02T00:00:00.000Z',
+        revokedAt: null,
+        certificateTheme: '#2563eb',
+        certificateHeaderImage: null,
+      },
+    });
+
+    const html = renderToStaticMarkup(await CertificatePage({
+      params: Promise.resolve({ code: 'CERT-PUBLIC' }),
+    }));
+
+    expect(getPublicCertificateVerificationMock).toHaveBeenCalledWith('CERT-PUBLIC');
+    expect(html).toContain('CERT-PUBLIC');
+    expect(html).not.toContain('userId');
+    expect(html).not.toContain('courseId');
+    expect(html).not.toContain('revokedReason');
+  });
+
+  it('does not import database authority into the public page', () => {
+    const source = readFileSync('src/app/certificate/[code]/page.tsx', 'utf8');
+
+    expect(source).toContain('getPublicCertificateVerification');
+    expect(source).not.toContain("from '@/lib/db'");
+    expect(source).not.toContain("from '@/lib/db/schema'");
+  });
+});

--- a/tests/lib/certificate-owner-projection.test.ts
+++ b/tests/lib/certificate-owner-projection.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getOwnerCertificateCollection,
+  type CertificateProjectionStore,
+} from '@/lib/certificate-credentials';
+
+describe('getOwnerCertificateCollection', () => {
+  it('returns active, revoked, and completed-without-certificate descriptors without internal fields', async () => {
+    const store: CertificateProjectionStore = {
+      readOwner: vi.fn().mockResolvedValue({
+        enrollments: [
+          {
+            courseId: 'internal-course-active',
+            courseTitle: 'Active credential course',
+            courseSlug: 'active-course',
+            enrolledAt: new Date('2026-06-01T00:00:00.000Z'),
+            completedAt: new Date('2026-06-20T00:00:00.000Z'),
+          },
+          {
+            courseId: 'internal-course-revoked',
+            courseTitle: 'Revoked credential course',
+            courseSlug: 'revoked-course',
+            enrolledAt: new Date('2026-05-01T00:00:00.000Z'),
+            completedAt: new Date('2026-05-20T00:00:00.000Z'),
+          },
+          {
+            courseId: 'internal-course-missing',
+            courseTitle: 'Missing credential course',
+            courseSlug: 'missing-course',
+            enrolledAt: new Date('2026-07-01T00:00:00.000Z'),
+            completedAt: new Date('2026-07-20T00:00:00.000Z'),
+          },
+          {
+            courseId: 'internal-course-learning',
+            courseTitle: 'Still learning',
+            courseSlug: 'still-learning',
+            enrolledAt: new Date('2026-08-01T00:00:00.000Z'),
+            completedAt: null,
+          },
+        ],
+        certificates: [
+          {
+            courseId: 'internal-course-active',
+            certificateCode: 'CERT-ACTIVE',
+            recipientName: 'Miler Dev',
+            courseTitle: 'Active credential course',
+            courseSlug: 'active-course',
+            completedAt: new Date('2026-06-20T00:00:00.000Z'),
+            issuedAt: new Date('2026-06-21T00:00:00.000Z'),
+            revokedAt: null,
+          },
+          {
+            courseId: 'internal-course-revoked',
+            certificateCode: 'CERT-REVOKED',
+            recipientName: 'Miler Dev',
+            courseTitle: 'Revoked credential course',
+            courseSlug: 'revoked-course',
+            completedAt: new Date('2026-05-20T00:00:00.000Z'),
+            issuedAt: new Date('2026-05-21T00:00:00.000Z'),
+            revokedAt: new Date('2026-08-15T00:00:00.000Z'),
+          },
+        ],
+      }),
+      readPublic: vi.fn(),
+    };
+
+    const collection = await getOwnerCertificateCollection('internal-member-id', store);
+
+    expect(store.readOwner).toHaveBeenCalledWith('internal-member-id');
+    expect(collection).toEqual({
+      summary: {
+        activeCount: 1,
+        revokedCount: 1,
+        missingCount: 1,
+        hasEnrollment: true,
+      },
+      items: [
+        {
+          kind: 'active',
+          code: 'CERT-ACTIVE',
+          recipientName: 'Miler Dev',
+          courseTitle: 'Active credential course',
+          courseSlug: 'active-course',
+          completedAt: '2026-06-20T00:00:00.000Z',
+          issuedAt: '2026-06-21T00:00:00.000Z',
+        },
+        {
+          kind: 'revoked',
+          code: 'CERT-REVOKED',
+          recipientName: 'Miler Dev',
+          courseTitle: 'Revoked credential course',
+          courseSlug: 'revoked-course',
+          completedAt: '2026-05-20T00:00:00.000Z',
+          issuedAt: '2026-05-21T00:00:00.000Z',
+        },
+        {
+          kind: 'missing',
+          courseTitle: 'Missing credential course',
+          courseSlug: 'missing-course',
+          completedAt: '2026-07-20T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const serialized = JSON.stringify(collection);
+    expect(serialized).not.toContain('internal-member-id');
+    expect(serialized).not.toContain('internal-course-');
+    expect(serialized).not.toContain('revokedReason');
+  });
+});

--- a/tests/lib/certificate-public-projection.test.ts
+++ b/tests/lib/certificate-public-projection.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getPublicCertificateVerification,
+  type CertificateProjectionStore,
+} from '@/lib/certificate-credentials';
+
+function storeFor(
+  fact: Awaited<ReturnType<CertificateProjectionStore['readPublic']>>,
+): CertificateProjectionStore {
+  return {
+    readOwner: vi.fn(),
+    readPublic: vi.fn().mockResolvedValue(fact),
+  };
+}
+
+const publicFact = {
+  courseId: 'internal-course-id',
+  certificateCode: 'CERT-ABCD-2345',
+  recipientName: 'Miler Dev',
+  courseTitle: 'TypeScript Foundations',
+  courseSlug: 'typescript-foundations',
+  completedAt: new Date('2026-07-20T00:00:00.000Z'),
+  issuedAt: new Date('2026-07-21T00:00:00.000Z'),
+  revokedAt: null,
+  certificateTheme: '#2563eb',
+  certificateHeaderImage: '/certificate-header.png',
+};
+
+describe('getPublicCertificateVerification', () => {
+  it('returns minimal active, revoked, and not-found verification results', async () => {
+    const active = await getPublicCertificateVerification(
+      'CERT-ABCD-2345',
+      storeFor(publicFact),
+    );
+    const revoked = await getPublicCertificateVerification(
+      'CERT-ABCD-2345',
+      storeFor({
+        ...publicFact,
+        revokedAt: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    );
+    const notFound = await getPublicCertificateVerification(
+      'CERT-MISSING',
+      storeFor(null),
+    );
+
+    expect(active).toEqual({
+      kind: 'active',
+      credential: {
+        code: 'CERT-ABCD-2345',
+        recipientName: 'Miler Dev',
+        courseTitle: 'TypeScript Foundations',
+        courseSlug: 'typescript-foundations',
+        completedAt: '2026-07-20T00:00:00.000Z',
+        issuedAt: '2026-07-21T00:00:00.000Z',
+        revokedAt: null,
+        certificateTheme: '#2563eb',
+        certificateHeaderImage: '/certificate-header.png',
+      },
+    });
+    expect(revoked).toMatchObject({
+      kind: 'revoked',
+      credential: { revokedAt: '2026-08-01T00:00:00.000Z' },
+    });
+    expect(notFound).toEqual({ kind: 'not_found' });
+
+    const serialized = JSON.stringify([active, revoked]);
+    expect(serialized).not.toContain('internal-course-id');
+    expect(serialized).not.toContain('userId');
+    expect(serialized).not.toContain('revokedReason');
+  });
+});

--- a/tests/lib/certificate-repair-failure.test.ts
+++ b/tests/lib/certificate-repair-failure.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  repairOwnerCertificate,
+  type CertificateRepairAdapter,
+} from '@/lib/certificate-credentials';
+
+describe('repairOwnerCertificate failure recovery', () => {
+  it('returns temporarily unavailable without exposing issuance failure details', async () => {
+    const adapter: CertificateRepairAdapter = {
+      read: vi.fn().mockResolvedValue({
+        courseId: 'internal-course-id',
+        completedAt: new Date('2026-08-20T00:00:00.000Z'),
+        certificate: null,
+      }),
+      ensureCompleted: vi.fn().mockRejectedValue(
+        new Error('private database and email provider detail'),
+      ),
+    };
+
+    const result = await repairOwnerCertificate('member-1', 'typescript', adapter);
+
+    expect(result).toEqual({ kind: 'temporarily_unavailable' });
+    expect(JSON.stringify(result)).not.toContain('private database');
+  });
+});

--- a/tests/lib/certificate-repair-not-completed.test.ts
+++ b/tests/lib/certificate-repair-not-completed.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  repairOwnerCertificate,
+  type CertificateRepairAdapter,
+} from '@/lib/certificate-credentials';
+
+describe('repairOwnerCertificate completion authority', () => {
+  it('does not issue when the owner has no authoritative completion', async () => {
+    const adapter: CertificateRepairAdapter = {
+      read: vi.fn().mockResolvedValue({
+        courseId: 'internal-course-id',
+        completedAt: null,
+        certificate: null,
+      }),
+      ensureCompleted: vi.fn(),
+    };
+
+    await expect(repairOwnerCertificate('member-1', 'typescript', adapter)).resolves.toEqual({
+      kind: 'not_completed',
+    });
+    expect(adapter.ensureCompleted).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/certificate-repair-revoked.test.ts
+++ b/tests/lib/certificate-repair-revoked.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  repairOwnerCertificate,
+  type CertificateRepairAdapter,
+} from '@/lib/certificate-credentials';
+
+describe('repairOwnerCertificate for a revoked credential', () => {
+  it('returns revoked without issuing or restoring a credential', async () => {
+    const adapter: CertificateRepairAdapter = {
+      read: vi.fn().mockResolvedValue({
+        courseId: 'internal-course-id',
+        completedAt: new Date('2026-08-20T00:00:00.000Z'),
+        certificate: {
+          code: 'CERT-REVOKED',
+          revokedAt: new Date('2026-08-25T00:00:00.000Z'),
+        },
+      }),
+      ensureCompleted: vi.fn(),
+    };
+
+    await expect(repairOwnerCertificate('member-1', 'typescript', adapter)).resolves.toEqual({
+      kind: 'revoked',
+      code: 'CERT-REVOKED',
+    });
+    expect(adapter.ensureCompleted).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/certificate-repair.test.ts
+++ b/tests/lib/certificate-repair.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  repairOwnerCertificate,
+  type CertificateRepairAdapter,
+} from '@/lib/certificate-credentials';
+
+describe('repairOwnerCertificate', () => {
+  it('issues a completed missing credential once and returns ready on replay', async () => {
+    let certificate: { code: string; revokedAt: Date | null } | null = null;
+    const adapter: CertificateRepairAdapter = {
+      read: vi.fn().mockImplementation(async () => ({
+        courseId: 'internal-course-id',
+        completedAt: new Date('2026-08-20T00:00:00.000Z'),
+        certificate,
+      })),
+      ensureCompleted: vi.fn().mockImplementation(async () => {
+        certificate = { code: 'CERT-REPAIRED', revokedAt: null };
+        return { kind: 'issued', code: 'CERT-REPAIRED' };
+      }),
+    };
+
+    await expect(repairOwnerCertificate('member-1', 'typescript', adapter)).resolves.toEqual({
+      kind: 'issued',
+      code: 'CERT-REPAIRED',
+    });
+    await expect(repairOwnerCertificate('member-1', 'typescript', adapter)).resolves.toEqual({
+      kind: 'ready',
+      code: 'CERT-REPAIRED',
+    });
+
+    expect(adapter.read).toHaveBeenCalledTimes(2);
+    expect(adapter.read).toHaveBeenCalledWith('member-1', 'typescript');
+    expect(adapter.ensureCompleted).toHaveBeenCalledOnce();
+    expect(adapter.ensureCompleted).toHaveBeenCalledWith('member-1', 'internal-course-id');
+  });
+});

--- a/tests/lib/learning-progress-certificate-boundary.test.ts
+++ b/tests/lib/learning-progress-certificate-boundary.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('learning progress certificate boundary', () => {
+  it('uses the completion-authorized idempotent issuer after progress commits', () => {
+    const source = readFileSync('src/lib/learning-progress.ts', 'utf8');
+
+    expect(source).toContain("import { ensureCompletedCertificate } from '@/lib/certificate'");
+    expect(source).toContain('await ensureCompletedCertificate(input.userId, result.courseId)');
+    expect(source).toContain("certificate.kind === 'issued'");
+    expect(source).not.toContain('await issueCertificate(input.userId, result.courseId)');
+  });
+});


### PR DESCRIPTION
## Summary
- add owner-scoped active, revoked, and missing certificate projections
- add authenticated rate-limited repair with completion and replay checks
- serialize issuance and preserve revoked credentials without duplicate auto-issuance
- move public certificate verification onto a minimal DTO

## Verification
- npm run test -- --run (855 passed)
- npm run lint
- npm run build
- git diff --check
- two-axis Standards and Spec review completed

## Production risk
- no database migration or production-data operation
- direct database writes outside application issuance paths are not covered by the application transaction lock

Closes #40