### PR TITLE
feat(learning): add authorized workspace projection

### DIFF
--- a/src/app/courses/[slug]/learn/[lessonId]/page.tsx
+++ b/src/app/courses/[slug]/learn/[lessonId]/page.tsx
@@ -2,11 +2,10 @@ import { redirect, notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { courses, lessons, enrollments, lessonProgress } from '@/lib/db/schema';
-import { eq, and, asc } from 'drizzle-orm';
+import { courses, lessons } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
 import LearnPageClient from '@/components/course/LearnPageClient';
-import { generateSignedVideoUrl, extractBunnyVideoInfo, isBunnyVideo } from '@/lib/bunny';
-import sanitizeHtml from 'sanitize-html';
+import { getLearningWorkspaceProjection } from '@/lib/learning-workspace';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,146 +35,32 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-async function getLessonWithAccess(slug: string, lessonId: string, userId: string | null) {
-  // Get course
-  const [course] = await db
-    .select()
-    .from(courses)
-    .where(eq(courses.slug, slug))
-    .limit(1);
-
-  if (!course) return null;
-
-  // Get current lesson first to check if it's free preview
-  const [lesson] = await db
-    .select()
-    .from(lessons)
-    .where(eq(lessons.id, lessonId))
-    .limit(1);
-
-  if (!lesson || lesson.courseId !== course.id) return null;
-
-  // Check enrollment (only if user is logged in)
-  let isEnrolled = false;
-  if (userId) {
-    const [enrollment] = await db
-      .select()
-      .from(enrollments)
-      .where(
-        and(
-          eq(enrollments.userId, userId),
-          eq(enrollments.courseId, course.id)
-        )
-      )
-      .limit(1);
-    isEnrolled = !!enrollment;
-  }
-
-  // If not enrolled and not free preview, deny access
-  if (!isEnrolled && !lesson.isFreePreview) {
-    return { accessDenied: true, course, lesson: null, allLessons: [], isEnrolled };
-  }
-
-  // Get all lessons for sidebar
-  const allLessons = await db
-    .select()
-    .from(lessons)
-    .where(eq(lessons.courseId, course.id))
-    .orderBy(asc(lessons.orderIndex));
-
-  // Find current lesson index
-  const currentIndex = allLessons.findIndex(l => l.id === lessonId);
-  const prevLesson = currentIndex > 0 ? allLessons[currentIndex - 1] : null;
-  const nextLesson = currentIndex < allLessons.length - 1 ? allLessons[currentIndex + 1] : null;
-
-  // Get completed lesson IDs for this user
-  let completedLessonIds: string[] = [];
-  if (userId) {
-    const completedProgress = await db
-      .select({ lessonId: lessonProgress.lessonId })
-      .from(lessonProgress)
-      .innerJoin(lessons, eq(lessonProgress.lessonId, lessons.id))
-      .where(
-        and(
-          eq(lessonProgress.userId, userId),
-          eq(lessons.courseId, course.id),
-          eq(lessonProgress.completed, true)
-        )
-      );
-    completedLessonIds = completedProgress.map(p => p.lessonId);
-  }
-
-  return {
-    accessDenied: false,
-    course,
-    lesson,
-    allLessons,
-    prevLesson,
-    nextLesson,
-    currentIndex,
-    isEnrolled,
-    completedLessonIds,
-  };
-}
-
 export default async function LessonPage({ params }: Props) {
-  const session = await auth();
-  const { slug, lessonId } = await params;
+  const [session, { slug, lessonId }] = await Promise.all([auth(), params]);
+  const projection = await getLearningWorkspaceProjection({
+    memberId: session?.user?.id ?? null,
+    courseSlug: slug,
+    lessonId,
+  });
 
-  // Allow access for free preview even without login
-  const userId = session?.user?.id || null;
-  const data = await getLessonWithAccess(slug, lessonId, userId);
-
-  if (!data) {
-    notFound();
+  if (projection.kind === 'not_found') notFound();
+  if (projection.kind === 'access_denied') {
+    redirect(`/courses/${projection.courseSlug}?access=denied`);
   }
 
-  // Handle access denied - redirect to course page with message
-  if (data.accessDenied) {
-    redirect(`/courses/${slug}?access=denied`);
-  }
-
-  const { course, lesson, allLessons, prevLesson, nextLesson, currentIndex, isEnrolled, completedLessonIds } = data;
-
-  // Additional null check for lesson
-  if (!lesson) {
-    notFound();
-  }
-
-  // Sanitize lesson content HTML on the server
-  const signedLesson = { ...lesson };
-  if (signedLesson.content) {
-    signedLesson.content = sanitizeHtml(signedLesson.content, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['h1', 'h2', 'h3', 'pre', 'code', 'span', 'del']),
-      allowedAttributes: {
-        ...sanitizeHtml.defaults.allowedAttributes,
-        'a': ['href', 'target', 'rel'],
-        'code': ['class'],
-        'span': ['class', 'style'],
-        'pre': ['class'],
-      },
-    });
-  }
-
-  // Sign Bunny.net video URL on the server
-  if (signedLesson.videoUrl && isBunnyVideo(signedLesson.videoUrl)) {
-    const bunnyVideo = extractBunnyVideoInfo(signedLesson.videoUrl);
-    if (bunnyVideo) {
-      signedLesson.videoUrl = generateSignedVideoUrl(bunnyVideo.videoId, 3600, bunnyVideo.libraryId);
-    }
-  }
-
+  const { playbackUrl: videoUrl, ...currentLesson } = projection.currentLesson;
   return (
     <LearnPageClient
-      course={course}
-      currentLesson={signedLesson}
-      allLessons={allLessons}
-      prevLesson={prevLesson}
-      nextLesson={nextLesson}
-      currentIndex={currentIndex ?? 0}
-      isEnrolled={isEnrolled ?? false}
-      canTrackProgress={Boolean(userId)}
-      completedLessonIds={completedLessonIds ?? []}
+      course={projection.course}
+      currentLesson={{ ...currentLesson, videoUrl }}
+      allLessons={projection.curriculum}
+      prevLesson={projection.previousLesson}
+      nextLesson={projection.nextLesson}
+      currentIndex={projection.currentIndex}
+      isEnrolled={projection.isEnrolled}
+      canTrackProgress={projection.canTrackProgress}
+      completedLessonIds={projection.completedLessonIds}
+      currentProgress={projection.currentProgress}
     />
   );
 }

--- a/src/components/course/LearnPageClient.tsx
+++ b/src/components/course/LearnPageClient.tsx
@@ -31,13 +31,10 @@ import {
 } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import LearningWorkspaceAnalytics from '@/components/analytics/LearningWorkspaceAnalytics';
+import type { LearningCurriculumLesson } from '@/lib/learning-workspace';
 
-interface Lesson {
-  id: string;
-  title: string;
+interface CurrentLesson extends LearningCurriculumLesson {
   videoUrl: string | null;
-  videoDuration: number | null;
-  isFreePreview: boolean | null;
   content: string | null;
 }
 
@@ -49,14 +46,15 @@ interface Course {
 
 interface LearnPageClientProps {
   course: Course;
-  currentLesson: Lesson;
-  allLessons: Lesson[];
-  prevLesson: Lesson | null;
-  nextLesson: Lesson | null;
+  currentLesson: CurrentLesson;
+  allLessons: LearningCurriculumLesson[];
+  prevLesson: LearningCurriculumLesson | null;
+  nextLesson: LearningCurriculumLesson | null;
   currentIndex: number;
   isEnrolled: boolean;
   canTrackProgress: boolean;
   completedLessonIds: string[];
+  currentProgress: { completed: boolean; watchTimeSeconds: number };
 }
 
 const formatDuration = (seconds: number | null) => {
@@ -76,16 +74,17 @@ export default function LearnPageClient({
   isEnrolled,
   canTrackProgress,
   completedLessonIds: initialCompletedIds,
+  currentProgress,
 }: LearnPageClientProps) {
   const [mobileCurriculumOpen, setMobileCurriculumOpen] = useState(false);
   const [curriculumCollapsed, setCurriculumCollapsed] = useState(false);
   const [lessonSearch, setLessonSearch] = useState('');
-  const [lockedLesson, setLockedLesson] = useState<Lesson | null>(null);
+  const [lockedLesson, setLockedLesson] = useState<LearningCurriculumLesson | null>(null);
   const [completedIds, setCompletedIds] = useState<Set<string>>(new Set(initialCompletedIds));
   const [markingComplete, setMarkingComplete] = useState(false);
   const completionPendingRef = useRef(false);
-  const watchTimeRef = useRef(0);
-  const lastSyncRef = useRef(0);
+  const watchTimeRef = useRef(currentProgress.watchTimeSeconds);
+  const lastSyncRef = useRef(currentProgress.watchTimeSeconds);
   const isPlayingRef = useRef(false);
   const mobileCurriculumTriggerRef = useRef<HTMLElement | null>(null);
   const lockedLessonTriggerRef = useRef<HTMLElement | null>(null);
@@ -134,13 +133,13 @@ export default function LearnPageClient({
   }, [canTrackProgress, syncWatchTime]);
 
   useEffect(() => {
-    watchTimeRef.current = 0;
-    lastSyncRef.current = 0;
+    watchTimeRef.current = currentProgress.watchTimeSeconds;
+    lastSyncRef.current = currentProgress.watchTimeSeconds;
     isPlayingRef.current = false;
     completionPendingRef.current = false;
     setMarkingComplete(false);
     setLockedLesson(null);
-  }, [currentLesson.id]);
+  }, [currentLesson.id, currentProgress.watchTimeSeconds]);
 
   const completeCurrentLesson = useCallback(async () => {
     if (!isEnrolled || !canTrackProgress || completedIds.has(currentLesson.id) || completionPendingRef.current) return;

--- a/src/lib/learning-progress.ts
+++ b/src/lib/learning-progress.ts
@@ -35,6 +35,22 @@ export type LearningProgressUpdateResult =
     enrollmentId: string | null;
   };
 
+export function derivePersistedLearningProgress(
+  current: { completed: boolean; watchTimeSeconds: number },
+  update: Pick<LearningProgressUpdate, 'completed' | 'watchTimeSeconds'>,
+) {
+  const completed = update.completed ?? current.completed;
+  const watchTimeSeconds = update.watchTimeSeconds === undefined
+    ? current.watchTimeSeconds
+    : Math.max(current.watchTimeSeconds, update.watchTimeSeconds);
+
+  return {
+    completed,
+    watchTimeSeconds,
+    changed: completed !== current.completed || watchTimeSeconds !== current.watchTimeSeconds,
+  };
+}
+
 export async function retryLearningProgressTransaction<T>(
   operation: () => Promise<T>,
 ): Promise<T> {
@@ -135,13 +151,14 @@ export async function updateLearningProgress(
 
     const progressId = existingProgress?.id ?? createId();
     const wasCompleted = existingProgress?.completed === true;
-    const nextCompleted = input.completed ?? existingProgress?.completed ?? false;
-    const currentWatchTimeSeconds = Number(existingProgress?.watchTimeSeconds ?? 0);
-    const nextWatchTimeSeconds = input.watchTimeSeconds === undefined
-      ? currentWatchTimeSeconds
-      : Math.max(currentWatchTimeSeconds, input.watchTimeSeconds);
-    const progressChanged = nextWatchTimeSeconds !== currentWatchTimeSeconds
-      || nextCompleted !== (existingProgress?.completed ?? false);
+    const {
+      completed: nextCompleted,
+      watchTimeSeconds: nextWatchTimeSeconds,
+      changed: progressChanged,
+    } = derivePersistedLearningProgress({
+      completed: existingProgress?.completed ?? false,
+      watchTimeSeconds: Number(existingProgress?.watchTimeSeconds ?? 0),
+    }, input);
 
     if (existingProgress) {
       if (progressChanged) {

--- a/src/lib/learning-workspace.ts
+++ b/src/lib/learning-workspace.ts
@@ -1,0 +1,237 @@
+import 'server-only';
+
+import { and, asc, eq } from 'drizzle-orm';
+import sanitizeHtml from 'sanitize-html';
+
+import { extractBunnyVideoInfo, generateSignedVideoUrl, isBunnyVideo } from '@/lib/bunny';
+import { db } from '@/lib/db';
+import { courses, enrollments, lessonProgress, lessons } from '@/lib/db/schema';
+
+type CourseFact = { id: string; slug: string; title: string };
+type LessonAccessFact = {
+  id: string;
+  courseId: string;
+  isFreePreview: boolean | null;
+};
+type CurrentLessonFact = LessonAccessFact & {
+  title: string;
+  content: string | null;
+  videoUrl: string | null;
+  videoDuration: number | null;
+};
+type CurriculumFact = {
+  id: string;
+  title: string;
+  videoDuration: number | null;
+  isFreePreview: boolean | null;
+};
+type ProgressFact = {
+  lessonId: string;
+  completed: boolean | null;
+  watchTimeSeconds: number | null;
+};
+
+export type LearningWorkspaceStore = {
+  readCourse(courseSlug: string): Promise<CourseFact | null>;
+  readLessonAccess(lessonId: string): Promise<LessonAccessFact | null>;
+  readAuthorizedLesson(
+    lessonId: string,
+    accessMode: 'enrolled' | 'free_preview',
+  ): Promise<CurrentLessonFact | null>;
+  hasEnrollment(memberId: string, courseId: string): Promise<boolean>;
+  readCurriculum(courseId: string): Promise<CurriculumFact[]>;
+  readProgress(memberId: string, courseId: string): Promise<ProgressFact[]>;
+};
+
+export type LearningCurriculumLesson = {
+  id: string;
+  title: string;
+  videoDuration: number | null;
+  isFreePreview: boolean;
+};
+
+export type LearningWorkspaceProjection =
+  | { kind: 'not_found' }
+  | { kind: 'access_denied'; courseSlug: string }
+  | {
+    kind: 'ready';
+    course: CourseFact;
+    currentLesson: {
+      id: string;
+      title: string;
+      content: string | null;
+      playbackUrl: string | null;
+      videoDuration: number | null;
+      isFreePreview: boolean;
+    };
+    curriculum: LearningCurriculumLesson[];
+    previousLesson: LearningCurriculumLesson | null;
+    nextLesson: LearningCurriculumLesson | null;
+    currentIndex: number;
+    isEnrolled: boolean;
+    canTrackProgress: boolean;
+    completedLessonIds: string[];
+    currentProgress: { completed: boolean; watchTimeSeconds: number };
+  };
+
+const databaseStore: LearningWorkspaceStore = {
+  async readCourse(courseSlug) {
+    const [course] = await db
+      .select({ id: courses.id, slug: courses.slug, title: courses.title })
+      .from(courses)
+      .where(eq(courses.slug, courseSlug))
+      .limit(1);
+    return course ?? null;
+  },
+  async readLessonAccess(lessonId) {
+    const [lesson] = await db
+      .select({
+        id: lessons.id,
+        courseId: lessons.courseId,
+        isFreePreview: lessons.isFreePreview,
+      })
+      .from(lessons)
+      .where(eq(lessons.id, lessonId))
+      .limit(1);
+    return lesson ?? null;
+  },
+  async readAuthorizedLesson(lessonId, accessMode) {
+    const [lesson] = await db
+      .select({
+        id: lessons.id,
+        courseId: lessons.courseId,
+        title: lessons.title,
+        content: lessons.content,
+        videoUrl: lessons.videoUrl,
+        videoDuration: lessons.videoDuration,
+        isFreePreview: lessons.isFreePreview,
+      })
+      .from(lessons)
+      .where(accessMode === 'enrolled'
+        ? eq(lessons.id, lessonId)
+        : and(eq(lessons.id, lessonId), eq(lessons.isFreePreview, true)))
+      .limit(1);
+    return lesson ?? null;
+  },
+  async hasEnrollment(memberId, courseId) {
+    const [enrollment] = await db
+      .select({ id: enrollments.id })
+      .from(enrollments)
+      .where(and(
+        eq(enrollments.userId, memberId),
+        eq(enrollments.courseId, courseId),
+      ))
+      .limit(1);
+    return Boolean(enrollment);
+  },
+  async readCurriculum(courseId) {
+    return db
+      .select({
+        id: lessons.id,
+        title: lessons.title,
+        videoDuration: lessons.videoDuration,
+        isFreePreview: lessons.isFreePreview,
+      })
+      .from(lessons)
+      .where(eq(lessons.courseId, courseId))
+      .orderBy(asc(lessons.orderIndex));
+  },
+  async readProgress(memberId, courseId) {
+    return db
+      .select({
+        lessonId: lessonProgress.lessonId,
+        completed: lessonProgress.completed,
+        watchTimeSeconds: lessonProgress.watchTimeSeconds,
+      })
+      .from(lessonProgress)
+      .innerJoin(lessons, eq(lessonProgress.lessonId, lessons.id))
+      .where(and(
+        eq(lessonProgress.userId, memberId),
+        eq(lessons.courseId, courseId),
+      ));
+  },
+};
+
+function sanitizeLessonContent(content: string | null) {
+  if (!content) return null;
+  return sanitizeHtml(content, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['h1', 'h2', 'h3', 'pre', 'code', 'span', 'del']),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      a: ['href', 'target', 'rel'],
+      code: ['class'],
+      span: ['class', 'style'],
+      pre: ['class'],
+    },
+  });
+}
+
+function preparePlaybackUrl(videoUrl: string | null) {
+  if (!videoUrl || !isBunnyVideo(videoUrl)) return videoUrl;
+  const bunnyVideo = extractBunnyVideoInfo(videoUrl);
+  return bunnyVideo
+    ? generateSignedVideoUrl(bunnyVideo.videoId, 3600, bunnyVideo.libraryId)
+    : videoUrl;
+}
+
+export async function getLearningWorkspaceProjection(
+  input: { memberId: string | null; courseSlug: string; lessonId: string },
+  store: LearningWorkspaceStore = databaseStore,
+): Promise<LearningWorkspaceProjection> {
+  const [course, lessonAccess] = await Promise.all([
+    store.readCourse(input.courseSlug),
+    store.readLessonAccess(input.lessonId),
+  ]);
+  if (!course || !lessonAccess || lessonAccess.courseId !== course.id) {
+    return { kind: 'not_found' };
+  }
+
+  const isEnrolled = input.memberId
+    ? await store.hasEnrollment(input.memberId, course.id)
+    : false;
+  if (!isEnrolled && !lessonAccess.isFreePreview) {
+    return { kind: 'access_denied', courseSlug: course.slug };
+  }
+
+  const [lesson, curriculumFacts, progressFacts] = await Promise.all([
+    store.readAuthorizedLesson(input.lessonId, isEnrolled ? 'enrolled' : 'free_preview'),
+    store.readCurriculum(course.id),
+    input.memberId ? store.readProgress(input.memberId, course.id) : Promise.resolve([]),
+  ]);
+  if (!lesson || lesson.courseId !== course.id) return { kind: 'not_found' };
+  const curriculum = curriculumFacts.map((item): LearningCurriculumLesson => ({
+    id: item.id,
+    title: item.title,
+    videoDuration: item.videoDuration,
+    isFreePreview: Boolean(item.isFreePreview),
+  }));
+  const currentIndex = curriculum.findIndex((item) => item.id === lesson.id);
+  if (currentIndex < 0) return { kind: 'not_found' };
+
+  const currentProgress = progressFacts.find((item) => item.lessonId === lesson.id);
+  return {
+    kind: 'ready',
+    course,
+    currentLesson: {
+      id: lesson.id,
+      title: lesson.title,
+      content: sanitizeLessonContent(lesson.content),
+      playbackUrl: preparePlaybackUrl(lesson.videoUrl),
+      videoDuration: lesson.videoDuration,
+      isFreePreview: Boolean(lesson.isFreePreview),
+    },
+    curriculum,
+    previousLesson: currentIndex > 0 ? curriculum[currentIndex - 1] : null,
+    nextLesson: currentIndex < curriculum.length - 1 ? curriculum[currentIndex + 1] : null,
+    currentIndex,
+    isEnrolled,
+    canTrackProgress: Boolean(input.memberId),
+    completedLessonIds: progressFacts
+      .filter((item) => item.completed)
+      .map((item) => item.lessonId),
+    currentProgress: {
+      completed: Boolean(currentProgress?.completed),
+      watchTimeSeconds: Math.max(0, currentProgress?.watchTimeSeconds ?? 0),
+    },
+  };
+}

--- a/tests/api/progress-auth-contract.test.ts
+++ b/tests/api/progress-auth-contract.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/db', () => ({ db: {} }));
+vi.mock('@/lib/error-handler', () => ({ logError: vi.fn() }));
+vi.mock('@/lib/learning-progress', () => ({ updateLearningProgress: vi.fn() }));
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  rateLimits: { general: { maxRequests: 100, windowMs: 60_000 } },
+  rateLimitResponse: vi.fn(),
+}));
+
+import { auth } from '@/lib/auth';
+import { updateLearningProgress } from '@/lib/learning-progress';
+import { checkRateLimit } from '@/lib/rate-limit';
+
+describe('POST /api/progress authentication boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue(null as never);
+  });
+
+  it('does not rate-limit or write progress for an anonymous preview', async () => {
+    const { POST } = await import('@/app/api/progress/route');
+    const response = await POST(new Request('http://localhost/api/progress', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lessonId: 'lesson-free', watchTimeSeconds: 12 }),
+    }));
+
+    expect(response.status).toBe(401);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(updateLearningProgress).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/learning-workspace-page.test.tsx
+++ b/tests/app/learning-workspace-page.test.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/db', () => ({ db: {} }));
+vi.mock('@/lib/learning-workspace', () => ({ getLearningWorkspaceProjection: vi.fn() }));
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => { throw new Error('NEXT_NOT_FOUND'); }),
+  redirect: vi.fn((destination: string) => { throw new Error(`NEXT_REDIRECT:${destination}`); }),
+}));
+vi.mock('@/components/course/LearnPageClient', () => ({ default: () => null }));
+
+import { auth } from '@/lib/auth';
+import { getLearningWorkspaceProjection } from '@/lib/learning-workspace';
+
+describe('lesson learning workspace page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({ user: { id: 'member-1' } } as never);
+  });
+
+  it('renders only the authorized projection and resumes current progress', async () => {
+    vi.mocked(getLearningWorkspaceProjection).mockResolvedValue({
+      kind: 'ready',
+      course: { id: 'course-1', slug: 'typescript', title: 'TypeScript' },
+      currentLesson: {
+        id: 'lesson-2',
+        title: 'Lesson two',
+        content: '<p>Notes</p>',
+        playbackUrl: 'https://signed.example/current',
+        videoDuration: 90,
+        isFreePreview: false,
+      },
+      curriculum: [
+        { id: 'lesson-1', title: 'Lesson one', videoDuration: 60, isFreePreview: true },
+        { id: 'lesson-2', title: 'Lesson two', videoDuration: 90, isFreePreview: false },
+      ],
+      previousLesson: { id: 'lesson-1', title: 'Lesson one', videoDuration: 60, isFreePreview: true },
+      nextLesson: null,
+      currentIndex: 1,
+      isEnrolled: true,
+      canTrackProgress: true,
+      completedLessonIds: ['lesson-1'],
+      currentProgress: { completed: false, watchTimeSeconds: 37 },
+    });
+
+    const { default: LessonPage } = await import('@/app/courses/[slug]/learn/[lessonId]/page');
+    const element = await LessonPage({
+      params: Promise.resolve({ slug: 'typescript', lessonId: 'lesson-2' }),
+    });
+
+    expect(getLearningWorkspaceProjection).toHaveBeenCalledWith({
+      memberId: 'member-1',
+      courseSlug: 'typescript',
+      lessonId: 'lesson-2',
+    });
+    expect(element.props).toMatchObject({
+      course: { id: 'course-1', slug: 'typescript', title: 'TypeScript' },
+      currentLesson: {
+        id: 'lesson-2',
+        title: 'Lesson two',
+        content: '<p>Notes</p>',
+        videoUrl: 'https://signed.example/current',
+      },
+      allLessons: [
+        { id: 'lesson-1', title: 'Lesson one', videoDuration: 60, isFreePreview: true },
+        { id: 'lesson-2', title: 'Lesson two', videoDuration: 90, isFreePreview: false },
+      ],
+      currentProgress: { completed: false, watchTimeSeconds: 37 },
+    });
+    expect(element.props.currentLesson).not.toHaveProperty('playbackUrl');
+  });
+});

--- a/tests/lib/learning-progress-persistence.test.ts
+++ b/tests/lib/learning-progress-persistence.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { derivePersistedLearningProgress } from '@/lib/learning-progress';
+
+describe('learning progress persistence boundary', () => {
+  it('keeps watch position monotonic when a stale client reports a lower value', () => {
+    expect(derivePersistedLearningProgress(
+      { completed: false, watchTimeSeconds: 120 },
+      { watchTimeSeconds: 60 },
+    )).toEqual({
+      completed: false,
+      watchTimeSeconds: 120,
+      changed: false,
+    });
+  });
+
+  it('makes repeated completion updates idempotent', () => {
+    expect(derivePersistedLearningProgress(
+      { completed: true, watchTimeSeconds: 120 },
+      { completed: true, watchTimeSeconds: 120 },
+    )).toEqual({
+      completed: true,
+      watchTimeSeconds: 120,
+      changed: false,
+    });
+  });
+
+  it('preserves the existing explicit completion policy', () => {
+    expect(derivePersistedLearningProgress(
+      { completed: true, watchTimeSeconds: 120 },
+      { completed: false },
+    )).toEqual({
+      completed: false,
+      watchTimeSeconds: 120,
+      changed: true,
+    });
+  });
+});

--- a/tests/lib/learning-workspace-access.test.ts
+++ b/tests/lib/learning-workspace-access.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getLearningWorkspaceProjection,
+  type LearningWorkspaceStore,
+} from '@/lib/learning-workspace';
+
+function enrolledStore(overrides: Partial<LearningWorkspaceStore> = {}): LearningWorkspaceStore {
+  return {
+    async readCourse() {
+      return { id: 'course-1', slug: 'typescript', title: 'TypeScript' };
+    },
+    async readLessonAccess() {
+      return { id: 'lesson-2', courseId: 'course-1', isFreePreview: false };
+    },
+    async readAuthorizedLesson() {
+      return {
+        id: 'lesson-2',
+        courseId: 'course-1',
+        title: 'Lesson two',
+        content: '<p>Lesson notes</p>',
+        videoUrl: null,
+        videoDuration: null,
+        isFreePreview: false,
+      };
+    },
+    async hasEnrollment() {
+      return true;
+    },
+    async readCurriculum() {
+      return [
+        { id: 'lesson-1', title: 'Lesson one', videoDuration: 60, isFreePreview: true },
+        { id: 'lesson-2', title: 'Lesson two', videoDuration: null, isFreePreview: false },
+      ];
+    },
+    async readProgress() {
+      return [
+        { lessonId: 'lesson-1', completed: true, watchTimeSeconds: 60 },
+        { lessonId: 'lesson-2', completed: false, watchTimeSeconds: 37 },
+      ];
+    },
+    ...overrides,
+  };
+}
+
+describe('LearningWorkspaceProjection access boundary', () => {
+  it('returns enrolled progress and truthful content-only lesson fields', async () => {
+    const result = await getLearningWorkspaceProjection({
+      memberId: 'member-1',
+      courseSlug: 'typescript',
+      lessonId: 'lesson-2',
+    }, enrolledStore());
+
+    expect(result).toMatchObject({
+      kind: 'ready',
+      currentLesson: {
+        content: '<p>Lesson notes</p>',
+        playbackUrl: null,
+        videoDuration: null,
+      },
+      isEnrolled: true,
+      canTrackProgress: true,
+      completedLessonIds: ['lesson-1'],
+      currentProgress: { completed: false, watchTimeSeconds: 37 },
+    });
+  });
+
+  it.each([
+    { content: null, videoUrl: 'https://video.example/lesson', label: 'video-only' },
+    { content: null, videoUrl: null, label: 'empty' },
+  ])('keeps $label lesson fields truthful', async ({ content, videoUrl }) => {
+    const result = await getLearningWorkspaceProjection({
+      memberId: 'member-1',
+      courseSlug: 'typescript',
+      lessonId: 'lesson-2',
+    }, enrolledStore({
+      async readAuthorizedLesson() {
+        return {
+          id: 'lesson-2',
+          courseId: 'course-1',
+          title: 'Lesson two',
+          content,
+          videoUrl,
+          videoDuration: videoUrl ? 90 : null,
+          isFreePreview: false,
+        };
+      },
+    }));
+
+    expect(result).toMatchObject({
+      kind: 'ready',
+      currentLesson: {
+        content,
+        playbackUrl: videoUrl,
+        videoDuration: videoUrl ? 90 : null,
+      },
+    });
+  });
+
+  it('denies a locked lesson before reading curriculum or member progress', async () => {
+    const readCurriculum = vi.fn();
+    const readProgress = vi.fn();
+    const readAuthorizedLesson = vi.fn();
+    const result = await getLearningWorkspaceProjection({
+      memberId: 'member-1',
+      courseSlug: 'typescript',
+      lessonId: 'lesson-2',
+    }, enrolledStore({
+      async hasEnrollment() {
+        return false;
+      },
+      readAuthorizedLesson,
+      readCurriculum,
+      readProgress,
+    }));
+
+    expect(result).toEqual({ kind: 'access_denied', courseSlug: 'typescript' });
+    expect(readAuthorizedLesson).not.toHaveBeenCalled();
+    expect(readCurriculum).not.toHaveBeenCalled();
+    expect(readProgress).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/learning-workspace-authorization-order.test.ts
+++ b/tests/lib/learning-workspace-authorization-order.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getLearningWorkspaceProjection,
+  type LearningWorkspaceStore,
+} from '@/lib/learning-workspace';
+
+describe('LearningWorkspaceProjection authorization order', () => {
+  it('reads current content only through the authorized lesson query', async () => {
+    const readAuthorizedLesson = vi.fn().mockResolvedValue({
+      id: 'lesson-1',
+      courseId: 'course-1',
+      title: 'Private lesson',
+      content: '<p>Authorized</p>',
+      videoUrl: 'https://video.example/authorized',
+      videoDuration: 90,
+      isFreePreview: false,
+    });
+    const store: LearningWorkspaceStore = {
+      readCourse: vi.fn().mockResolvedValue({ id: 'course-1', slug: 'typescript', title: 'TypeScript' }),
+      readLessonAccess: vi.fn().mockResolvedValue({
+        id: 'lesson-1',
+        courseId: 'course-1',
+        isFreePreview: false,
+      }),
+      readAuthorizedLesson,
+      hasEnrollment: vi.fn().mockResolvedValue(true),
+      readCurriculum: vi.fn().mockResolvedValue([
+        { id: 'lesson-1', title: 'Private lesson', videoDuration: 90, isFreePreview: false },
+      ]),
+      readProgress: vi.fn().mockResolvedValue([]),
+    };
+
+    const result = await getLearningWorkspaceProjection({
+      memberId: 'member-1',
+      courseSlug: 'typescript',
+      lessonId: 'lesson-1',
+    }, store);
+
+    expect(readAuthorizedLesson).toHaveBeenCalledWith('lesson-1', 'enrolled');
+    expect(result).toMatchObject({
+      kind: 'ready',
+      currentLesson: {
+        content: '<p>Authorized</p>',
+        playbackUrl: 'https://video.example/authorized',
+      },
+    });
+  });
+
+  it('never reads current content when a locked lesson is denied', async () => {
+    const readAuthorizedLesson = vi.fn();
+    const store: LearningWorkspaceStore = {
+      readCourse: vi.fn().mockResolvedValue({ id: 'course-1', slug: 'typescript', title: 'TypeScript' }),
+      readLessonAccess: vi.fn().mockResolvedValue({
+        id: 'lesson-1',
+        courseId: 'course-1',
+        isFreePreview: false,
+      }),
+      readAuthorizedLesson,
+      hasEnrollment: vi.fn().mockResolvedValue(false),
+      readCurriculum: vi.fn(),
+      readProgress: vi.fn(),
+    };
+
+    await expect(getLearningWorkspaceProjection({
+      memberId: 'member-1',
+      courseSlug: 'typescript',
+      lessonId: 'lesson-1',
+    }, store)).resolves.toEqual({ kind: 'access_denied', courseSlug: 'typescript' });
+    expect(readAuthorizedLesson).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/learning-workspace-projection.test.ts
+++ b/tests/lib/learning-workspace-projection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getLearningWorkspaceProjection,
+  type LearningWorkspaceStore,
+} from '@/lib/learning-workspace';
+
+function workspaceStore(): LearningWorkspaceStore {
+  return {
+    async readCourse() {
+      return { id: 'course-1', slug: 'typescript', title: 'TypeScript' };
+    },
+    async readLessonAccess() {
+      return { id: 'lesson-free', courseId: 'course-1', isFreePreview: true };
+    },
+    async readAuthorizedLesson() {
+      return {
+        id: 'lesson-free',
+        courseId: 'course-1',
+        title: 'Free lesson',
+        content: '<p>Preview</p>',
+        videoUrl: 'https://video.example/free',
+        videoDuration: 120,
+        isFreePreview: true,
+      };
+    },
+    async hasEnrollment() {
+      return false;
+    },
+    async readCurriculum() {
+      const curriculumWithPrivateFields = [
+        {
+          id: 'lesson-free',
+          title: 'Free lesson',
+          content: '<p>Preview</p>',
+          videoUrl: 'https://video.example/free',
+          videoDuration: 120,
+          isFreePreview: true,
+        },
+        {
+          id: 'lesson-locked',
+          title: 'Locked lesson',
+          content: '<p>Private</p>',
+          videoUrl: 'https://video.example/private',
+          videoDuration: 240,
+          isFreePreview: false,
+        },
+      ];
+      return curriculumWithPrivateFields;
+    },
+    async readProgress() {
+      throw new Error('anonymous preview must not read member progress');
+    },
+  };
+}
+
+describe('LearningWorkspaceProjection', () => {
+  it('returns current free-preview content but strips content and video identity from curriculum records', async () => {
+    const result = await getLearningWorkspaceProjection({
+      memberId: null,
+      courseSlug: 'typescript',
+      lessonId: 'lesson-free',
+    }, workspaceStore());
+
+    expect(result).toEqual({
+      kind: 'ready',
+      course: { id: 'course-1', slug: 'typescript', title: 'TypeScript' },
+      currentLesson: {
+        id: 'lesson-free',
+        title: 'Free lesson',
+        content: '<p>Preview</p>',
+        playbackUrl: 'https://video.example/free',
+        videoDuration: 120,
+        isFreePreview: true,
+      },
+      curriculum: [
+        { id: 'lesson-free', title: 'Free lesson', videoDuration: 120, isFreePreview: true },
+        { id: 'lesson-locked', title: 'Locked lesson', videoDuration: 240, isFreePreview: false },
+      ],
+      previousLesson: null,
+      nextLesson: { id: 'lesson-locked', title: 'Locked lesson', videoDuration: 240, isFreePreview: false },
+      currentIndex: 0,
+      isEnrolled: false,
+      canTrackProgress: false,
+      completedLessonIds: [],
+      currentProgress: { completed: false, watchTimeSeconds: 0 },
+    });
+    expect(JSON.stringify(result)).not.toContain('video.example/private');
+    expect(JSON.stringify(result)).not.toContain('<p>Private</p>');
+  });
+});


### PR DESCRIPTION
## Summary

- add a server-only authorized learning workspace projection with minimal course, current lesson, curriculum, and progress DTOs
- authorize from minimal lesson facts before reading private content or video identity, and constrain free-preview content reads in SQL
- preserve strict progress validation while making monotonic watch-time and replay-safe persistence behavior explicit and tested
- initialize client tracking from the persisted current watch position without changing lesson order, auto-next, or completion policy

## Verification

- `npm run lint`
- `npm run test -- --run` (165 files, 865 tests)
- targeted issue suite after final review fixes (9 files, 33 tests)
- `npm run build`
- `git diff --check`
- two-axis code review: final Spec findings 0; final Standards findings resolved

Closes #41
