### PR TITLE
feat(blog): improve public content discovery

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,10 +1,11 @@
-import MainContent from '@/components/layout/MainContent';
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import Footer from '@/components/layout/Footer';
+import MainContent from '@/components/layout/MainContent';
 import Navbar from '@/components/layout/Navbar';
 import PublicPageHeader from '@/components/layout/PublicPageHeader';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -26,9 +27,21 @@ export const metadata: Metadata = {
 };
 
 const learningMethod = [
-  { title: 'เข้าใจเหตุผล', description: 'เริ่มจากปัญหาและเป้าหมายของงาน เพื่อให้รู้ว่าเครื่องมือแต่ละชิ้นมีไว้ทำอะไร' },
-  { title: 'เขียนไปพร้อมกัน', description: 'เรียนแนวคิดผ่านโค้ด ตัวอย่าง และการลงมือทำ ไม่หยุดอยู่ที่การจำ syntax' },
-  { title: 'จบด้วยผลงาน', description: 'เชื่อมบทเรียนเป็นโปรเจกต์ที่อธิบายได้ ทดสอบได้ และนำไปพัฒนาต่อได้' },
+  {
+    step: '01',
+    title: 'เห็นภาพงานก่อนเริ่ม',
+    description: 'เริ่มจากสิ่งที่จะสร้างและพื้นฐานที่ต้องใช้ เพื่อให้รู้ว่าแต่ละบทเรียนพาไปถึงไหน',
+  },
+  {
+    step: '02',
+    title: 'เข้าใจแล้วเขียนตามลำดับ',
+    description: 'อธิบายเหตุผลของแนวคิดและเครื่องมือ ก่อนลงมือเขียนเป็นช่วงที่ทดลองและตรวจสอบได้',
+  },
+  {
+    step: '03',
+    title: 'ปิดด้วยสิ่งที่ใช้ต่อได้',
+    description: 'จบแต่ละช่วงด้วยโค้ดหรือชิ้นงานที่ตรวจสอบ อธิบาย และนำไปพัฒนาต่อได้',
+  },
 ];
 
 const principles = [
@@ -38,81 +51,120 @@ const principles = [
   ['เรียนต่อได้ไม่เสียจังหวะ', 'บทเรียน progress และ next action ต้องช่วยให้กลับมาทำต่อได้ทันที'],
 ];
 
+const teachingMedia = [1, 5, 9].map((number) => ({
+  src: `/showcase/${String(number).padStart(2, '0')}-showcase-1024x768.webp`,
+  alt: `ภาพจากกิจกรรมการสอนและแบ่งปันความรู้ของ MilerDev ลำดับที่ ${number}`,
+  caption: 'ภาพจากกิจกรรมการสอนและเวทีแบ่งปันความรู้ของ MilerDev',
+}));
+
 export default function AboutPage() {
   return (
     <>
       <Navbar />
-      <MainContent className="bg-[var(--academy-canvas)]">
+      <MainContent className={'bg-[var(--academy-canvas)]'}>
         <PublicPageHeader
-          variant="story"
-          title="พื้นที่เรียนโค้ดสำหรับคนที่อยากสร้างจริง"
-          description="MilerDev คือ coding learning studio ภาษาไทย เราออกแบบคอร์สและบทเรียนให้ผู้เรียนเข้าใจแนวคิดผ่านการเขียนโค้ดและสร้างโปรเจกต์ด้วยตัวเอง"
+          variant={'story'}
+          title={'พื้นที่เรียนโค้ดสำหรับคนที่อยากสร้างจริง'}
+          description={'MilerDev คือ coding learning studio ภาษาไทย เราออกแบบคอร์สและบทเรียนให้ผู้เรียนเข้าใจแนวคิดผ่านการเขียนโค้ดและสร้างโปรเจกต์ด้วยตัวเอง'}
         />
 
-        <section className="py-14 sm:py-20" aria-labelledby="about-manifesto-title">
-          <div className="container grid gap-8 lg:grid-cols-[.7fr_1.3fr] lg:items-center lg:gap-16">
-            <div className="relative mx-auto flex aspect-square w-full max-w-sm items-center justify-center overflow-hidden rounded-3xl bg-[radial-gradient(circle_at_50%_35%,rgba(0,171,255,.3),transparent_40%),var(--academy-navy)] p-8 shadow-[var(--academy-shadow-card)]" aria-hidden="true">
-              <Image src={'/milerdev-logo-transparent.png'} alt={''} width={280} height={280} priority />
+        <section className={'py-14 sm:py-20'} aria-labelledby={'about-manifesto-title'}>
+          <div className={'container grid gap-8 lg:grid-cols-[.7fr_1.3fr] lg:items-center lg:gap-16'}>
+            <div
+              className={'relative mx-auto flex aspect-square w-full max-w-sm items-center justify-center overflow-hidden rounded-3xl bg-[radial-gradient(circle_at_50%_35%,rgba(0,171,255,.3),transparent_40%),var(--academy-navy)] p-8 shadow-[var(--academy-shadow-card)]'}
+              aria-hidden={true}
+            >
+              <Image
+                src={'/milerdev-logo-transparent.png'}
+                alt={''}
+                width={280}
+                height={280}
+                priority
+              />
             </div>
             <div>
-              <h2 id="about-manifesto-title" className="text-3xl leading-tight font-semibold tracking-[-.03em] text-balance sm:text-4xl">การเรียนเขียนโปรแกรมควรพาคุณไปไกลกว่าการทำตาม</h2>
-              <div className="mt-6 flex max-w-2xl flex-col gap-4 text-base leading-8 text-muted-foreground"><p>เป้าหมายของเราไม่ใช่การรวบรวมวิดีโอให้ได้มากที่สุด แต่คือการจัดลำดับความรู้ให้ผู้เรียนเห็นความสัมพันธ์ระหว่างแนวคิด โค้ด และผลลัพธ์ที่เกิดขึ้นจริง</p><p>เมื่อจบบทเรียน ผู้เรียนควรอธิบายสิ่งที่ตัวเองสร้างได้ แก้ปัญหาต่อได้ และรู้ว่าควรพัฒนาทักษะส่วนไหนเป็นลำดับถัดไป</p></div>
+              <h2 id={'about-manifesto-title'} className={'text-3xl leading-tight font-semibold tracking-[-.03em] text-balance sm:text-4xl'}>
+                การเรียนเขียนโปรแกรมควรพาคุณไปไกลกว่าการทำตาม
+              </h2>
+              <div className={'mt-6 flex max-w-2xl flex-col gap-4 text-base leading-8 text-muted-foreground'}>
+                <p>เป้าหมายของเราไม่ใช่การรวบรวมวิดีโอให้ได้มากที่สุด แต่คือการจัดลำดับความรู้ให้ผู้เรียนเห็นความสัมพันธ์ระหว่างแนวคิด โค้ด และผลลัพธ์ที่เกิดขึ้นจริง</p>
+                <p>เมื่อจบบทเรียน ผู้เรียนควรอธิบายสิ่งที่ตัวเองสร้างได้ แก้ปัญหาต่อได้ และรู้ว่าควรพัฒนาทักษะส่วนไหนเป็นลำดับถัดไป</p>
+              </div>
             </div>
           </div>
         </section>
 
-        <section className="border-y bg-background py-14 sm:py-20" aria-labelledby="about-method-title">
+        <section className={'border-y bg-background py-14 sm:py-20'} aria-labelledby={'about-method-title'}>
           <div className={'container'}>
-            <div className="mb-8 grid gap-3 md:grid-cols-[1fr_.8fr] md:items-end">
-              <h2 id="about-method-title" className="text-3xl font-semibold tracking-[-.03em] sm:text-4xl">วิธีเรียนแบบ MilerDev</h2>
-              <p className="leading-7 text-muted-foreground">ทุกคอร์สเดินจากความเข้าใจ ไปสู่การลงมือเขียน และจบด้วยสิ่งที่ตรวจสอบได้</p>
+            <div className={'mb-8 grid gap-3 md:grid-cols-[1fr_.8fr] md:items-end'}>
+              <h2 id={'about-method-title'} className={'text-3xl font-semibold tracking-[-.03em] sm:text-4xl'}>เราออกแบบบทเรียนอย่างไร</h2>
+              <p className={'leading-7 text-muted-foreground'}>ทุกช่วงเรียงจากภาพงานและเหตุผล ไปสู่การลงมือเขียน แล้วจบด้วยสิ่งที่ตรวจสอบได้</p>
             </div>
-            <ol className="grid gap-5 md:grid-cols-3">
+            <ol className={'grid gap-5 md:grid-cols-3'}>
               {learningMethod.map((item) => (
-                <li key={item.title}><Card className="h-full"><CardHeader><CardTitle className="text-xl">{item.title}</CardTitle></CardHeader><CardContent><p className="text-sm leading-7 text-muted-foreground">{item.description}</p></CardContent></Card></li>
+                <li key={item.step} className={'min-w-0'}>
+                  <Card className={'h-full'}>
+                    <CardHeader>
+                      <Badge variant={'outline'} className={'w-fit font-mono'}>{item.step}</Badge>
+                      <CardTitle className={'text-xl'}>{item.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <p className={'text-sm leading-7 text-muted-foreground'}>{item.description}</p>
+                    </CardContent>
+                  </Card>
+                </li>
               ))}
             </ol>
           </div>
         </section>
 
-        <section className="py-14 sm:py-20" aria-labelledby="about-principles-title">
-          <div className="container grid gap-8 lg:grid-cols-[.7fr_1.3fr] lg:gap-16">
-            <div>
-              <h2 id="about-principles-title" className="text-3xl font-semibold tracking-[-.03em] sm:text-4xl">หลักที่ใช้ตัดสินใจทุกบทเรียน</h2>
-            </div>
-            <dl className="divide-y border-y">
+        <section className={'py-14 sm:py-20'} aria-labelledby={'about-principles-title'}>
+          <div className={'container grid gap-8 lg:grid-cols-[.7fr_1.3fr] lg:gap-16'}>
+            <h2 id={'about-principles-title'} className={'text-3xl font-semibold tracking-[-.03em] sm:text-4xl'}>หลักที่ใช้ตัดสินใจทุกบทเรียน</h2>
+            <dl className={'divide-y border-y'}>
               {principles.map(([title, description]) => (
-                <div key={title} className="grid gap-2 py-5 sm:grid-cols-[12rem_1fr] sm:gap-8">
-                  <dt className="font-semibold">{title}</dt>
-                  <dd className="text-sm leading-7 text-muted-foreground">{description}</dd>
+                <div key={title} className={'grid gap-2 py-5 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-8'}>
+                  <dt className={'font-semibold'}>{title}</dt>
+                  <dd className={'text-sm leading-7 text-muted-foreground'}>{description}</dd>
                 </div>
               ))}
             </dl>
           </div>
         </section>
 
-        <section className="bg-[var(--academy-navy)] py-14 text-white sm:py-20" aria-labelledby="about-proof-title">
+        <section className={'bg-[var(--academy-navy)] py-14 text-white sm:py-20'} aria-labelledby={'about-proof-title'}>
           <div className={'container'}>
-            <div className="mb-8 grid gap-3 md:grid-cols-[1fr_.8fr] md:items-end">
-              <h2 id="about-proof-title" className="text-3xl font-semibold tracking-[-.03em] sm:text-4xl">จากห้องเรียนสู่เวทีแบ่งปันความรู้</h2>
-              <p className="leading-7 text-white/65">MilerDev เคยได้รับเชิญจากองค์กรและมหาวิทยาลัยให้เป็นวิทยากรด้านการเขียนโปรแกรมและการพัฒนาเว็บไซต์</p>
+            <div className={'mb-8 grid gap-3 md:grid-cols-[1fr_.8fr] md:items-end'}>
+              <h2 id={'about-proof-title'} className={'text-3xl font-semibold tracking-[-.03em] sm:text-4xl'}>ภาพจากกิจกรรมการสอนและเวทีแบ่งปันความรู้</h2>
+              <p className={'leading-7 text-white/65'}>ภาพชุดนี้บันทึกบรรยากาศการอธิบาย การสาธิต และการเรียนรู้ร่วมกันจากกิจกรรมของ MilerDev</p>
             </div>
-            <div className="grid gap-5 md:grid-cols-3">
-              {[1, 5, 9].map((number) => (
-                <figure key={number} className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
-                  <Image className="aspect-[4/3] w-full object-cover" src={`/showcase/${String(number).padStart(2, '0')}-showcase-1024x768.webp`} alt={`บรรยากาศงานบรรยายของ MilerDev ภาพที่ ${number}`} width={1024} height={768} sizes={'(max-width: 640px) 100vw, 33vw'} />
+            <div className={'grid gap-5 md:grid-cols-3'}>
+              {teachingMedia.map((media) => (
+                <figure key={media.src} className={'overflow-hidden rounded-2xl border border-white/10 bg-white/5'}>
+                  <Image
+                    className={'aspect-[4/3] w-full object-cover'}
+                    src={media.src}
+                    alt={media.alt}
+                    width={1024}
+                    height={768}
+                    sizes={'(max-width: 767px) 100vw, 33vw'}
+                  />
+                  <figcaption className={'px-4 py-3 text-xs leading-5 text-white/65'}>{media.caption}</figcaption>
                 </figure>
               ))}
             </div>
           </div>
         </section>
 
-        <section className="py-14 sm:py-20">
-          <div className="container grid gap-6 rounded-3xl border bg-card p-8 shadow-[var(--academy-shadow-card)] md:grid-cols-[1fr_auto] md:items-end sm:p-10">
-            <div><h2 className="text-3xl leading-tight font-semibold tracking-[-.03em]">เลือกทักษะที่อยากพัฒนา แล้วเริ่มสร้างโปรเจกต์แรก</h2><p className="mt-3 leading-7 text-muted-foreground">ดูรายละเอียด ผลลัพธ์ และเนื้อหาของแต่ละคอร์สก่อนตัดสินใจเรียน</p></div>
-            <div className="flex flex-wrap gap-3">
-              <Button asChild><Link href="/courses">ดูคอร์สทั้งหมด →</Link></Button>
-              <Button variant="outline" asChild><Link href="/contact">ติดต่อ MilerDev</Link></Button>
+        <section className={'py-14 sm:py-20'}>
+          <div className={'container grid gap-6 rounded-3xl border bg-card p-8 shadow-[var(--academy-shadow-card)] sm:p-10 md:grid-cols-[1fr_auto] md:items-end'}>
+            <div>
+              <h2 className={'text-3xl leading-tight font-semibold tracking-[-.03em]'}>เลือกทักษะที่อยากพัฒนา แล้วเริ่มสร้างโปรเจกต์แรก</h2>
+              <p className={'mt-3 leading-7 text-muted-foreground'}>ดูรายละเอียด ผลลัพธ์ และเนื้อหาของแต่ละคอร์สก่อนตัดสินใจเรียน</p>
+            </div>
+            <div className={'flex flex-wrap gap-3'}>
+              <Button asChild><Link href={'/courses'}>ดูคอร์สทั้งหมด →</Link></Button>
+              <Button variant={'outline'} asChild><Link href={'/contact'}>ติดต่อ MilerDev</Link></Button>
             </div>
           </div>
         </section>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,25 +1,30 @@
-import MainContent from '@/components/layout/MainContent';
 import type { Metadata } from 'next';
 import { unstable_cache } from 'next/cache';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import ArticleCourseBridge from '@/components/blog/ArticleCourseBridge';
 import CodeCopyButton from '@/components/blog/CodeCopyButton';
+import EditorialImage from '@/components/blog/EditorialImage';
 import ReadingProgress from '@/components/blog/ReadingProgress';
 import ScrollToTop from '@/components/blog/ScrollToTop';
 import ShareButtons from '@/components/blog/ShareButtons';
 import TableOfContents from '@/components/blog/TableOfContents';
 import Footer from '@/components/layout/Footer';
+import MainContent from '@/components/layout/MainContent';
 import Navbar from '@/components/layout/Navbar';
 import NavigationBreadcrumbs from '@/components/layout/NavigationBreadcrumbs';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { db } from '@/lib/db';
 import { blogPosts, blogPostTags, tags, users } from '@/lib/db/schema';
-import { getProcessedBlogContent } from '@/lib/sanitize';
+import { getBlogTableOfContents, getProcessedBlogContent } from '@/lib/sanitize';
 import { absoluteUrl, serializeJsonLd, SITE_URL } from '@/lib/seo';
 import { and, eq, ne, sql } from 'drizzle-orm';
+
+export const revalidate = 3600;
 
 function getReadingTime(html: string): number {
   const text = html.replace(/<[^>]*>/g, ' ');
@@ -41,8 +46,6 @@ function formatDate(date: Date | null): string {
     day: 'numeric',
   });
 }
-
-export const revalidate = 3600;
 
 const getPublishedPostMetadata = unstable_cache(
   async (slug: string) => {
@@ -104,16 +107,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 async function getRelatedPosts(postId: string, postTags: { id: string }[], limit = 3) {
+  const selection = {
+    id: blogPosts.id,
+    title: blogPosts.title,
+    slug: blogPosts.slug,
+    excerpt: blogPosts.excerpt,
+    thumbnailUrl: blogPosts.thumbnailUrl,
+    publishedAt: blogPosts.publishedAt,
+  };
+
   if (postTags.length === 0) {
     return db
-      .select({
-        id: blogPosts.id,
-        title: blogPosts.title,
-        slug: blogPosts.slug,
-        excerpt: blogPosts.excerpt,
-        thumbnailUrl: blogPosts.thumbnailUrl,
-        publishedAt: blogPosts.publishedAt,
-      })
+      .select(selection)
       .from(blogPosts)
       .where(and(eq(blogPosts.status, 'published'), ne(blogPosts.id, postId)))
       .orderBy(sql`${blogPosts.publishedAt} DESC`)
@@ -122,14 +127,7 @@ async function getRelatedPosts(postId: string, postTags: { id: string }[], limit
 
   const tagIds = postTags.map((tag) => tag.id);
   return db
-    .select({
-      id: blogPosts.id,
-      title: blogPosts.title,
-      slug: blogPosts.slug,
-      excerpt: blogPosts.excerpt,
-      thumbnailUrl: blogPosts.thumbnailUrl,
-      publishedAt: blogPosts.publishedAt,
-    })
+    .select(selection)
     .from(blogPosts)
     .where(
       and(
@@ -188,6 +186,7 @@ export default async function BlogPostPage({ params }: Props) {
   const relatedPosts = await getRelatedPosts(post.id, post.tags);
   const readingTime = getReadingTime(post.content ?? '');
   const processedContent = getProcessedBlogContent(post.content ?? '');
+  const tableOfContents = getBlogTableOfContents(processedContent);
   const thumbnailUrl = normalizeUrl(post.thumbnailUrl);
   const avatarUrl = normalizeUrl(post.author?.avatarUrl ?? null);
 
@@ -227,11 +226,11 @@ export default async function BlogPostPage({ params }: Props) {
       <script type={'application/ld+json'} dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }} />
       <ReadingProgress />
       <Navbar />
-      <MainContent className="bg-[var(--academy-canvas)]">
-        <header className="border-b bg-[radial-gradient(circle_at_84%_8%,var(--color-accent-soft),transparent_32%),var(--academy-canvas)] py-12 sm:py-16 lg:py-20">
-          <div className="container">
+      <MainContent className={'bg-[var(--academy-canvas)]'}>
+        <header className={'border-b bg-[radial-gradient(circle_at_84%_8%,var(--color-accent-soft),transparent_32%),var(--academy-canvas)] py-12 sm:py-16 lg:py-20'}>
+          <div className={'container'}>
             <NavigationBreadcrumbs
-              className="mb-8 text-xs"
+              className={'mb-8 text-xs'}
               items={[
                 { href: '/', label: 'หน้าแรก' },
                 { href: '/blog', label: 'บทความ' },
@@ -239,31 +238,48 @@ export default async function BlogPostPage({ params }: Props) {
               ]}
             />
 
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1.25fr)_minmax(18rem,.75fr)] lg:items-end lg:gap-16">
-              <div>
+            <div className={'grid gap-8 lg:grid-cols-[minmax(0,1.25fr)_minmax(18rem,.75fr)] lg:items-end lg:gap-16'}>
+              <div className={'min-w-0'}>
                 {post.tags.length > 0 ? (
-                  <nav className="mb-5 flex flex-wrap gap-2" aria-label="หัวข้อของบทความ">
-                    {post.tags.map((tag) => <Badge key={tag.id} variant="secondary" asChild><Link href={`/blog?tag=${tag.slug}`}>{tag.name}</Link></Badge>)}
+                  <nav className={'mb-5 flex flex-wrap gap-2'} aria-label={'หัวข้อของบทความ'}>
+                    {post.tags.map((tag) => (
+                      <Badge key={tag.id} variant={'secondary'} asChild>
+                        <Link href={`/blog?tag=${tag.slug}`}>{tag.name}</Link>
+                      </Badge>
+                    ))}
                   </nav>
                 ) : null}
-                <h1 className="mt-4 max-w-4xl text-4xl leading-[1.16] font-semibold tracking-[-.04em] text-balance sm:text-5xl lg:text-6xl">{post.title}</h1>
-                {post.excerpt ? <p className="mt-6 max-w-3xl text-base leading-8 text-muted-foreground sm:text-lg">{post.excerpt}</p> : null}
+                <h1 className={'mt-4 max-w-4xl text-4xl leading-[1.16] font-semibold tracking-[-.04em] text-balance [overflow-wrap:anywhere] sm:text-5xl lg:text-6xl'}>{post.title}</h1>
+                {post.excerpt ? (
+                  <p className={'mt-6 max-w-3xl text-base leading-8 text-muted-foreground sm:text-lg'}>{post.excerpt}</p>
+                ) : null}
               </div>
 
-              <Card className="bg-card/85 backdrop-blur" aria-label="ข้อมูลบทความ">
-                <CardContent className="pt-6">
-                <div className="flex items-center gap-3">
-                  <span className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary text-sm font-semibold text-primary-foreground" aria-hidden={!avatarUrl}>
-                    {avatarUrl ? <img className="size-full object-cover" src={avatarUrl} alt={post.author?.name || 'MilerDev'} /> : 'MD'}
-                  </span>
-                  <div><span className="block text-xs text-muted-foreground">ผู้เขียน</span><strong className="text-sm">{post.author?.name || 'MilerDev'}</strong></div>
-                </div>
-                <Separator className="my-5" />
-                <dl className="flex flex-col gap-3 text-sm">
-                  <div className="flex justify-between gap-4"><dt className="text-muted-foreground">เผยแพร่</dt><dd>{formatDate(post.publishedAt) || '—'}</dd></div>
-                  <div className="flex justify-between gap-4"><dt className="text-muted-foreground">เวลาอ่าน</dt><dd>{readingTime} นาที</dd></div>
-                  <div className="flex justify-between gap-4"><dt className="text-muted-foreground">ยอดอ่าน</dt><dd>{(post.viewCount ?? 0).toLocaleString()} ครั้ง</dd></div>
-                </dl>
+              <Card aria-label={'ข้อมูลบทความ'}>
+                <CardContent className={'pt-6'}>
+                  <div className={'flex items-center gap-3'}>
+                    <Avatar className={'size-11'}>
+                      {avatarUrl ? (
+                        <AvatarImage
+                          src={avatarUrl}
+                          alt={post.author?.name || 'MilerDev'}
+                          width={44}
+                          height={44}
+                        />
+                      ) : null}
+                      <AvatarFallback>MD</AvatarFallback>
+                    </Avatar>
+                    <div className={'min-w-0'}>
+                      <span className={'block text-xs text-muted-foreground'}>ผู้เขียน</span>
+                      <strong className={'block truncate text-sm'}>{post.author?.name || 'MilerDev'}</strong>
+                    </div>
+                  </div>
+                  <Separator className={'my-5'} />
+                  <dl className={'flex flex-col gap-3 text-sm'}>
+                    <div className={'flex justify-between gap-4'}><dt className={'text-muted-foreground'}>เผยแพร่</dt><dd>{formatDate(post.publishedAt) || '—'}</dd></div>
+                    <div className={'flex justify-between gap-4'}><dt className={'text-muted-foreground'}>เวลาอ่าน</dt><dd>{readingTime} นาที</dd></div>
+                    <div className={'flex justify-between gap-4'}><dt className={'text-muted-foreground'}>ยอดอ่าน</dt><dd>{(post.viewCount ?? 0).toLocaleString()} ครั้ง</dd></div>
+                  </dl>
                 </CardContent>
               </Card>
             </div>
@@ -271,54 +287,81 @@ export default async function BlogPostPage({ params }: Props) {
         </header>
 
         {thumbnailUrl ? (
-          <figure className="container mt-8 sm:mt-10">
-            <img className="aspect-[16/7] w-full rounded-3xl object-cover shadow-[var(--academy-shadow-card)]" src={thumbnailUrl} alt={post.title} />
+          <figure className={'container mt-8 overflow-hidden rounded-3xl shadow-[var(--academy-shadow-card)] sm:mt-10'}>
+            <EditorialImage
+              src={thumbnailUrl}
+              alt={post.title}
+              width={1200}
+              height={675}
+              loading={'eager'}
+              className={'aspect-[16/7] w-full object-cover'}
+            />
           </figure>
         ) : null}
 
-        <section className="py-12 sm:py-16 lg:py-20" aria-label="เนื้อหาบทความ">
-          <div className="container grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start lg:gap-16">
-            <article className="min-w-0">
+        <section className={'py-12 sm:py-16 lg:py-20'} aria-label={'เนื้อหาบทความ'}>
+          <div className={'container grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start lg:gap-16'}>
+            {tableOfContents.length > 0 ? (
+              <Card size={'sm'} className={'lg:hidden'}>
+                <CardContent><TableOfContents items={tableOfContents} variant={'mobile'} /></CardContent>
+              </Card>
+            ) : null}
+
+            <article className={'min-w-0'}>
               {post.content ? (
                 <div
-                  className="rich-content mx-auto max-w-3xl"
+                  className={'rich-content mx-auto max-w-3xl'}
                   dangerouslySetInnerHTML={{ __html: processedContent }}
                 />
               ) : null}
               <CodeCopyButton />
 
               {relatedPosts.length > 0 ? (
-                <section className="mt-14 border-t pt-10" aria-labelledby="related-articles-title">
-                  <div className="mb-6">
-                    <h2 id="related-articles-title" className="text-2xl font-semibold sm:text-3xl">บทความที่เกี่ยวข้อง</h2>
-                  </div>
-                  <ol className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
-                    {relatedPosts.map((relatedPost, index) => {
-                      const relatedImage = normalizeUrl(relatedPost.thumbnailUrl);
-                      return (
-                        <li key={relatedPost.id}>
-                          <Link href={`/blog/${relatedPost.slug}`} className="group block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30">
-                            <Card className="h-full gap-0 overflow-hidden py-0"><figure className="aspect-[16/9] overflow-hidden bg-[var(--academy-navy)]">
-                              {relatedImage ? <img className="size-full object-cover transition-transform group-hover:scale-[1.03]" src={relatedImage} alt={relatedPost.title} /> : <span className="flex size-full items-center justify-center text-2xl font-semibold text-primary" aria-hidden="true">MD</span>}
+                <section className={'mt-14 border-t pt-10'} aria-labelledby={'related-articles-title'}>
+                  <h2 id={'related-articles-title'} className={'mb-6 text-2xl font-semibold sm:text-3xl'}>บทความที่เกี่ยวข้อง</h2>
+                  <ol className={'grid gap-5 sm:grid-cols-2 xl:grid-cols-3'}>
+                    {relatedPosts.map((relatedPost, index) => (
+                      <li key={relatedPost.id} className={'min-w-0'}>
+                        <Link
+                          href={`/blog/${relatedPost.slug}`}
+                          className={'group block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30'}
+                        >
+                          <Card className={'h-full gap-0 overflow-hidden py-0'}>
+                            <figure className={'aspect-[16/9] overflow-hidden'}>
+                              <EditorialImage
+                                src={normalizeUrl(relatedPost.thumbnailUrl)}
+                                alt={relatedPost.title}
+                                width={1200}
+                                height={675}
+                                className={'size-full object-cover transition-transform motion-reduce:transition-none group-hover:scale-[1.03] motion-reduce:transform-none'}
+                              />
                             </figure>
-                            <CardContent className="pt-5"><span className="font-mono text-xs text-primary">{String(index + 1).padStart(2, '0')}</span><h3 className="mt-2 line-clamp-2 font-semibold group-hover:text-primary">{relatedPost.title}</h3><p className="mt-3 text-xs text-muted-foreground">{formatDate(relatedPost.publishedAt)}</p></CardContent></Card>
-                          </Link>
-                        </li>
-                      );
-                    })}
+                            <CardContent className={'pt-5'}>
+                              <span className={'font-mono text-xs text-primary'}>{String(index + 1).padStart(2, '0')}</span>
+                              <h3 className={'mt-2 line-clamp-2 font-semibold [overflow-wrap:anywhere] group-hover:text-primary'}>{relatedPost.title}</h3>
+                              <p className={'mt-3 text-xs text-muted-foreground'}>{formatDate(relatedPost.publishedAt)}</p>
+                            </CardContent>
+                          </Card>
+                        </Link>
+                      </li>
+                    ))}
                   </ol>
                 </section>
               ) : null}
 
-              <footer className="mt-10 flex flex-col gap-5 border-t pt-8 sm:flex-row sm:items-center sm:justify-between">
-                <ShareButtons url={`https://milerdev.com/blog/${post.slug}`} title={post.title} />
-                <Button variant="outline" asChild><Link href="/blog">← กลับไปบทความทั้งหมด</Link></Button>
+              <ArticleCourseBridge />
+
+              <footer className={'mt-10 flex flex-col gap-5 border-t pt-8 sm:flex-row sm:items-center sm:justify-between'}>
+                <ShareButtons url={absoluteUrl(`/blog/${post.slug}`)} title={post.title} />
+                <Button variant={'outline'} asChild><Link href={'/blog'}>← กลับไปบทความทั้งหมด</Link></Button>
               </footer>
             </article>
 
-            <aside className="sticky top-24 hidden rounded-2xl border bg-card p-5 lg:block" aria-label="สารบัญบทความ">
-              <TableOfContents contentHtml={processedContent} />
-            </aside>
+            {tableOfContents.length > 0 ? (
+              <aside className={'sticky top-24 hidden rounded-2xl border bg-card p-5 lg:block'} aria-label={'สารบัญบทความ'}>
+                <TableOfContents items={tableOfContents} variant={'desktop'} />
+              </aside>
+            ) : null}
           </div>
         </section>
       </MainContent>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,28 +1,31 @@
-import MainContent from '@/components/layout/MainContent';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Search } from 'lucide-react';
+import EditorialImage from '@/components/blog/EditorialImage';
 import Footer from '@/components/layout/Footer';
+import MainContent from '@/components/layout/MainContent';
 import Navbar from '@/components/layout/Navbar';
+import PublicPageHeader from '@/components/layout/PublicPageHeader';
+import { FeedbackState } from '@/components/status/FeedbackState';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
+import {
+  buildBlogHref,
+  getBlogRecoveryAction,
+  readBlogDiscoveryState,
+  type BlogSearchParamsInput,
+} from '@/lib/blog-discovery';
 import { db } from '@/lib/db';
 import { blogPosts, blogPostTags, tags, users } from '@/lib/db/schema';
 import { and, count, desc, eq, like, sql } from 'drizzle-orm';
 
 export const revalidate = 300;
 
-type SearchParamsInput = {
-  search?: string | string[];
-  tag?: string | string[];
-  page?: string | string[];
-};
-
 type Props = {
-  searchParams?: Promise<SearchParamsInput>;
+  searchParams?: Promise<BlogSearchParamsInput>;
 };
 
 interface Tag {
@@ -42,10 +45,6 @@ interface BlogPostItem {
   tags: Tag[];
 }
 
-function getSingleParam(value: string | string[] | undefined): string {
-  return Array.isArray(value) ? value[0] ?? '' : value ?? '';
-}
-
 function normalizeUrl(url: string | null): string | null {
   if (!url || url.trim() === '') return null;
   if (url.startsWith('http')) return url;
@@ -61,24 +60,14 @@ function formatDate(date: Date | null): string {
   });
 }
 
-function buildBlogQuery(params: { search?: string; tag?: string; page?: number }) {
-  const query = new URLSearchParams();
-  if (params.search) query.set('search', params.search);
-  if (params.tag && params.tag !== 'all') query.set('tag', params.tag);
-  if (params.page && params.page > 1) query.set('page', String(params.page));
-  const output = query.toString();
-  return output ? `/blog?${output}` : '/blog';
-}
-
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
-  const resolved = searchParams ? await searchParams : {};
-  const search = getSingleParam(resolved.search).trim();
-  const tag = getSingleParam(resolved.tag) || 'all';
-  const page = Math.max(1, parseInt(getSingleParam(resolved.page) || '1', 10) || 1);
-  const hasFacets = !!search || tag !== 'all' || page > 1;
+  const state = readBlogDiscoveryState(searchParams ? await searchParams : {});
+  const hasFacets = Boolean(state.search || state.tag !== 'all' || state.page > 1);
 
   return {
-    title: search ? `ผลการค้นหา ${search}` : 'บทความเขียนโปรแกรมและ Web Development',
+    title: state.search
+      ? `ผลการค้นหา ${state.search}`
+      : 'บทความเขียนโปรแกรมและ Web Development',
     alternates: { canonical: '/blog' },
     robots: hasFacets ? { index: false, follow: true } : { index: true, follow: true },
   };
@@ -88,7 +77,12 @@ async function getAllTags(): Promise<Tag[]> {
   return db.select({ id: tags.id, name: tags.name, slug: tags.slug }).from(tags).orderBy(tags.name);
 }
 
-async function getBlogData(input: { page: number; limit: number; search: string; tagSlug: string }) {
+async function getBlogData(input: {
+  page: number;
+  limit: number;
+  search: string;
+  tagSlug: string;
+}) {
   const { page, limit, search, tagSlug } = input;
   const offset = (page - 1) * limit;
   const conditions = [eq(blogPosts.status, 'published')];
@@ -142,16 +136,21 @@ async function getBlogData(input: { page: number; limit: number; search: string;
   const tagsByPost = new Map<string, Tag[]>();
   for (const row of allPostTags) {
     if (!tagsByPost.has(row.postId)) tagsByPost.set(row.postId, []);
-    tagsByPost.get(row.postId)!.push({ id: row.tagId, name: row.tagName, slug: row.tagSlug });
+    tagsByPost.get(row.postId)!.push({
+      id: row.tagId,
+      name: row.tagName,
+      slug: row.tagSlug,
+    });
   }
 
+  const total = totalResult[0]?.total ?? 0;
   return {
     posts: postRows.map((post) => ({ ...post, tags: tagsByPost.get(post.id) || [] })) as BlogPostItem[],
     pagination: {
       page,
       limit,
-      total: totalResult[0]?.total ?? 0,
-      totalPages: Math.ceil((totalResult[0]?.total ?? 0) / limit),
+      total,
+      totalPages: Math.ceil(total / limit),
     },
   };
 }
@@ -160,82 +159,223 @@ function getPageNumbers(totalPages: number, currentPage: number): (number | '...
   if (totalPages <= 7) return Array.from({ length: totalPages }, (_, index) => index + 1);
   const pages: (number | '...')[] = [1];
   if (currentPage > 3) pages.push('...');
-  for (let page = Math.max(2, currentPage - 1); page <= Math.min(totalPages - 1, currentPage + 1); page++) pages.push(page);
+  for (
+    let page = Math.max(2, currentPage - 1);
+    page <= Math.min(totalPages - 1, currentPage + 1);
+    page++
+  ) {
+    pages.push(page);
+  }
   if (currentPage < totalPages - 2) pages.push('...');
   pages.push(totalPages);
   return pages;
 }
 
-function PostImage({ post, featured = false }: { post: BlogPostItem; featured?: boolean }) {
-  const imageUrl = normalizeUrl(post.thumbnailUrl);
-  if (imageUrl) return <img src={imageUrl} alt={post.title} className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03] motion-reduce:transform-none" />;
-
+function PostImage({ post, eager = false }: { post: BlogPostItem; eager?: boolean }) {
   return (
-    <div className={`flex size-full flex-col justify-between bg-[radial-gradient(circle_at_75%_20%,rgba(0,171,255,.35),transparent_35%),var(--academy-navy)] p-5 text-white ${featured ? 'min-h-64' : 'min-h-40'}`} aria-hidden={true}>
-      <span className="text-2xl font-semibold">MD</span>
-    </div>
+    <EditorialImage
+      src={normalizeUrl(post.thumbnailUrl)}
+      alt={post.title}
+      width={1200}
+      height={675}
+      loading={eager ? 'eager' : 'lazy'}
+      className={'size-full object-cover transition-transform duration-300 motion-reduce:transition-none group-hover:scale-[1.03] motion-reduce:transform-none'}
+    />
   );
 }
 
 export default async function BlogPage({ searchParams }: Props) {
-  const resolved = searchParams ? await searchParams : {};
-  const search = getSingleParam(resolved.search).trim();
-  const tagFilter = getSingleParam(resolved.tag) || 'all';
-  const currentPage = Math.max(1, parseInt(getSingleParam(resolved.page) || '1', 10) || 1);
-
+  const state = readBlogDiscoveryState(searchParams ? await searchParams : {});
   const [blogData, allTags] = await Promise.all([
-    getBlogData({ page: currentPage, limit: 12, search, tagSlug: tagFilter }),
+    getBlogData({ page: state.page, limit: 12, search: state.search, tagSlug: state.tag }),
     getAllTags(),
   ]);
 
   const { posts, pagination } = blogData;
-  const featuredPost = currentPage === 1 && !search && tagFilter === 'all' ? posts[0] : null;
+  const featuredPost = state.page === 1 && !state.search && state.tag === 'all' ? posts[0] : null;
   const articlePosts = featuredPost ? posts.slice(1) : posts;
   const topicItems = [{ id: 'all', name: 'ทั้งหมด', slug: 'all' }, ...allTags];
+  const hasActiveFilters = Boolean(state.search || state.tag !== 'all');
+  const recoveryAction = getBlogRecoveryAction(state, pagination.total);
 
   return (
     <>
       <Navbar />
-      <MainContent className="bg-[var(--academy-canvas)]">
-        <header className="border-b bg-[radial-gradient(circle_at_82%_12%,var(--color-accent-soft),transparent_32%),var(--academy-canvas)] py-16 sm:py-20 lg:py-24">
-          <div className="container"><div className="grid gap-6 lg:grid-cols-[1.2fr_.8fr] lg:items-end lg:gap-16"><h1 className="text-4xl leading-[1.15] font-semibold tracking-[-.04em] text-balance sm:text-5xl lg:text-6xl">อ่านแนวคิด แล้วกลับไปเขียนโค้ด</h1><p className="max-w-xl text-base leading-8 text-muted-foreground sm:text-lg">บทความภาษาไทยสำหรับนักพัฒนาที่ต้องการเข้าใจเครื่องมือ วิธีคิด และการสร้างซอฟต์แวร์จากงานจริง</p></div></div>
-        </header>
+      <MainContent className={'bg-[var(--academy-canvas)]'}>
+        <PublicPageHeader
+          variant={'catalog'}
+          title={'อ่านแนวคิด แล้วกลับไปเขียนโค้ด'}
+          description={'บทความภาษาไทยสำหรับนักพัฒนาที่ต้องการเข้าใจเครื่องมือ วิธีคิด และการสร้างซอฟต์แวร์จากงานจริง'}
+        />
 
-        <section className="py-14 sm:py-20" aria-labelledby="blog-catalog-title">
-          <div className="container">
-            <header className="mb-8 flex flex-wrap items-end justify-between gap-4 border-b pb-7"><h2 id="blog-catalog-title" className="text-3xl font-semibold tracking-[-.03em] sm:text-4xl">{search || tagFilter !== 'all' ? 'ผลลัพธ์ที่กรองแล้ว' : 'บทความทั้งหมด'}</h2><Badge variant="secondary" aria-live="polite">{pagination.total} รายการ</Badge></header>
+        <section className={'py-14 sm:py-20'} aria-labelledby={'blog-catalog-title'}>
+          <div className={'container'}>
+            <header className={'mb-8 flex flex-wrap items-end justify-between gap-4 border-b pb-7'}>
+              <h2 id={'blog-catalog-title'} className={'text-3xl font-semibold tracking-[-.03em] sm:text-4xl'}>
+                {hasActiveFilters ? 'ผลลัพธ์ที่กรองแล้ว' : 'บทความทั้งหมด'}
+              </h2>
+              <Badge variant={'secondary'} aria-live={'polite'}>{pagination.total} รายการ</Badge>
+            </header>
 
-            <Card className="mb-6">
-              <CardHeader className="sr-only"><CardTitle>ค้นหาและกรองบทความ</CardTitle></CardHeader>
+            <Card className={'mb-6'}>
+              <CardHeader className={'sr-only'}>
+                <CardTitle>ค้นหาและกรองบทความ</CardTitle>
+              </CardHeader>
               <CardContent>
-                <form method="GET" action="/blog" role="search">
-                  <FieldGroup className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+                <form method={'GET'} action={'/blog'} role={'search'}>
+                  <FieldGroup className={'grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end'}>
                     <Field>
-                      <FieldLabel htmlFor="blog-search">ค้นหาบทความ</FieldLabel>
+                      <FieldLabel htmlFor={'blog-search'}>ค้นหาบทความ</FieldLabel>
                       <InputGroup>
-                        <InputGroupAddon><Search aria-hidden="true" /></InputGroupAddon>
-                        <InputGroupInput id="blog-search" type="search" name="search" defaultValue={search} placeholder="ค้นหาจากชื่อบทความ" />
+                        <InputGroupAddon><Search aria-hidden={true} /></InputGroupAddon>
+                        <InputGroupInput
+                          id={'blog-search'}
+                          type={'search'}
+                          name={'search'}
+                          defaultValue={state.search}
+                          placeholder={'ค้นหาจากชื่อบทความ'}
+                        />
                       </InputGroup>
                     </Field>
-                    {tagFilter !== 'all' ? <input type="hidden" name="tag" value={tagFilter} /> : null}
-                    <Field orientation="horizontal" className="gap-2">
-                      <Button type="submit">แสดงผลลัพธ์</Button>
-                      <Button variant="outline" asChild><Link href="/blog">ล้างตัวกรอง</Link></Button>
+                    {state.tag !== 'all' ? <input type={'hidden'} name={'tag'} value={state.tag} /> : null}
+                    <Field orientation={'horizontal'} className={'gap-2'}>
+                      <Button type={'submit'}>แสดงผลลัพธ์</Button>
+                      {hasActiveFilters ? (
+                        <Button variant={'outline'} asChild><Link href={'/blog'}>ล้างตัวกรอง</Link></Button>
+                      ) : null}
                     </Field>
                   </FieldGroup>
                 </form>
               </CardContent>
             </Card>
 
-            {allTags.length > 0 ? <nav className="mb-10 flex flex-wrap gap-2" aria-label="หัวข้อบทความ">{topicItems.map((tag) => { const isActive = tagFilter === tag.slug; return <Button key={tag.id} variant={isActive ? 'default' : 'outline'} size="sm" asChild><Link href={buildBlogQuery({ search, tag: tag.slug, page: 1 })} aria-current={isActive ? 'page' : undefined}>{tag.name}</Link></Button>; })}</nav> : null}
+            {allTags.length > 0 ? (
+              <nav className={'mb-10 flex flex-wrap gap-2'} aria-label={'หัวข้อบทความ'}>
+                {topicItems.map((tag) => {
+                  const isActive = state.tag === tag.slug;
+                  return (
+                    <Button key={tag.id} variant={isActive ? 'default' : 'outline'} size={'sm'} asChild>
+                      <Link
+                        href={buildBlogHref({ search: state.search, tag: tag.slug, page: 1 })}
+                        aria-current={isActive ? 'page' : undefined}
+                      >
+                        {tag.name}
+                      </Link>
+                    </Button>
+                  );
+                })}
+              </nav>
+            ) : null}
 
-            {posts.length === 0 ? <Card className="items-center py-14 text-center"><CardContent><h3 className="text-2xl font-semibold">ไม่พบบทความตามเงื่อนไขนี้</h3><p className="mt-2 text-muted-foreground">ลองใช้คำค้นที่สั้นลง หรือเลือกหัวข้อใหม่</p><Button className="mt-6" asChild><Link href="/blog">ดูบทความทั้งหมด</Link></Button></CardContent></Card> : (
+            {posts.length === 0 ? (
+              <FeedbackState
+                state={'empty'}
+                className={'border'}
+                title={state.page > 1 && pagination.total > 0 ? 'หน้านี้ไม่มีบทความ' : 'ไม่พบบทความตามเงื่อนไขนี้'}
+                description={state.page > 1 && pagination.total > 0
+                  ? 'กลับไปหน้าแรกของผลลัพธ์เพื่อเลือกบทความที่ยังเผยแพร่อยู่'
+                  : 'ลองใช้คำค้นที่สั้นลง เลือกหัวข้อใหม่ หรือล้างตัวกรอง'}
+                action={(
+                  <Button asChild>
+                    <Link href={recoveryAction.href}>{recoveryAction.label}</Link>
+                  </Button>
+                )}
+              />
+            ) : (
               <>
-                {featuredPost ? <Link href={`/blog/${featuredPost.slug}`} className="group mb-8 block rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30"><Card className="gap-0 overflow-hidden py-0 md:grid md:grid-cols-[1.1fr_.9fr]"><figure className="aspect-[16/9] overflow-hidden md:aspect-auto md:min-h-96"><PostImage post={featuredPost} featured /></figure><div className="flex flex-col justify-center p-6 sm:p-9"><div className="mb-5 flex flex-wrap gap-2">{featuredPost.tags.slice(0, 3).map((tag) => <Badge key={tag.id} variant="secondary">{tag.name}</Badge>)}</div><p className="text-sm text-muted-foreground">{formatDate(featuredPost.publishedAt)}</p><h2 className="mt-3 text-3xl leading-tight font-semibold tracking-[-.03em] group-hover:text-primary">{featuredPost.title}</h2>{featuredPost.excerpt ? <p className="mt-4 line-clamp-3 leading-7 text-muted-foreground">{featuredPost.excerpt}</p> : null}<div className="mt-7 flex items-center justify-between gap-4 border-t pt-5 text-sm"><span className="text-muted-foreground">{featuredPost.authorName ? `โดย ${featuredPost.authorName}` : 'MilerDev'}</span><strong className="text-primary">อ่านบทความ →</strong></div></div></Card></Link> : null}
+                {featuredPost ? (
+                  <Link
+                    href={`/blog/${featuredPost.slug}`}
+                    className={'group mb-8 block rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30'}
+                  >
+                    <Card className={'gap-0 overflow-hidden py-0 md:grid md:grid-cols-[1.1fr_.9fr]'}>
+                      <figure className={'aspect-[16/9] overflow-hidden md:aspect-auto md:min-h-96'}>
+                        <PostImage post={featuredPost} eager />
+                      </figure>
+                      <div className={'flex min-w-0 flex-col justify-center p-6 sm:p-9'}>
+                        <div className={'mb-5 flex flex-wrap gap-2'}>
+                          {featuredPost.tags.slice(0, 3).map((tag) => (
+                            <Badge key={tag.id} variant={'secondary'}>{tag.name}</Badge>
+                          ))}
+                        </div>
+                        <p className={'text-sm text-muted-foreground'}>{formatDate(featuredPost.publishedAt)}</p>
+                        <h2 className={'mt-3 text-3xl leading-tight font-semibold tracking-[-.03em] [overflow-wrap:anywhere] group-hover:text-primary'}>
+                          {featuredPost.title}
+                        </h2>
+                        {featuredPost.excerpt ? (
+                          <p className={'mt-4 line-clamp-3 leading-7 text-muted-foreground'}>{featuredPost.excerpt}</p>
+                        ) : null}
+                        <div className={'mt-7 flex items-center justify-between gap-4 border-t pt-5 text-sm'}>
+                          <span className={'text-muted-foreground'}>{featuredPost.authorName ? `โดย ${featuredPost.authorName}` : 'MilerDev'}</span>
+                          <strong className={'text-primary'}>อ่านบทความ →</strong>
+                        </div>
+                      </div>
+                    </Card>
+                  </Link>
+                ) : null}
 
-                {articlePosts.length > 0 ? <ol className="grid gap-5 lg:grid-cols-2">{articlePosts.map((post) => <li key={post.id}><Link href={`/blog/${post.slug}`} className="group block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30"><Card className="h-full gap-0 overflow-hidden py-0 sm:grid sm:grid-cols-[11rem_1fr]"><figure className="aspect-[16/9] overflow-hidden sm:aspect-auto"><PostImage post={post} /></figure><div className="p-5"><div className="flex flex-wrap gap-2">{post.tags.slice(0, 2).map((tag) => <Badge key={tag.id} variant="secondary">{tag.name}</Badge>)}</div><h2 className="mt-4 text-xl leading-snug font-semibold group-hover:text-primary">{post.title}</h2>{post.excerpt ? <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">{post.excerpt}</p> : null}<p className="mt-4 text-xs text-muted-foreground">{post.authorName ? `โดย ${post.authorName}` : 'MilerDev'} / {formatDate(post.publishedAt)}</p></div></Card></Link></li>)}</ol> : null}
+                {articlePosts.length > 0 ? (
+                  <ol className={'grid gap-5 lg:grid-cols-2'}>
+                    {articlePosts.map((post) => (
+                      <li key={post.id} className={'min-w-0'}>
+                        <Link
+                          href={`/blog/${post.slug}`}
+                          className={'group block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30'}
+                        >
+                          <Card className={'h-full gap-0 overflow-hidden py-0 sm:grid sm:grid-cols-[11rem_minmax(0,1fr)]'}>
+                            <figure className={'aspect-[16/9] overflow-hidden sm:aspect-auto'}><PostImage post={post} /></figure>
+                            <div className={'min-w-0 p-5'}>
+                              <div className={'flex flex-wrap gap-2'}>
+                                {post.tags.slice(0, 2).map((tag) => (
+                                  <Badge key={tag.id} variant={'secondary'}>{tag.name}</Badge>
+                                ))}
+                              </div>
+                              <h2 className={'mt-4 text-xl leading-snug font-semibold [overflow-wrap:anywhere] group-hover:text-primary'}>{post.title}</h2>
+                              {post.excerpt ? <p className={'mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground'}>{post.excerpt}</p> : null}
+                              <p className={'mt-4 text-xs text-muted-foreground'}>
+                                {post.authorName ? `โดย ${post.authorName}` : 'MilerDev'} / {formatDate(post.publishedAt)}
+                              </p>
+                            </div>
+                          </Card>
+                        </Link>
+                      </li>
+                    ))}
+                  </ol>
+                ) : null}
 
-                {pagination.totalPages > 1 ? <nav className="mt-10 flex flex-wrap items-center justify-center gap-2" aria-label="หน้ารายการบทความ">{currentPage > 1 ? <Button variant="outline" asChild><Link href={buildBlogQuery({ search, tag: tagFilter, page: currentPage - 1 })}>← ก่อนหน้า</Link></Button> : null}{getPageNumbers(pagination.totalPages, currentPage).map((pageNumber, index) => pageNumber === '...' ? <span key={`dots-${index}`} className="px-2" aria-hidden="true">…</span> : <Button key={pageNumber} variant={currentPage === pageNumber ? 'default' : 'outline'} size="icon-sm" asChild><Link href={buildBlogQuery({ search, tag: tagFilter, page: pageNumber })} aria-current={currentPage === pageNumber ? 'page' : undefined}>{pageNumber}</Link></Button>)}{currentPage < pagination.totalPages ? <Button variant="outline" asChild><Link href={buildBlogQuery({ search, tag: tagFilter, page: currentPage + 1 })}>ถัดไป →</Link></Button> : null}</nav> : null}
+                {pagination.totalPages > 1 ? (
+                  <nav className={'mt-10 flex flex-wrap items-center justify-center gap-2'} aria-label={'หน้ารายการบทความ'}>
+                    {state.page > 1 ? (
+                      <Button variant={'outline'} asChild>
+                        <Link href={buildBlogHref({ ...state, page: state.page - 1 })}>← ก่อนหน้า</Link>
+                      </Button>
+                    ) : null}
+                    {getPageNumbers(pagination.totalPages, state.page).map((pageNumber, index) => (
+                      pageNumber === '...'
+                        ? <span key={`dots-${index}`} className={'px-2'} aria-hidden={true}>…</span>
+                        : (
+                            <Button
+                              key={pageNumber}
+                              variant={state.page === pageNumber ? 'default' : 'outline'}
+                              size={'icon-sm'}
+                              asChild
+                            >
+                              <Link
+                                href={buildBlogHref({ ...state, page: pageNumber })}
+                                aria-current={state.page === pageNumber ? 'page' : undefined}
+                              >
+                                {pageNumber}
+                              </Link>
+                            </Button>
+                          )
+                    ))}
+                    {state.page < pagination.totalPages ? (
+                      <Button variant={'outline'} asChild>
+                        <Link href={buildBlogHref({ ...state, page: state.page + 1 })}>ถัดไป →</Link>
+                      </Button>
+                    ) : null}
+                  </nav>
+                ) : null}
               </>
             )}
           </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -305,12 +305,28 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* Rich Content (Blog / Course descriptions) — overrides Tailwind Preflight */
+.rich-content {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .rich-content h1,
 .rich-content h2,
 .rich-content h3,
 .rich-content h4 {
   font-weight: 700 !important;
   color: #1e293b !important;
+}
+
+.rich-content h2,
+.rich-content h3 {
+  scroll-margin-top: 7rem;
+}
+
+.rich-content h2:focus-visible,
+.rich-content h3:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 0.375rem;
 }
 
 .rich-content h1 {
@@ -350,6 +366,7 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--accent-strong) !important;
   text-decoration: underline !important;
   text-underline-offset: 2px !important;
+  overflow-wrap: anywhere;
 }
 
 .rich-content a:hover {
@@ -424,6 +441,13 @@ h1, h2, h3, h4, h5, h6 {
   height: auto !important;
   border-radius: 12px !important;
   margin: 1.5rem 0 !important;
+}
+
+.rich-content table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
 }
 
 .rich-content hr {

--- a/src/components/blog/ArticleCourseBridge.tsx
+++ b/src/components/blog/ArticleCourseBridge.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export default function ArticleCourseBridge() {
+  return (
+    <section className={'mt-10'} aria-labelledby={'article-course-bridge-title'}>
+      <Card size={'sm'}>
+        <CardHeader>
+          <CardTitle id={'article-course-bridge-title'} className={'text-xl'}>
+            ฝึกต่อจากแนวคิดนี้
+          </CardTitle>
+          <CardDescription className={'max-w-2xl leading-6'}>
+            อยากลงมือทำเป็นลำดับ? ดูคอร์สทั้งหมดแล้วเลือกจากหัวข้อและระดับที่ตรงกับคุณ
+          </CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Button variant={'outline'} asChild>
+            <Link href={'/courses'}>
+              ดูคอร์สทั้งหมด
+              <ArrowRight data-icon={'inline-end'} aria-hidden={true} />
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/blog/EditorialImage.tsx
+++ b/src/components/blog/EditorialImage.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface EditorialImageProps {
+  src: string | null;
+  alt: string;
+  width: number;
+  height: number;
+  className?: string;
+  loading?: 'eager' | 'lazy';
+}
+
+export default function EditorialImage({
+  src,
+  alt,
+  width,
+  height,
+  className,
+  loading = 'lazy',
+}: EditorialImageProps) {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  if (!src || status === 'error') {
+    return (
+      <div
+        className={cn(
+          'flex size-full min-h-36 flex-col items-center justify-center gap-2 bg-[var(--academy-navy)] p-5 text-center text-white',
+          className,
+        )}
+        role={'img'}
+        aria-label={src ? `ไม่สามารถแสดงภาพประกอบ: ${alt}` : 'ภาพประกอบ MilerDev'}
+        data-image-state={src ? 'error' : 'empty'}
+      >
+        <strong className={'text-2xl'}>MD</strong>
+        {src ? <span className={'text-xs text-white/70'}>ไม่สามารถแสดงภาพประกอบ</span> : null}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      loading={loading}
+      decoding={'async'}
+      className={className}
+      onLoad={() => setStatus('ready')}
+      onError={() => setStatus('error')}
+      aria-busy={status === 'loading' || undefined}
+      data-image-state={status}
+    />
+  );
+}

--- a/src/components/blog/TableOfContents.tsx
+++ b/src/components/blog/TableOfContents.tsx
@@ -1,99 +1,93 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ChevronDown, List } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { BlogTableOfContentsItem } from '@/lib/sanitize';
 import { cn } from '@/lib/utils';
 
-interface TocItem {
-  id: string;
-  text: string;
-  level: 2 | 3;
-}
-
 interface Props {
-  contentHtml: string;
+  items: BlogTableOfContentsItem[];
+  variant: 'mobile' | 'desktop';
 }
 
-export default function TableOfContents({ contentHtml }: Props) {
-  const [activeId, setActiveId] = useState<string>('');
-  const [open, setOpen] = useState(true);
-  const [isMobile, setIsMobile] = useState<boolean | null>(null);
+export default function TableOfContents({ items, variant }: Props) {
+  const [activeId, setActiveId] = useState('');
+  const [open, setOpen] = useState(variant === 'desktop');
+  const controlsId = `blog-toc-items-${variant}`;
 
   useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 1024);
-    check();
-    window.addEventListener('resize', check);
-    return () => window.removeEventListener('resize', check);
-  }, []);
+    if (items.length === 0 || !('IntersectionObserver' in window)) return;
 
-  const items = useMemo<TocItem[]>(() => {
-    const parsed: TocItem[] = [];
-    const regex = /<h2[^>]*>([\s\S]*?)<\/h2>/gi;
-    let match;
-    let index = 0;
-    while ((match = regex.exec(contentHtml)) !== null) {
-      const rawText = match[1].replace(/<[^>]+>/g, '').trim();
-      if (!rawText) continue;
-      const id = `toc-${index}-${rawText.toLowerCase().replace(/[^a-z0-9ก-๙]+/g, '-').replace(/^-|-$/g, '')}`;
-      parsed.push({ id, text: rawText, level: 2 });
-      index += 1;
-    }
-    return parsed;
-  }, [contentHtml]);
-
-  useEffect(() => {
-    if (items.length === 0) return;
-
-    const realHeadings = document.querySelectorAll<HTMLElement>('.rich-content h2');
-    realHeadings.forEach((heading, index) => {
-      if (items[index]) heading.id = items[index].id;
-    });
-
+    const headings = items
+      .map((item) => document.getElementById(item.id))
+      .filter((heading): heading is HTMLElement => heading !== null);
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries.filter((entry) => entry.isIntersecting);
-        if (visible.length > 0) setActiveId(visible[0].target.id);
+        const visibleHeading = entries.find((entry) => entry.isIntersecting);
+        if (visibleHeading) setActiveId(visibleHeading.target.id);
       },
       { rootMargin: '-80px 0px -60% 0px', threshold: 0 },
     );
 
-    realHeadings.forEach((heading) => observer.observe(heading));
+    headings.forEach((heading) => observer.observe(heading));
     return () => observer.disconnect();
   }, [items]);
 
-  if (isMobile === null || isMobile || items.length < 2) return null;
+  if (items.length === 0) return null;
 
   return (
-    <div data-open={open || undefined}>
+    <div data-toc-variant={variant} data-open={open || undefined}>
       <Button
         type={'button'}
-        variant="ghost"
-        className="w-full justify-between px-2"
+        variant={'ghost'}
+        className={'w-full justify-between px-2'}
         onClick={() => setOpen((current) => !current)}
         aria-expanded={open}
-        aria-controls={'blog-toc-items'}
+        aria-controls={controlsId}
       >
-        <span className="inline-flex items-center gap-2"><List data-icon="inline-start" aria-hidden="true" />สารบัญบทความ</span>
-        <ChevronDown data-icon="inline-end" className={cn('transition-transform', open && 'rotate-180')} aria-hidden="true" />
+        <span className={'inline-flex items-center gap-2'}>
+          <List data-icon={'inline-start'} aria-hidden={true} />
+          สารบัญบทความ ({items.length})
+        </span>
+        <ChevronDown
+          data-icon={'inline-end'}
+          className={cn('transition-transform motion-reduce:transition-none', open && 'rotate-180')}
+          aria-hidden={true}
+        />
       </Button>
 
       {open ? (
-        <nav id="blog-toc-items" className="mt-3 flex flex-col gap-1 border-t pt-3" aria-label="หัวข้อในบทความ">
+        <nav
+          id={controlsId}
+          className={'mt-3 flex flex-col gap-1 border-t pt-3'}
+          aria-label={'หัวข้อในบทความ'}
+        >
           {items.map((item) => (
             <a
               key={item.id}
               href={`#${item.id}`}
-              className={cn('block rounded-lg px-3 py-2 text-sm leading-5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground', activeId === item.id && 'bg-primary/10 font-semibold text-primary')}
+              className={cn(
+                'block rounded-lg px-3 py-2 text-sm leading-5 text-muted-foreground transition-colors motion-reduce:transition-none hover:bg-muted hover:text-foreground',
+                item.level === 3 && 'pl-6 text-xs',
+                activeId === item.id && 'bg-primary/10 font-semibold text-primary',
+              )}
               data-active={activeId === item.id || undefined}
               aria-current={activeId === item.id ? 'location' : undefined}
               onClick={(event) => {
                 event.preventDefault();
+                const heading = document.getElementById(item.id);
+                if (!heading) return;
+
                 const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-                document.getElementById(item.id)?.scrollIntoView({
+                heading.scrollIntoView({
                   behavior: reduceMotion ? 'auto' : 'smooth',
                   block: 'start',
                 });
+                heading.focus({ preventScroll: true });
+                window.history.pushState(null, '', `#${item.id}`);
+                setActiveId(item.id);
+                if (variant === 'mobile') setOpen(false);
               }}
             >
               {item.text}

--- a/src/lib/blog-discovery.ts
+++ b/src/lib/blog-discovery.ts
@@ -1,0 +1,51 @@
+export type BlogSearchParamsInput = {
+  search?: string | string[];
+  tag?: string | string[];
+  page?: string | string[];
+};
+
+export interface BlogDiscoveryState {
+  search: string;
+  tag: string;
+  page: number;
+}
+
+function getSingleParam(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] ?? '' : value ?? '';
+}
+
+export function readBlogDiscoveryState(params: BlogSearchParamsInput): BlogDiscoveryState {
+  const search = getSingleParam(params.search).trim();
+  const tag = getSingleParam(params.tag).trim() || 'all';
+  const requestedPage = Number.parseInt(getSingleParam(params.page) || '1', 10);
+
+  return {
+    search,
+    tag,
+    page: Number.isFinite(requestedPage) ? Math.max(1, requestedPage) : 1,
+  };
+}
+
+export function buildBlogHref(params: Partial<BlogDiscoveryState>): string {
+  const query = new URLSearchParams();
+  if (params.search) query.set('search', params.search);
+  if (params.tag && params.tag !== 'all') query.set('tag', params.tag);
+  if (params.page && params.page > 1) query.set('page', String(params.page));
+
+  const output = query.toString();
+  return output ? `/blog?${output}` : '/blog';
+}
+
+export function getBlogRecoveryAction(
+  state: BlogDiscoveryState,
+  totalResults: number,
+): { href: string; label: string } {
+  if (totalResults > 0 && state.page > 1) {
+    return {
+      href: buildBlogHref({ search: state.search, tag: state.tag, page: 1 }),
+      label: 'กลับหน้าแรกของผลลัพธ์',
+    };
+  }
+
+  return { href: '/blog', label: 'ล้างตัวกรอง' };
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -55,6 +55,12 @@ const lowlight = createLowlight({
 const MAX_PROCESSED_HTML_CACHE_BYTES = 2 * 1024 * 1024;
 const processedHtmlCache = new SizeBoundedStringLruCache(MAX_PROCESSED_HTML_CACHE_BYTES);
 
+export interface BlogTableOfContentsItem {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
 type HastNode = {
   type: string;
   tagName?: string;
@@ -181,6 +187,59 @@ export function sanitizeRichContent(html: string): string {
     });
 }
 
+function createHeadingId(text: string, index: number): string {
+    const slug = text
+        .normalize('NFKC')
+        .toLocaleLowerCase('th-TH')
+        .replace(/[^\p{L}\p{M}\p{N}]+/gu, '-')
+        .replace(/^-+|-+$/g, '');
+
+    return `section-${slug || index + 1}`;
+}
+
+/**
+ * Add deterministic anchors after sanitization so article HTML and the TOC
+ * share one server-authored source of truth before hydration.
+ */
+export function addStableBlogHeadingIds(html: string): string {
+    const seenIds = new Map<string, number>();
+    let headingIndex = 0;
+
+    return html.replace(
+        /<(h[23])([^>]*)>([\s\S]*?)<\/\1>/gi,
+        (_match, tag: 'h2' | 'h3', attributes: string, content: string) => {
+            const text = stripHtml(content);
+            const baseId = createHeadingId(text, headingIndex);
+            const occurrence = (seenIds.get(baseId) ?? 0) + 1;
+            const id = occurrence === 1 ? baseId : `${baseId}-${occurrence}`;
+
+            seenIds.set(baseId, occurrence);
+            headingIndex += 1;
+
+            return `<${tag}${attributes} id='${id}' tabindex='-1'>${content}</${tag}>`;
+        },
+    );
+}
+
+export function getBlogTableOfContents(html: string): BlogTableOfContentsItem[] {
+    const items: BlogTableOfContentsItem[] = [];
+    const headingPattern = /<h([23])[^>]*\sid='([^']+)'[^>]*>([\s\S]*?)<\/h\1>/gi;
+    let match: RegExpExecArray | null;
+
+    while ((match = headingPattern.exec(html)) !== null) {
+        const text = stripHtml(match[3]);
+        if (!text) continue;
+
+        items.push({
+            id: match[2],
+            text,
+            level: Number(match[1]) as 2 | 3,
+        });
+    }
+
+    return items;
+}
+
 function getCachedProcessedHtml(cacheKey: string, compute: () => string): string {
     const existing = processedHtmlCache.get(cacheKey);
     if (existing !== undefined) return existing;
@@ -192,7 +251,9 @@ function getCachedProcessedHtml(cacheKey: string, compute: () => string): string
 
 export function getProcessedBlogContent(html: string): string {
     return getCachedProcessedHtml(`blog:${html}`, () =>
-        sanitizeRichContent(highlightCodeBlocks(enhanceBlogContent(html)))
+        addStableBlogHeadingIds(
+            sanitizeRichContent(highlightCodeBlocks(enhanceBlogContent(html)))
+        )
     );
 }
 

--- a/tests/components/blog-article-discovery.test.tsx
+++ b/tests/components/blog-article-discovery.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ArticleCourseBridge from '@/components/blog/ArticleCourseBridge';
+import EditorialImage from '@/components/blog/EditorialImage';
+import TableOfContents from '@/components/blog/TableOfContents';
+
+const items = [
+  { id: 'section-เริ่มต้น', text: 'เริ่มต้น', level: 2 as const },
+  { id: 'section-ทดลอง', text: 'ทดลอง', level: 3 as const },
+];
+
+describe('Blog article discovery', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: true }),
+    });
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('offers a collapsed mobile TOC and moves keyboard focus to the stable heading', () => {
+    render(
+      <>
+        <h2 id={items[0].id} tabIndex={-1}>เริ่มต้น</h2>
+        <TableOfContents items={items} variant={'mobile'} />
+      </>,
+    );
+
+    const toggle = screen.getByRole('button', { name: 'สารบัญบทความ (2)' });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle);
+
+    const link = screen.getByRole('link', { name: 'เริ่มต้น' });
+    fireEvent.click(link);
+    expect(document.activeElement).toBe(screen.getByRole('heading', { name: 'เริ่มต้น' }));
+    expect(decodeURIComponent(window.location.hash)).toBe(`#${items[0].id}`);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps the desktop TOC expanded and includes nested headings', () => {
+    render(<TableOfContents items={items} variant={'desktop'} />);
+
+    expect(screen.getByRole('button', { name: 'สารบัญบทความ (2)' }).getAttribute('aria-expanded'))
+      .toBe('true');
+    expect(screen.getByRole('link', { name: 'ทดลอง' }).getAttribute('href'))
+      .toBe('#section-ทดลอง');
+  });
+
+  it('reserves image geometry and exposes a truthful load-error fallback', () => {
+    render(
+      <EditorialImage
+        src={'https://cdn.example.com/article.webp'}
+        alt={'ชื่อบทความภาษาไทยที่ยาวมากเพื่อทดสอบการแสดงผล'}
+        width={1200}
+        height={675}
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'ชื่อบทความภาษาไทยที่ยาวมากเพื่อทดสอบการแสดงผล' });
+    expect(image.getAttribute('width')).toBe('1200');
+    expect(image.getAttribute('height')).toBe('675');
+    expect(image.getAttribute('loading')).toBe('lazy');
+    expect(image.getAttribute('aria-busy')).toBe('true');
+    expect(image.getAttribute('data-image-state')).toBe('loading');
+
+    fireEvent.error(image);
+    expect(screen.getByRole('img', { name: /ไม่สามารถแสดงภาพประกอบ/ }).getAttribute('data-image-state'))
+      .toBe('error');
+  });
+
+  it('renders one low-pressure catalog bridge without claiming a course relation', () => {
+    const html = renderToStaticMarkup(<ArticleCourseBridge />);
+
+    expect(html.match(/<a\b/g)).toHaveLength(1);
+    expect(html).toContain('/courses');
+    expect(html).toContain('ฝึกต่อจากแนวคิดนี้');
+    expect(html).not.toContain('คอร์สที่เกี่ยวข้อง');
+  });
+});

--- a/tests/components/public-acquisition-content.test.ts
+++ b/tests/components/public-acquisition-content.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const aboutSource = readFileSync('src/app/about/page.tsx', 'utf8');
+const articleSource = readFileSync('src/app/blog/[slug]/page.tsx', 'utf8');
+const richContentCss = readFileSync('src/app/globals.css', 'utf8');
+
+describe('Public acquisition content contracts', () => {
+  it('keeps About evidence factual until named-event authority exists', () => {
+    expect(aboutSource).toContain('ภาพจากกิจกรรมการสอนและเวทีแบ่งปันความรู้');
+    expect(aboutSource).toContain('<figcaption');
+    expect(aboutSource).not.toContain('องค์กรและมหาวิทยาลัย');
+  });
+
+  it('renders mobile and desktop TOCs from the same server-authored items', () => {
+    expect(articleSource.match(/items=\{tableOfContents\}/g)).toHaveLength(2);
+    expect(articleSource).toContain(`variant={'mobile'}`);
+    expect(articleSource).toContain(`variant={'desktop'}`);
+  });
+
+  it('keeps long rich content inside the reading column', () => {
+    expect(richContentCss).toContain('overflow-wrap: anywhere');
+    expect(richContentCss).toContain('overscroll-behavior-inline: contain');
+    expect(richContentCss).toContain('scroll-margin-top: 7rem');
+  });
+});

--- a/tests/lib/blog-discovery.test.ts
+++ b/tests/lib/blog-discovery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBlogHref,
+  getBlogRecoveryAction,
+  readBlogDiscoveryState,
+} from '@/lib/blog-discovery';
+
+describe('Blog URL discovery', () => {
+  it('reads the URL as the source of search, tag, and page state', () => {
+    expect(readBlogDiscoveryState({
+      search: ['  React ภาษาไทย  ', 'ignored'],
+      tag: 'next-js',
+      page: '3',
+    })).toEqual({ search: 'React ภาษาไทย', tag: 'next-js', page: 3 });
+  });
+
+  it('normalizes missing or invalid pagination without losing active facets', () => {
+    expect(readBlogDiscoveryState({ search: 'react', tag: '', page: '-8' })).toEqual({
+      search: 'react',
+      tag: 'all',
+      page: 1,
+    });
+    expect(readBlogDiscoveryState({ page: 'not-a-page' }).page).toBe(1);
+  });
+
+  it('preserves search and tag while paging and resets default values', () => {
+    expect(buildBlogHref({ search: 'react hooks', tag: 'typescript', page: 4 }))
+      .toBe('/blog?search=react+hooks&tag=typescript&page=4');
+    expect(buildBlogHref({ search: '', tag: 'all', page: 1 })).toBe('/blog');
+  });
+
+  it('recovers an out-of-range page without discarding its filters', () => {
+    expect(getBlogRecoveryAction({ search: 'react', tag: 'typescript', page: 9 }, 4)).toEqual({
+      href: '/blog?search=react&tag=typescript',
+      label: 'กลับหน้าแรกของผลลัพธ์',
+    });
+    expect(getBlogRecoveryAction({ search: 'missing', tag: 'all', page: 1 }, 0)).toEqual({
+      href: '/blog',
+      label: 'ล้างตัวกรอง',
+    });
+  });
+});

--- a/tests/lib/sanitize.test.ts
+++ b/tests/lib/sanitize.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+    getBlogTableOfContents,
+    getProcessedBlogContent,
     highlightCodeBlocks,
     sanitizeRichContent,
 } from '@/lib/sanitize';
@@ -40,5 +42,21 @@ describe('rich content processing', () => {
         expect(result).toContain('<a>link</a>');
         expect(result).not.toContain('<script');
         expect(result).not.toContain('javascript:');
+    });
+
+    it('creates stable unique Thai heading anchors before hydration', () => {
+        const input = '<h2 id=unsafe>เริ่มเขียนโค้ด</h2><h3>ลองทีละส่วน</h3><h2>เริ่มเขียนโค้ด</h2>';
+        const first = getProcessedBlogContent(input);
+        const second = getProcessedBlogContent(input);
+
+        expect(second).toBe(first);
+        expect(first).toContain(`id='section-เริ่มเขียนโค้ด' tabindex='-1'`);
+        expect(first).toContain(`id='section-เริ่มเขียนโค้ด-2' tabindex='-1'`);
+        expect(first).not.toContain('id=unsafe');
+        expect(getBlogTableOfContents(first)).toEqual([
+            { id: 'section-เริ่มเขียนโค้ด', text: 'เริ่มเขียนโค้ด', level: 2 },
+            { id: 'section-ลองทีละส่วน', text: 'ลองทีละส่วน', level: 3 },
+            { id: 'section-เริ่มเขียนโค้ด-2', text: 'เริ่มเขียนโค้ด', level: 2 },
+        ]);
     });
 });


### PR DESCRIPTION
## Summary
- reshape About around a three-step lesson method and factual teaching-media evidence without unsupported named claims
- keep Blog discovery server- and URL-backed with canonical empty recovery and resilient intrinsic-size editorial images
- generate stable Thai article heading anchors before hydration, expose responsive keyboard-friendly TOCs, and add one low-pressure catalog bridge
- harden rich-content focus and long-content overflow behavior

## Verification
- npm run test -- --run (175 files, 914 tests)
- npm run lint
- npx tsc --noEmit
- npm run build
- git diff --check
- browser screenshots: About at 390/1440 and Blog empty state at 390/768/1440

Article browser capture was not available because the local public database has no published post fixture; article TOC, focus, image loading/error, course bridge, and overflow contracts are covered by deterministic component/unit tests.

Closes #45