### PR TITLE
feat: recover trusted Bunny progress saves

### DIFF
--- a/src/components/course/LearnPageClient.tsx
+++ b/src/components/course/LearnPageClient.tsx
@@ -2,12 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, ArrowRight, Check, CircleCheck, FileText, Lock } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Check, CircleCheck, FileText, LoaderCircle, Lock } from 'lucide-react';
 import BunnyPlayer from '@/components/video/BunnyPlayer';
 import LearningCurriculum from './LearningCurriculum';
 import LearningNavbar from './LearningNavbar';
 import { sanitizeRichContent } from '@/lib/sanitize';
 import { showToast } from '@/components/ui/Toast';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -64,6 +65,13 @@ const formatDuration = (seconds: number | null) => {
   return `${minutes} นาที ${remainingSeconds < 10 ? '0' : ''}${remainingSeconds} วินาที`;
 };
 
+const formatResumeTime = (seconds: number) => {
+  const wholeSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(wholeSeconds / 60);
+  const remainingSeconds = wholeSeconds % 60;
+  return String(minutes).padStart(2, '0') + ':' + String(remainingSeconds).padStart(2, '0');
+};
+
 export default function LearnPageClient({
   course,
   currentLesson,
@@ -81,8 +89,13 @@ export default function LearnPageClient({
   const [lessonSearch, setLessonSearch] = useState('');
   const [lockedLesson, setLockedLesson] = useState<LearningCurriculumLesson | null>(null);
   const [completedIds, setCompletedIds] = useState<Set<string>>(new Set(initialCompletedIds));
-  const [markingComplete, setMarkingComplete] = useState(false);
-  const completionPendingRef = useRef(false);
+  const [completionSaveState, setCompletionSaveState] = useState<'idle' | 'pending' | 'saved' | 'failed'>(
+    currentProgress.completed ? 'saved' : 'idle',
+  );
+  const [watchSyncFailed, setWatchSyncFailed] = useState(false);
+  const [resumedAtSeconds, setResumedAtSeconds] = useState<number | null>(null);
+  const completionRequestedRef = useRef(currentProgress.completed);
+  const watchSyncPendingRef = useRef(false);
   const watchTimeRef = useRef(currentProgress.watchTimeSeconds);
   const lastSyncRef = useRef(currentProgress.watchTimeSeconds);
   const isPlayingRef = useRef(false);
@@ -96,12 +109,32 @@ export default function LearnPageClient({
   const isReviewMode = isEnrolled && totalCount > 0 && completedCount === totalCount;
   const hasContent = Boolean(currentLesson.content?.trim());
   const duration = formatDuration(currentLesson.videoDuration);
+  const statusHeading = completionSaveState === 'pending'
+    ? 'กำลังบันทึกบทเรียน…'
+    : completionSaveState === 'failed'
+      ? 'ยังบันทึกบทนี้ไม่ได้'
+      : isReviewMode
+        ? 'เรียนครบแล้ว · กำลังทบทวน'
+        : isCurrentCompleted
+          ? 'เรียนจบบทนี้แล้ว'
+          : isEnrolled
+            ? 'เรียนตามจังหวะของคุณ'
+            : 'บทเรียนทดลองใช้ฟรี';
+  const statusDescription = completionSaveState === 'pending'
+    ? 'รอระบบยืนยันก่อนปิดหน้าหรือเปลี่ยนบทเรียน'
+    : completionSaveState === 'failed'
+      ? 'ยังไม่มีการยืนยันว่าเรียนจบ กดลองบันทึกอีกครั้งได้'
+      : isCurrentCompleted
+        ? 'คุณกลับมาทบทวนบทนี้ได้เสมอ'
+        : isEnrolled
+          ? 'เมื่อเรียนเนื้อหาครบแล้ว กดบันทึกว่าเรียนจบได้'
+          : 'ความคืบหน้าจะถูกบันทึกหลังจากสมัครและเข้าสู่ระบบ';
 
   const syncWatchTime = useCallback(async () => {
-    if (!canTrackProgress) return;
+    if (!canTrackProgress || watchSyncPendingRef.current) return false;
     const currentWatchTime = Math.floor(watchTimeRef.current);
-    if (currentWatchTime <= lastSyncRef.current) return;
-    lastSyncRef.current = currentWatchTime;
+    if (currentWatchTime <= lastSyncRef.current) return true;
+    watchSyncPendingRef.current = true;
 
     try {
       const response = await fetch('/api/progress', {
@@ -112,9 +145,15 @@ export default function LearnPageClient({
           watchTimeSeconds: currentWatchTime,
         }),
       });
-      if (!response.ok) lastSyncRef.current = 0;
+      if (!response.ok) throw new Error('Unable to save watch position');
+      lastSyncRef.current = currentWatchTime;
+      setWatchSyncFailed(false);
+      return true;
     } catch {
-      lastSyncRef.current = 0;
+      setWatchSyncFailed(true);
+      return false;
+    } finally {
+      watchSyncPendingRef.current = false;
     }
   }, [canTrackProgress, currentLesson.id]);
 
@@ -136,16 +175,19 @@ export default function LearnPageClient({
     watchTimeRef.current = currentProgress.watchTimeSeconds;
     lastSyncRef.current = currentProgress.watchTimeSeconds;
     isPlayingRef.current = false;
-    completionPendingRef.current = false;
-    setMarkingComplete(false);
+    watchSyncPendingRef.current = false;
+    completionRequestedRef.current = currentProgress.completed;
+    setCompletionSaveState(currentProgress.completed ? 'saved' : 'idle');
+    setWatchSyncFailed(false);
+    setResumedAtSeconds(null);
     setLockedLesson(null);
-  }, [currentLesson.id, currentProgress.watchTimeSeconds]);
+  }, [currentLesson.id, currentProgress.completed, currentProgress.watchTimeSeconds]);
 
   const completeCurrentLesson = useCallback(async () => {
-    if (!isEnrolled || !canTrackProgress || completedIds.has(currentLesson.id) || completionPendingRef.current) return;
+    if (!isEnrolled || !canTrackProgress || completionRequestedRef.current) return;
 
-    completionPendingRef.current = true;
-    setMarkingComplete(true);
+    completionRequestedRef.current = true;
+    setCompletionSaveState('pending');
     try {
       const response = await fetch('/api/progress', {
         method: 'POST',
@@ -156,22 +198,22 @@ export default function LearnPageClient({
           watchTimeSeconds: Math.floor(watchTimeRef.current) || undefined,
         }),
       });
-
       if (!response.ok) throw new Error('Unable to save lesson progress');
 
-      const nextCompletedCount = completedIds.size + 1;
+      const nextCompletedCount = completedCount + 1;
       setCompletedIds((current) => new Set(current).add(currentLesson.id));
+      setCompletionSaveState('saved');
+      setWatchSyncFailed(false);
       showToast(
         nextCompletedCount === totalCount ? 'เรียนครบทุกบทแล้ว พร้อมกลับมาทบทวนได้ทุกเมื่อ' : 'บันทึกว่าเรียนจบบทนี้แล้ว',
         'success',
       );
     } catch {
+      completionRequestedRef.current = false;
+      setCompletionSaveState('failed');
       showToast('บันทึกความคืบหน้าไม่สำเร็จ กรุณาลองอีกครั้ง', 'error');
-    } finally {
-      completionPendingRef.current = false;
-      setMarkingComplete(false);
     }
-  }, [canTrackProgress, completedIds, currentLesson.id, isEnrolled, totalCount]);
+  }, [canTrackProgress, completedCount, currentLesson.id, isEnrolled, totalCount]);
 
   const handleTimeUpdate = useCallback((currentTime: number) => {
     watchTimeRef.current = currentTime;
@@ -188,7 +230,11 @@ export default function LearnPageClient({
 
   const handleEnded = useCallback(() => {
     isPlayingRef.current = false;
-    void syncWatchTime().then(completeCurrentLesson);
+    if (completionRequestedRef.current) {
+      void syncWatchTime();
+      return;
+    }
+    void completeCurrentLesson();
   }, [completeCurrentLesson, syncWatchTime]);
 
   const openLockedDialog = useCallback((lessonId: string) => {
@@ -253,15 +299,25 @@ export default function LearnPageClient({
             </header>
 
             {currentLesson.videoUrl && (
-              <div className="relative aspect-video overflow-hidden rounded-2xl bg-slate-950 shadow-[0_22px_60px_-32px_rgba(15,23,42,0.65)] ring-1 ring-slate-950/10 [&_iframe]:h-full [&_iframe]:w-full">
-                <BunnyPlayer
-                  videoId={currentLesson.videoUrl}
-                  onTimeUpdate={handleTimeUpdate}
-                  onPlay={handlePlay}
-                  onPause={handlePause}
-                  onEnded={handleEnded}
-                />
-              </div>
+              <>
+                <div className="relative aspect-video overflow-hidden rounded-2xl bg-slate-950 shadow-[0_22px_60px_-32px_rgba(15,23,42,0.65)] ring-1 ring-slate-950/10 [&_iframe]:h-full [&_iframe]:w-full">
+                  <BunnyPlayer
+                    videoId={currentLesson.videoUrl}
+                    lessonTitle={currentLesson.title}
+                    resumeAtSeconds={currentProgress.watchTimeSeconds}
+                    onTimeUpdate={handleTimeUpdate}
+                    onPlay={handlePlay}
+                    onPause={handlePause}
+                    onEnded={handleEnded}
+                    onResume={setResumedAtSeconds}
+                  />
+                </div>
+                {resumedAtSeconds !== null && (
+                  <p role="status" aria-live="polite" className="mt-3 text-sm text-muted-foreground">
+                    กลับมาเรียนต่อที่ {formatResumeTime(resumedAtSeconds)}
+                  </p>
+                )}
+              </>
             )}
 
             <section className="mt-6 flex flex-col gap-4 rounded-2xl border bg-background p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between sm:p-5" aria-label="สถานะบทเรียน">
@@ -269,26 +325,40 @@ export default function LearnPageClient({
                 <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary" aria-hidden="true">
                   {isCurrentCompleted ? <CircleCheck className="size-5" /> : <FileText className="size-5" />}
                 </span>
-                <div>
-                  <h2 className="font-heading text-base font-semibold">
-                    {isReviewMode ? 'เรียนครบแล้ว · กำลังทบทวน' : isCurrentCompleted ? 'เรียนจบบทนี้แล้ว' : isEnrolled ? 'เรียนตามจังหวะของคุณ' : 'บทเรียนทดลองฟรี'}
-                  </h2>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {isCurrentCompleted
-                      ? 'คุณกลับมาทบทวนบทนี้ได้เสมอ'
-                      : isEnrolled
-                        ? currentLesson.videoUrl ? 'ดูวิดีโอจนจบ หรือกดบันทึกเมื่อเรียนเนื้อหาครบแล้ว' : 'กดบันทึกเมื่ออ่านและฝึกตามเนื้อหาเรียบร้อยแล้ว'
-                        : 'ความคืบหน้าจะถูกบันทึกหลังจากสมัครและเข้าสู่ระบบ'}
-                  </p>
+                <div role="status" aria-live="polite">
+                  <h2 className="font-heading text-base font-semibold">{statusHeading}</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">{statusDescription}</p>
                 </div>
               </div>
               {isEnrolled && !isCurrentCompleted && (
-                <Button type="button" onClick={() => void completeCurrentLesson()} disabled={markingComplete}>
-                  <Check data-icon="inline-start" aria-hidden="true" />
-                  {markingComplete ? 'กำลังบันทึก...' : 'ทำเครื่องหมายว่าเรียนจบ'}
+                <Button
+                  type="button"
+                  onClick={() => void completeCurrentLesson()}
+                  disabled={completionSaveState === 'pending'}
+                >
+                  {completionSaveState === 'pending'
+                    ? <LoaderCircle className="animate-spin" data-icon="inline-start" aria-hidden="true" />
+                    : <Check data-icon="inline-start" aria-hidden="true" />}
+                  {completionSaveState === 'pending'
+                    ? 'กำลังบันทึก...'
+                    : completionSaveState === 'failed'
+                      ? 'ลองบันทึกอีกครั้ง'
+                      : 'ทำเครื่องหมายว่าเรียนจบ'}
                 </Button>
               )}
             </section>
+
+            {watchSyncFailed && canTrackProgress && (
+              <Alert className="mt-4">
+                <AlertTitle>ยังบันทึกตำแหน่งล่าสุดไม่ได้</AlertTitle>
+                <AlertDescription>
+                  <p>การเล่นวิดีโอยังดำเนินต่อได้ และคุณลองบันทึกตำแหน่งอีกครั้งได้</p>
+                  <Button type="button" variant="outline" size="sm" className="mt-3" onClick={() => void syncWatchTime()}>
+                    ลองบันทึกตำแหน่งอีกครั้ง
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
 
             {hasContent && (
               <Card className="mt-6" aria-labelledby="lesson-content-title">

--- a/src/components/video/BunnyPlayer.tsx
+++ b/src/components/video/BunnyPlayer.tsx
@@ -1,160 +1,157 @@
 'use client';
 
-import { useRef, useEffect, useCallback, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { TriangleAlert, VideoOff } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { connectBunnyPlayer, type BunnyPlayerCallbacks } from '@/lib/bunny-player-adapter';
 import { cn } from '@/lib/utils';
 
 interface BunnyPlayerProps {
   videoId: string;
   libraryId?: string;
+  lessonTitle?: string;
   autoplay?: boolean;
   className?: string;
+  resumeAtSeconds?: number;
   onTimeUpdate?: (currentTime: number, duration: number) => void;
   onPlay?: () => void;
   onPause?: () => void;
   onEnded?: () => void;
+  onError?: () => void;
+  onResume?: (seconds: number) => void;
 }
 
 type VideoType = 'youtube' | 'vimeo' | 'bunny' | 'unknown';
 
-export default function BunnyPlayer({ 
-  videoId, 
+function detectVideoType(url: string): VideoType {
+  if (url.includes('youtube.com') || url.includes('youtu.be')) return 'youtube';
+  if (url.includes('vimeo.com')) return 'vimeo';
+  if (url.includes('iframe.mediadelivery.net') || url.includes('video.bunnycdn.com')) return 'bunny';
+  return 'unknown';
+}
+
+function getYouTubeId(url: string): string | null {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=)([^&\s]+)/,
+    /(?:youtu\.be\/)([^?\s]+)/,
+    /(?:youtube\.com\/embed\/)([^?\s]+)/,
+    /(?:youtube\.com\/v\/)([^?\s]+)/,
+  ];
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function getVimeoId(url: string): string | null {
+  const match = url.match(/vimeo\.com\/(?:video\/)?(\d+)/);
+  return match ? match[1] : null;
+}
+
+function resolveEmbedUrl(videoId: string, libraryId: string | undefined, autoplay: boolean) {
+  const videoType = detectVideoType(videoId);
+  if (videoType === 'youtube') {
+    const youtubeId = getYouTubeId(videoId);
+    if (youtubeId) {
+      return 'https://www.youtube.com/embed/' + youtubeId + (autoplay ? '?autoplay=1&rel=0' : '?rel=0');
+    }
+  }
+  if (videoType === 'vimeo') {
+    const vimeoId = getVimeoId(videoId);
+    if (vimeoId) {
+      return 'https://player.vimeo.com/video/' + vimeoId + (autoplay ? '?autoplay=1' : '');
+    }
+  }
+  if (videoType === 'bunny') {
+    if (videoId.includes('/play/')) return videoId.replace('/play/', '/embed/');
+    if (videoId.includes('/embed/')) return videoId;
+    const match = videoId.match(/([a-f0-9-]{36})/i);
+    if (match && libraryId) {
+      return 'https://iframe.mediadelivery.net/embed/' + libraryId + '/' + match[1];
+    }
+    return videoId;
+  }
+  if (/^[a-f0-9-]{36}$/i.test(videoId) && libraryId) {
+    return 'https://iframe.mediadelivery.net/embed/' + libraryId + '/' + videoId;
+  }
+  if (libraryId && !videoId.includes('http')) {
+    return 'https://iframe.mediadelivery.net/embed/' + libraryId + '/' + videoId;
+  }
+  return videoId;
+}
+
+export default function BunnyPlayer({
+  videoId,
   libraryId,
+  lessonTitle,
   autoplay = false,
   className = '',
+  resumeAtSeconds,
   onTimeUpdate,
   onPlay,
   onPause,
   onEnded,
+  onError,
+  onResume,
 }: BunnyPlayerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const callbacksRef = useRef<BunnyPlayerCallbacks>({});
   const [loadedUrl, setLoadedUrl] = useState('');
-  const [debugUrl, setDebugUrl] = useState('');
-
-  // Listen for postMessage events from Bunny.net iframe player
-  const handleMessage = useCallback((event: MessageEvent) => {
-    if (!event.data || typeof event.data !== 'object') return;
-
-    // Bunny.net player sends events like: { event: 'timeupdate', data: { currentTime, duration } }
-    const msg = event.data;
-    const eventName = msg.event || msg.type;
-    const data = msg.data || msg;
-
-    switch (eventName) {
-      case 'timeupdate':
-        if (onTimeUpdate && typeof data.currentTime === 'number') {
-          onTimeUpdate(data.currentTime, data.duration || 0);
-        }
-        break;
-      case 'play':
-      case 'playing':
-        onPlay?.();
-        break;
-      case 'pause':
-        onPause?.();
-        break;
-      case 'ended':
-      case 'complete':
-        onEnded?.();
-        break;
-    }
-  }, [onTimeUpdate, onPlay, onPause, onEnded]);
-
-  const embedUrl = useMemo(() => {
-    // Detect video type from URL
-    const detectVideoType = (url: string): VideoType => {
-      if (url.includes('youtube.com') || url.includes('youtu.be')) return 'youtube';
-      if (url.includes('vimeo.com')) return 'vimeo';
-      if (url.includes('iframe.mediadelivery.net') || url.includes('video.bunnycdn.com')) return 'bunny';
-      return 'unknown';
-    };
-
-    // Extract YouTube video ID
-    const getYouTubeId = (url: string): string | null => {
-      const patterns = [
-        /(?:youtube\.com\/watch\?v=)([^&\s]+)/,
-        /(?:youtu\.be\/)([^?\s]+)/,
-        /(?:youtube\.com\/embed\/)([^?\s]+)/,
-        /(?:youtube\.com\/v\/)([^?\s]+)/,
-      ];
-      for (const pattern of patterns) {
-        const match = url.match(pattern);
-        if (match) return match[1];
-      }
-      return null;
-    };
-
-    // Extract Vimeo video ID
-    const getVimeoId = (url: string): string | null => {
-      const match = url.match(/vimeo\.com\/(?:video\/)?(\d+)/);
-      return match ? match[1] : null;
-    };
-
-    const videoType = detectVideoType(videoId);
-
-    if (videoType === 'youtube') {
-      const ytId = getYouTubeId(videoId);
-      if (ytId) {
-        const params = autoplay ? '?autoplay=1&rel=0' : '?rel=0';
-        return `https://www.youtube.com/embed/${ytId}${params}`;
-      }
-    }
-
-    if (videoType === 'vimeo') {
-      const vimeoId = getVimeoId(videoId);
-      if (vimeoId) {
-        const params = autoplay ? '?autoplay=1' : '';
-        return `https://player.vimeo.com/video/${vimeoId}${params}`;
-      }
-    }
-
-    if (videoType === 'bunny') {
-      if (videoId.includes('/play/')) {
-        return videoId.replace('/play/', '/embed/');
-      }
-      if (videoId.includes('/embed/')) {
-        return videoId;
-      }
-      const match = videoId.match(/([a-f0-9-]{36})/i);
-      if (match && libraryId) {
-        return `https://iframe.mediadelivery.net/embed/${libraryId}/${match[1]}`;
-      }
-      return videoId;
-    }
-
-    if (/^[a-f0-9-]{36}$/i.test(videoId) && libraryId) {
-      return `https://iframe.mediadelivery.net/embed/${libraryId}/${videoId}`;
-    }
-
-    if (libraryId && !videoId.includes('http')) {
-      return `https://iframe.mediadelivery.net/embed/${libraryId}/${videoId}`;
-    }
-
-    return videoId;
-  }, [autoplay, libraryId, videoId]);
+  const [slowUrl, setSlowUrl] = useState('');
+  const [failedUrl, setFailedUrl] = useState('');
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
-    window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
-  }, [handleMessage]);
+    callbacksRef.current = { onTimeUpdate, onPlay, onPause, onEnded, onError, onResume };
+  }, [onEnded, onError, onPause, onPlay, onResume, onTimeUpdate]);
 
-  const finalUrl = embedUrl;
+  const finalUrl = useMemo(
+    () => resolveEmbedUrl(videoId, libraryId, autoplay),
+    [autoplay, libraryId, videoId],
+  );
+  const videoType = useMemo(() => detectVideoType(finalUrl), [finalUrl]);
+
+  useEffect(() => {
+    if (videoType !== 'bunny') return;
+    const frame = iframeRef.current;
+    if (!frame) return;
+    const connection = connectBunnyPlayer({
+      frame,
+      resumeAtSeconds,
+      callbacks: {
+        onTimeUpdate: (seconds, duration) => callbacksRef.current.onTimeUpdate?.(seconds, duration),
+        onPlay: () => callbacksRef.current.onPlay?.(),
+        onPause: () => callbacksRef.current.onPause?.(),
+        onEnded: () => callbacksRef.current.onEnded?.(),
+        onResume: (seconds) => callbacksRef.current.onResume?.(seconds),
+        onError: () => {
+          setFailedUrl(finalUrl);
+          callbacksRef.current.onError?.();
+        },
+      },
+    });
+    return () => connection?.disconnect();
+  }, [finalUrl, reloadNonce, resumeAtSeconds, videoType]);
+
   const iframeLoaded = loadedUrl === finalUrl;
-  const showDebugOverlay = debugUrl === finalUrl && !iframeLoaded;
+  const playerFailed = failedUrl === finalUrl;
+  const playerSlow = slowUrl === finalUrl && !iframeLoaded;
 
   useEffect(() => {
-    if (!finalUrl) return;
-
-    const timer = window.setTimeout(() => {
-      if (!iframeLoaded) {
-        setDebugUrl(finalUrl);
-      }
-    }, 8000);
-
+    if (!finalUrl || iframeLoaded || playerFailed) return;
+    const timer = window.setTimeout(() => setSlowUrl(finalUrl), 8_000);
     return () => window.clearTimeout(timer);
-  }, [finalUrl, iframeLoaded]);
+  }, [finalUrl, iframeLoaded, playerFailed, reloadNonce]);
+
+  const retry = () => {
+    setLoadedUrl('');
+    setSlowUrl('');
+    setFailedUrl('');
+    setReloadNonce((current) => current + 1);
+  };
 
   if (!videoId) {
     return (
@@ -171,22 +168,29 @@ export default function BunnyPlayer({
   return (
     <div className={cn('relative aspect-video overflow-hidden rounded-xl bg-muted', className)}>
       <iframe
-        key={finalUrl}
+        key={finalUrl + ':' + reloadNonce}
         ref={iframeRef}
         src={finalUrl}
+        title={lessonTitle ? 'วิดีโอบทเรียน ' + lessonTitle : 'วิดีโอตัวอย่างหลักสูตร'}
         loading="lazy"
-        onLoad={() => setLoadedUrl(finalUrl)}
+        onLoad={() => {
+          setLoadedUrl(finalUrl);
+          setSlowUrl('');
+        }}
         className="absolute inset-0 size-full border-0"
         allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture"
         allowFullScreen
       />
-      {showDebugOverlay && (
+      {(playerSlow || playerFailed) && (
         <div className="absolute inset-0 flex items-center justify-center bg-background/90 p-6">
           <Alert className="max-w-xl">
             <TriangleAlert aria-hidden="true" />
-            <AlertTitle>วิดีโอกำลังโหลดช้าผิดปกติ</AlertTitle>
+            <AlertTitle>{playerFailed ? 'ยังเล่นวิดีโอนี้ไม่ได้' : 'วิดีโอกำลังโหลดช้าผิดปกติ'}</AlertTitle>
             <AlertDescription>
-              หากหน้าจอยังคงเป็นสีดำ อาจเกิดจากเครือข่ายหรือผู้ให้บริการอินเทอร์เน็ตบล็อกการเชื่อมต่อกับระบบวิดีโอ
+              <p>ลองโหลดวิดีโอใหม่ หากความคืบหน้ายังบันทึกไม่สำเร็จอาจต้องลองบันทึกอีกครั้ง</p>
+              <Button type="button" size="sm" variant="secondary" className="mt-3" onClick={retry}>
+                ลองโหลดวิดีโออีกครั้ง
+              </Button>
             </AlertDescription>
           </Alert>
         </div>

--- a/src/components/video/BunnyPlayer.tsx
+++ b/src/components/video/BunnyPlayer.tsx
@@ -115,7 +115,7 @@ export default function BunnyPlayer({
   const videoType = useMemo(() => detectVideoType(finalUrl), [finalUrl]);
 
   useEffect(() => {
-    if (videoType !== 'bunny') return;
+    if (videoType !== 'bunny' || loadedUrl !== finalUrl) return;
     const frame = iframeRef.current;
     if (!frame) return;
     const connection = connectBunnyPlayer({
@@ -134,7 +134,7 @@ export default function BunnyPlayer({
       },
     });
     return () => connection?.disconnect();
-  }, [finalUrl, reloadNonce, resumeAtSeconds, videoType]);
+  }, [finalUrl, loadedUrl, reloadNonce, resumeAtSeconds, videoType]);
 
   const iframeLoaded = loadedUrl === finalUrl;
   const playerFailed = failedUrl === finalUrl;

--- a/src/lib/bunny-player-adapter.ts
+++ b/src/lib/bunny-player-adapter.ts
@@ -1,0 +1,246 @@
+import 'client-only';
+
+const PLAYER_CONTEXT = 'player.js';
+const PLAYER_VERSION = '0.0.11';
+const TRUSTED_BUNNY_ORIGINS = new Set([
+  'https://iframe.mediadelivery.net',
+  'https://video.bunnycdn.com',
+]);
+const RESUME_EDGE_SECONDS = 10;
+const RESUME_VERIFY_TOLERANCE_SECONDS = 2;
+
+type PlayerEventName = 'play' | 'pause' | 'timeupdate' | 'ended' | 'error';
+type PlayerMethodName = 'getDuration' | 'setCurrentTime' | 'getCurrentTime';
+
+type PlayerMessage = {
+  context?: unknown;
+  event?: unknown;
+  value?: unknown;
+  listener?: unknown;
+};
+
+type PlayerMessageTarget = {
+  postMessage(message: string, targetOrigin: string): void;
+};
+
+export type BunnyPlayerFrame = {
+  src: string;
+  contentWindow: PlayerMessageTarget | null;
+};
+
+export type BunnyPlayerMessageHost = {
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+};
+
+export type BunnyPlayerCallbacks = {
+  onPlay?: () => void;
+  onPause?: () => void;
+  onTimeUpdate?: (seconds: number, duration: number) => void;
+  onEnded?: () => void;
+  onError?: () => void;
+  onResume?: (seconds: number) => void;
+};
+
+export type BunnyPlayerConnection = {
+  disconnect(): void;
+};
+
+let listenerSequence = 0;
+
+function nextListenerId(label: string) {
+  listenerSequence += 1;
+  return `milerdev-${label}-${listenerSequence}`;
+}
+
+function parsePlayerMessage(data: unknown): PlayerMessage | null {
+  let parsed = data;
+  if (typeof data === 'string') {
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return parsed as PlayerMessage;
+}
+
+function parseTimingValue(value: unknown) {
+  let parsed = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const { seconds, duration } = parsed as { seconds?: unknown; duration?: unknown };
+  if (
+    typeof seconds !== 'number'
+    || !Number.isFinite(seconds)
+    || seconds < 0
+    || typeof duration !== 'number'
+    || !Number.isFinite(duration)
+    || duration <= 0
+  ) return null;
+  return { seconds, duration };
+}
+
+function playerOrigin(frameUrl: string) {
+  try {
+    const url = new URL(frameUrl);
+    return TRUSTED_BUNNY_ORIGINS.has(url.origin) ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringSet(value: unknown) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    return new Set<string>();
+  }
+  return new Set(value);
+}
+
+export function connectBunnyPlayer(
+  input: {
+    frame: BunnyPlayerFrame;
+    resumeAtSeconds?: number;
+    callbacks: BunnyPlayerCallbacks;
+  },
+  host: BunnyPlayerMessageHost = window as unknown as BunnyPlayerMessageHost,
+): BunnyPlayerConnection | null {
+  const { frame, callbacks } = input;
+  const origin = playerOrigin(frame.src);
+  const target = frame.contentWindow;
+  if (!origin || !target) return null;
+
+  let disconnected = false;
+  let ready = false;
+  let ended = false;
+  const subscriptions = new Map<PlayerEventName | 'ready', string>();
+  const pendingMethods = new Map<string, {
+    method: PlayerMethodName;
+    receive(value: unknown): void;
+  }>();
+
+  const send = (message: Record<string, unknown>) => {
+    if (disconnected) return;
+    target.postMessage(JSON.stringify({
+      context: PLAYER_CONTEXT,
+      version: PLAYER_VERSION,
+      ...message,
+    }), origin);
+  };
+
+  const unsubscribe = (eventName: PlayerEventName | 'ready') => {
+    const listener = subscriptions.get(eventName);
+    if (!listener) return;
+    send({ method: 'removeEventListener', value: eventName, listener });
+    subscriptions.delete(eventName);
+  };
+
+  const subscribe = (eventName: PlayerEventName | 'ready') => {
+    const listener = nextListenerId(eventName);
+    subscriptions.set(eventName, listener);
+    send({ method: 'addEventListener', value: eventName, listener });
+  };
+
+  const request = (
+    method: PlayerMethodName,
+    receive: (value: unknown) => void,
+  ) => {
+    const listener = nextListenerId(method);
+    pendingMethods.set(listener, { method, receive });
+    send({ method, listener });
+  };
+
+  const attemptResume = (methods: Set<string>) => {
+    const resumeAtSeconds = input.resumeAtSeconds;
+    if (
+      typeof resumeAtSeconds !== 'number'
+      || !Number.isFinite(resumeAtSeconds)
+      || resumeAtSeconds <= RESUME_EDGE_SECONDS
+      || !methods.has('getDuration')
+      || !methods.has('setCurrentTime')
+      || !methods.has('getCurrentTime')
+    ) return;
+
+    request('getDuration', (durationValue) => {
+      if (
+        typeof durationValue !== 'number'
+        || !Number.isFinite(durationValue)
+        || resumeAtSeconds >= durationValue - RESUME_EDGE_SECONDS
+      ) return;
+
+      send({ method: 'setCurrentTime', value: resumeAtSeconds });
+      request('getCurrentTime', (currentTimeValue) => {
+        if (
+          typeof currentTimeValue === 'number'
+          && Number.isFinite(currentTimeValue)
+          && Math.abs(currentTimeValue - resumeAtSeconds) <= RESUME_VERIFY_TOLERANCE_SECONDS
+        ) callbacks.onResume?.(resumeAtSeconds);
+      });
+    });
+  };
+
+  const onMessage = (event: MessageEvent) => {
+    if (disconnected || event.source !== target || event.origin !== origin) return;
+    const message = parsePlayerMessage(event.data);
+    if (!message || message.context !== PLAYER_CONTEXT || typeof message.event !== 'string') return;
+
+    if (message.event === 'ready') {
+      if (ready) return;
+      if (!message.value || typeof message.value !== 'object' || Array.isArray(message.value)) return;
+      const value = message.value as { src?: unknown; events?: unknown; methods?: unknown };
+      if (value.src !== frame.src) return;
+      ready = true;
+      unsubscribe('ready');
+      const supportedEvents = stringSet(value.events);
+      const supportedMethods = stringSet(value.methods);
+      for (const eventName of ['play', 'pause', 'timeupdate', 'ended', 'error'] as const) {
+        if (supportedEvents.has(eventName)) subscribe(eventName);
+      }
+      attemptResume(supportedMethods);
+      return;
+    }
+
+    if (typeof message.listener !== 'string') return;
+    const pendingMethod = pendingMethods.get(message.listener);
+    if (pendingMethod) {
+      if (message.event !== pendingMethod.method) return;
+      pendingMethods.delete(message.listener);
+      pendingMethod.receive(message.value);
+      return;
+    }
+
+    const eventName = message.event as PlayerEventName;
+    if (subscriptions.get(eventName) !== message.listener) return;
+    if (eventName === 'play') callbacks.onPlay?.();
+    if (eventName === 'pause') callbacks.onPause?.();
+    if (eventName === 'error') callbacks.onError?.();
+    if (eventName === 'timeupdate') {
+      const timing = parseTimingValue(message.value);
+      if (timing) callbacks.onTimeUpdate?.(timing.seconds, timing.duration);
+    }
+    if (eventName === 'ended' && !ended) {
+      ended = true;
+      callbacks.onEnded?.();
+    }
+  };
+
+  host.addEventListener('message', onMessage);
+  subscribe('ready');
+
+  return {
+    disconnect() {
+      if (disconnected) return;
+      for (const eventName of [...subscriptions.keys()]) unsubscribe(eventName);
+      disconnected = true;
+      pendingMethods.clear();
+      host.removeEventListener('message', onMessage);
+    },
+  };
+}

--- a/src/lib/bunny-player-adapter.ts
+++ b/src/lib/bunny-player-adapter.ts
@@ -46,6 +46,15 @@ export type BunnyPlayerConnection = {
   disconnect(): void;
 };
 
+const browserMessageHost: BunnyPlayerMessageHost = {
+  addEventListener(type, listener) {
+    window.addEventListener(type, listener);
+  },
+  removeEventListener(type, listener) {
+    window.removeEventListener(type, listener);
+  },
+};
+
 let listenerSequence = 0;
 
 function nextListenerId(label: string) {
@@ -110,7 +119,7 @@ export function connectBunnyPlayer(
     resumeAtSeconds?: number;
     callbacks: BunnyPlayerCallbacks;
   },
-  host: BunnyPlayerMessageHost = window as unknown as BunnyPlayerMessageHost,
+  host: BunnyPlayerMessageHost = browserMessageHost,
 ): BunnyPlayerConnection | null {
   const { frame, callbacks } = input;
   const origin = playerOrigin(frame.src);

--- a/tests/components/bunny-player.test.tsx
+++ b/tests/components/bunny-player.test.tsx
@@ -38,6 +38,8 @@ describe('BunnyPlayer trusted adapter lifecycle', () => {
       />,
     );
 
+    expect(connectBunnyPlayer).not.toHaveBeenCalled();
+    fireEvent.load(screen.getByTitle('วิดีโอบทเรียน บทที่หนึ่ง'));
     await waitFor(() => expect(connectBunnyPlayer).toHaveBeenCalledOnce());
     expect(connectBunnyPlayer).toHaveBeenCalledWith(expect.objectContaining({
       frame: expect.objectContaining({
@@ -68,6 +70,7 @@ describe('BunnyPlayer trusted adapter lifecycle', () => {
         lessonTitle="บทที่หนึ่ง"
       />,
     );
+    fireEvent.load(screen.getByTitle('วิดีโอบทเรียน บทที่หนึ่ง'));
     await waitFor(() => expect(connectBunnyPlayer).toHaveBeenCalledOnce());
     const input = vi.mocked(connectBunnyPlayer).mock.calls[0][0];
 
@@ -91,6 +94,7 @@ describe('BunnyPlayer trusted adapter lifecycle', () => {
     await act(async () => {
       vi.advanceTimersByTime(8_000);
     });
+    expect(connectBunnyPlayer).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'ลองโหลดวิดีโออีกครั้ง' })).toBeTruthy();
   });
 });

--- a/tests/components/bunny-player.test.tsx
+++ b/tests/components/bunny-player.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/bunny-player-adapter', () => ({ connectBunnyPlayer: vi.fn() }));
+
+import BunnyPlayer from '@/components/video/BunnyPlayer';
+import { connectBunnyPlayer } from '@/lib/bunny-player-adapter';
+
+describe('BunnyPlayer trusted adapter lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('connects only Bunny embeds and cleans up when the lesson URL changes', async () => {
+    const disconnect = vi.fn();
+    vi.mocked(connectBunnyPlayer).mockReturnValue({ disconnect });
+    const callbacks = {
+      onTimeUpdate: vi.fn(),
+      onPlay: vi.fn(),
+      onPause: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn(),
+      onResume: vi.fn(),
+    };
+    const view = render(
+      <BunnyPlayer
+        videoId="https://iframe.mediadelivery.net/embed/123/video-one"
+        lessonTitle="บทที่หนึ่ง"
+        resumeAtSeconds={42}
+        {...callbacks}
+      />,
+    );
+
+    await waitFor(() => expect(connectBunnyPlayer).toHaveBeenCalledOnce());
+    expect(connectBunnyPlayer).toHaveBeenCalledWith(expect.objectContaining({
+      frame: expect.objectContaining({
+        src: 'https://iframe.mediadelivery.net/embed/123/video-one',
+      }),
+      resumeAtSeconds: 42,
+      callbacks: expect.any(Object),
+    }));
+    expect(screen.getByTitle('วิดีโอบทเรียน บทที่หนึ่ง')).toBeTruthy();
+
+    view.rerender(
+      <BunnyPlayer
+        videoId="https://www.youtube.com/watch?v=video-two"
+        lessonTitle="บทที่สอง"
+        {...callbacks}
+      />,
+    );
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(connectBunnyPlayer).toHaveBeenCalledOnce();
+    expect(screen.getByTitle('วิดีโอบทเรียน บทที่สอง')).toBeTruthy();
+  });
+
+  it('turns trusted player errors into an inline reload action', async () => {
+    vi.mocked(connectBunnyPlayer).mockReturnValue({ disconnect: vi.fn() });
+    render(
+      <BunnyPlayer
+        videoId="https://iframe.mediadelivery.net/embed/123/video-one"
+        lessonTitle="บทที่หนึ่ง"
+      />,
+    );
+    await waitFor(() => expect(connectBunnyPlayer).toHaveBeenCalledOnce());
+    const input = vi.mocked(connectBunnyPlayer).mock.calls[0][0];
+
+    act(() => input.callbacks.onError?.());
+    const retry = screen.getByRole('button', { name: 'ลองโหลดวิดีโออีกครั้ง' });
+    const firstFrame = screen.getByTitle('วิดีโอบทเรียน บทที่หนึ่ง');
+    fireEvent.click(retry);
+    expect(screen.getByTitle('วิดีโอบทเรียน บทที่หนึ่ง')).not.toBe(firstFrame);
+  });
+
+  it('offers the same reload action when the iframe stays slow', async () => {
+    vi.useFakeTimers();
+    vi.mocked(connectBunnyPlayer).mockReturnValue({ disconnect: vi.fn() });
+    render(
+      <BunnyPlayer
+        videoId="https://iframe.mediadelivery.net/embed/123/video-one"
+        lessonTitle="บทที่หนึ่ง"
+      />,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(8_000);
+    });
+    expect(screen.getByRole('button', { name: 'ลองโหลดวิดีโออีกครั้ง' })).toBeTruthy();
+  });
+});

--- a/tests/components/learning-progress-recovery.test.tsx
+++ b/tests/components/learning-progress-recovery.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+vi.mock('@/components/analytics/LearningWorkspaceAnalytics', () => ({ default: () => null }));
+vi.mock('@/components/course/LearningCurriculum', () => ({ default: () => null }));
+vi.mock('@/components/course/LearningNavbar', () => ({ default: () => null }));
+vi.mock('@/components/ui/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('@/components/video/BunnyPlayer', () => ({
+  default: ({
+    lessonTitle,
+    resumeAtSeconds,
+    onTimeUpdate,
+    onPause,
+    onEnded,
+    onResume,
+  }: {
+    lessonTitle?: string;
+    resumeAtSeconds?: number;
+    onTimeUpdate?: (seconds: number, duration: number) => void;
+    onPause?: () => void;
+    onEnded?: () => void;
+    onResume?: (seconds: number) => void;
+  }) => (
+    <div data-testid="player" data-lesson-title={lessonTitle} data-resume-at={resumeAtSeconds}>
+      <button type="button" onClick={() => onTimeUpdate?.(42, 120)}>emit time</button>
+      <button type="button" onClick={() => onPause?.()}>emit pause</button>
+      <button type="button" onClick={() => onEnded?.()}>emit ended</button>
+      <button type="button" onClick={() => onResume?.(42)}>emit resume</button>
+    </div>
+  ),
+}));
+
+import LearnPageClient from '@/components/course/LearnPageClient';
+
+function renderWorkspace(currentProgress = { completed: false, watchTimeSeconds: 37 }) {
+  return render(
+    <LearnPageClient
+      course={{ id: 'course-1', slug: 'typescript', title: 'TypeScript' }}
+      currentLesson={{
+        id: 'lesson-1',
+        title: 'บทที่หนึ่ง',
+        content: null,
+        videoUrl: 'https://iframe.mediadelivery.net/embed/123/video-one',
+        videoDuration: 120,
+        isFreePreview: false,
+      }}
+      allLessons={[
+        { id: 'lesson-1', title: 'บทที่หนึ่ง', videoDuration: 120, isFreePreview: false },
+      ]}
+      prevLesson={null}
+      nextLesson={null}
+      currentIndex={0}
+      isEnrolled
+      canTrackProgress
+      completedLessonIds={currentProgress.completed ? ['lesson-1'] : []}
+      currentProgress={currentProgress}
+    />,
+  );
+}
+
+describe('learning progress save recovery', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows pending truth and sends one positive completion request for duplicate ended events', async () => {
+    let resolveResponse!: (response: Response) => void;
+    const response = new Promise<Response>((resolve) => { resolveResponse = resolve; });
+    vi.mocked(fetch).mockReturnValue(response);
+    renderWorkspace();
+
+    fireEvent.click(screen.getByRole('button', { name: 'emit ended' }));
+    fireEvent.click(screen.getByRole('button', { name: 'emit ended' }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(screen.getByRole('heading', { name: 'กำลังบันทึกบทเรียน…' })).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'เรียนจบบทนี้แล้ว' })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'เรียนครบแล้ว · กำลังทบทวน' })).toBeNull();
+
+    resolveResponse(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'เรียนครบแล้ว · กำลังทบทวน' })).toBeTruthy());
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string)).toMatchObject({
+      lessonId: 'lesson-1',
+      completed: true,
+    });
+  });
+
+  it('keeps a failed completion visible and retries from the inline action', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    renderWorkspace();
+
+    fireEvent.click(screen.getByRole('button', { name: 'emit ended' }));
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'ยังบันทึกบทนี้ไม่ได้' })).toBeTruthy());
+    expect(screen.queryByRole('heading', { name: 'เรียนจบบทนี้แล้ว' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'ลองบันทึกอีกครั้ง' }));
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'เรียนครบแล้ว · กำลังทบทวน' })).toBeTruthy());
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('claims resume only from the trusted callback and exposes watch-position retry', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    renderWorkspace();
+
+    expect(screen.getByTestId('player').getAttribute('data-lesson-title')).toBe('บทที่หนึ่ง');
+    expect(screen.getByTestId('player').getAttribute('data-resume-at')).toBe('37');
+    expect(screen.queryByText('กลับมาเรียนต่อที่ 00:42')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'emit resume' }));
+    expect(screen.getByText('กลับมาเรียนต่อที่ 00:42')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'emit time' }));
+    fireEvent.click(screen.getByRole('button', { name: 'emit pause' }));
+    await waitFor(() => expect(screen.getByText('ยังบันทึกตำแหน่งล่าสุดไม่ได้')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'ลองบันทึกตำแหน่งอีกครั้ง' }));
+    await waitFor(() => expect(screen.queryByText('ยังบันทึกตำแหน่งล่าสุดไม่ได้')).toBeNull());
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/lib/bunny-player-adapter.test.ts
+++ b/tests/lib/bunny-player-adapter.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  connectBunnyPlayer,
+  type BunnyPlayerMessageHost,
+} from '@/lib/bunny-player-adapter';
+
+type PlayerMessage = {
+  context: string;
+  method?: string;
+  event?: string;
+  value?: unknown;
+  listener?: string;
+};
+
+function playerHarness(resumeAtSeconds?: number) {
+  let messageListener: ((event: MessageEvent) => void) | null = null;
+  const postMessage = vi.fn();
+  const contentWindow = { postMessage };
+  const frame = {
+    src: 'https://iframe.mediadelivery.net/embed/123/video-id?token=signed',
+    contentWindow,
+  };
+  const host: BunnyPlayerMessageHost = {
+    addEventListener(_type, listener) {
+      messageListener = listener;
+    },
+    removeEventListener(_type, listener) {
+      if (messageListener === listener) messageListener = null;
+    },
+  };
+  const callbacks = {
+    onPlay: vi.fn(),
+    onPause: vi.fn(),
+    onTimeUpdate: vi.fn(),
+    onEnded: vi.fn(),
+    onError: vi.fn(),
+    onResume: vi.fn(),
+  };
+
+  const connection = connectBunnyPlayer({
+    frame,
+    resumeAtSeconds,
+    callbacks,
+  }, host);
+
+  function sentMessages() {
+    return postMessage.mock.calls.map(([message]) => JSON.parse(message as string) as PlayerMessage);
+  }
+
+  function emit(data: PlayerMessage | string, overrides: Partial<MessageEvent> = {}) {
+    messageListener?.({
+      data: typeof data === 'string' ? data : JSON.stringify(data),
+      origin: 'https://iframe.mediadelivery.net',
+      source: contentWindow,
+      ...overrides,
+    } as MessageEvent);
+  }
+
+  function ready(methods = ['getDuration', 'setCurrentTime', 'getCurrentTime']) {
+    emit({
+      context: 'player.js',
+      event: 'ready',
+      value: {
+        src: frame.src,
+        events: ['play', 'pause', 'timeupdate', 'ended', 'error'],
+        methods,
+      },
+    });
+  }
+
+  function listenerFor(eventName: string) {
+    return sentMessages().find((message) => (
+      message.method === 'addEventListener' && message.value === eventName
+    ))?.listener;
+  }
+
+  return {
+    callbacks,
+    connection,
+    contentWindow,
+    emit,
+    frame,
+    host,
+    listenerFor,
+    postMessage,
+    ready,
+    sentMessages,
+  };
+}
+
+describe('trusted Bunny Player.js adapter', () => {
+  it('accepts only the current iframe, exact origin, Player.js context, and subscription listener', () => {
+    const harness = playerHarness();
+    expect(harness.connection).not.toBeNull();
+    harness.ready();
+    const playListener = harness.listenerFor('play');
+    expect(playListener).toBeTruthy();
+
+    harness.emit({ context: 'player.js', event: 'play', listener: playListener }, {
+      source: { postMessage: vi.fn() } as unknown as MessageEventSource,
+    });
+    harness.emit({ context: 'player.js', event: 'play', listener: playListener }, {
+      origin: 'https://evil.example',
+    });
+    harness.emit({ context: 'other', event: 'play', listener: playListener });
+    harness.emit({ context: 'player.js', event: 'play', listener: 'wrong-listener' });
+    expect(harness.callbacks.onPlay).not.toHaveBeenCalled();
+
+    harness.emit({ context: 'player.js', event: 'play', listener: playListener });
+    expect(harness.callbacks.onPlay).toHaveBeenCalledOnce();
+  });
+
+  it('validates timeupdate payloads and emits trusted ended exactly once', () => {
+    const harness = playerHarness();
+    harness.ready();
+    const timeListener = harness.listenerFor('timeupdate');
+    const endedListener = harness.listenerFor('ended');
+
+    harness.emit({
+      context: 'player.js',
+      event: 'timeupdate',
+      listener: timeListener,
+      value: JSON.stringify({ seconds: 42, duration: 120 }),
+    });
+    harness.emit({
+      context: 'player.js',
+      event: 'timeupdate',
+      listener: timeListener,
+      value: { seconds: -1, duration: 120 },
+    });
+    harness.emit({ context: 'player.js', event: 'ended', listener: endedListener });
+    harness.emit({ context: 'player.js', event: 'ended', listener: endedListener });
+
+    expect(harness.callbacks.onTimeUpdate).toHaveBeenCalledOnce();
+    expect(harness.callbacks.onTimeUpdate).toHaveBeenCalledWith(42, 120);
+    expect(harness.callbacks.onEnded).toHaveBeenCalledOnce();
+  });
+
+  it('claims exact-position resume only after capability checks and a verified seek', () => {
+    const harness = playerHarness(42);
+    harness.ready();
+    const durationRequest = harness.sentMessages().find((message) => message.method === 'getDuration');
+    expect(durationRequest?.listener).toBeTruthy();
+
+    harness.emit({
+      context: 'player.js',
+      event: 'getDuration',
+      listener: durationRequest?.listener,
+      value: 120,
+    });
+    expect(harness.sentMessages()).toContainEqual(expect.objectContaining({
+      context: 'player.js',
+      method: 'setCurrentTime',
+      value: 42,
+    }));
+    const currentTimeRequest = harness.sentMessages().find((message) => message.method === 'getCurrentTime');
+    expect(harness.callbacks.onResume).not.toHaveBeenCalled();
+
+    harness.emit({
+      context: 'player.js',
+      event: 'getCurrentTime',
+      listener: currentTimeRequest?.listener,
+      value: 42.5,
+    });
+    expect(harness.callbacks.onResume).toHaveBeenCalledWith(42);
+  });
+
+  it('does not claim resume when the provider omits a required seek capability', () => {
+    const harness = playerHarness(42);
+    harness.ready(['getDuration', 'getCurrentTime']);
+
+    expect(harness.sentMessages().some((message) => message.method === 'getDuration')).toBe(false);
+    expect(harness.sentMessages().some((message) => message.method === 'setCurrentTime')).toBe(false);
+    expect(harness.callbacks.onResume).not.toHaveBeenCalled();
+  });
+  it('does not seek near the beginning/end and removes provider/window subscriptions on disconnect', () => {
+    const harness = playerHarness(115);
+    harness.ready();
+    const durationRequest = harness.sentMessages().find((message) => message.method === 'getDuration');
+    harness.emit({
+      context: 'player.js',
+      event: 'getDuration',
+      listener: durationRequest?.listener,
+      value: 120,
+    });
+    expect(harness.sentMessages().some((message) => message.method === 'setCurrentTime')).toBe(false);
+
+    harness.connection?.disconnect();
+    expect(harness.sentMessages()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ method: 'removeEventListener', value: 'play' }),
+      expect.objectContaining({ method: 'removeEventListener', value: 'ended' }),
+    ]));
+    const playListener = harness.listenerFor('play');
+    harness.emit({ context: 'player.js', event: 'play', listener: playListener });
+    expect(harness.callbacks.onPlay).not.toHaveBeenCalled();
+  });
+
+  it('refuses non-HTTPS and lookalike Bunny origins without installing a listener', () => {
+    const addEventListener = vi.fn();
+    const host: BunnyPlayerMessageHost = {
+      addEventListener,
+      removeEventListener: vi.fn(),
+    };
+
+    expect(connectBunnyPlayer({
+      frame: {
+        src: 'https://iframe.mediadelivery.net.evil.example/embed/123/video',
+        contentWindow: { postMessage: vi.fn() },
+      },
+      callbacks: {},
+    }, host)).toBeNull();
+    expect(connectBunnyPlayer({
+      frame: {
+        src: 'http://iframe.mediadelivery.net/embed/123/video',
+        contentWindow: { postMessage: vi.fn() },
+      },
+      callbacks: {},
+    }, host)).toBeNull();
+    expect(addEventListener).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/bunny-player-adapter.test.ts
+++ b/tests/lib/bunny-player-adapter.test.ts
@@ -98,7 +98,7 @@ describe('trusted Bunny Player.js adapter', () => {
     expect(playListener).toBeTruthy();
 
     harness.emit({ context: 'player.js', event: 'play', listener: playListener }, {
-      source: { postMessage: vi.fn() } as unknown as MessageEventSource,
+      source: null,
     });
     harness.emit({ context: 'player.js', event: 'play', listener: playListener }, {
       origin: 'https://evil.example',


### PR DESCRIPTION
Closes #42. Replaces ad-hoc player messages with a strict Bunny Player.js adapter, verified resume, idempotent completion, and inline retry states for player and progress failures. Preserves manual lesson navigation with no countdown or auto-next. Verified with ESLint, 879 Vitest tests, Thai text scan, production build, Required E2E 3/3, and two-axis code review.