### PR TITLE
feat(courses): align discovery with decision facts

### DIFF
--- a/src/app/api/courses/[slug]/reviews/route.ts
+++ b/src/app/api/courses/[slug]/reviews/route.ts
@@ -3,10 +3,11 @@ import { logError } from '@/lib/error-handler';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { reviews, courses, users, enrollments } from '@/lib/db/schema';
-import { eq, and, desc, sql, avg, count } from 'drizzle-orm';
+import { eq, and, desc, sql } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 import { checkRateLimit, getClientIP, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
 import { stripHtml } from '@/lib/sanitize';
+import { getCourseReviewStats } from '@/lib/course-review-stats';
 
 type RouteParams = { params: Promise<{ slug: string }> };
 
@@ -41,6 +42,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     const conditions = [
       eq(reviews.courseId, course.id),
       eq(reviews.isHidden, false),
+      eq(reviews.isVerified, true),
     ];
 
     if (filterRating) {
@@ -77,39 +79,18 @@ export async function GET(request: Request, { params }: RouteParams) {
         .select({ count: sql<number>`count(*)` })
         .from(reviews)
         .where(whereCondition),
-      db
-        .select({
-          avgRating: avg(reviews.rating),
-          totalReviews: count(),
-          star5: sql<number>`sum(case when rating = 5 then 1 else 0 end)`,
-          star4: sql<number>`sum(case when rating = 4 then 1 else 0 end)`,
-          star3: sql<number>`sum(case when rating = 3 then 1 else 0 end)`,
-          star2: sql<number>`sum(case when rating = 2 then 1 else 0 end)`,
-          star1: sql<number>`sum(case when rating = 1 then 1 else 0 end)`,
-        })
-        .from(reviews)
-        .where(and(eq(reviews.courseId, course.id), eq(reviews.isHidden, false))),
+      getCourseReviewStats(course.id),
     ]);
 
     const total = totalResult[0]?.count ?? 0;
-    const stats = statsResult[0];
+    const stats = statsResult;
 
     return NextResponse.json({
       reviews: reviewList.map(r => ({
         ...r,
         displayName: r.displayName || r.userName || 'ผู้ใช้',
       })),
-      stats: {
-        avgRating: stats?.avgRating ? parseFloat(String(stats.avgRating)) : 0,
-        totalReviews: stats?.totalReviews ?? 0,
-        distribution: {
-          5: stats?.star5 ?? 0,
-          4: stats?.star4 ?? 0,
-          3: stats?.star3 ?? 0,
-          2: stats?.star2 ?? 0,
-          1: stats?.star1 ?? 0,
-        },
-      },
+      stats,
       pagination: {
         page,
         limit,

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import MainContent from '@/components/layout/MainContent';
+import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 // Image import removed - using native img for external URLs
@@ -23,6 +24,7 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/u
 import { Separator } from '@/components/ui/separator';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { deriveCourseDecisionFacts } from '@/lib/course-decision-facts';
+import { getCourseReviewStats } from '@/lib/course-review-stats';
 
 function normalizeUrl(url: string | null): string | null {
     if (!url || url.trim() === '') return null;
@@ -91,8 +93,8 @@ async function getCourse(slug: string) {
 
   if (!course) return null;
 
-  // Parallelize instructor, lessons, and tags queries
-  const [instructorResult, courseLessons, courseTagRows] = await Promise.all([
+  // Parallelize instructor, lessons, tags, and decision evidence queries
+  const [instructorResult, courseLessons, courseTagRows, reviewStats] = await Promise.all([
     course.instructorId
       ? db
           .select({ id: users.id, name: users.name, avatarUrl: users.avatarUrl })
@@ -110,6 +112,7 @@ async function getCourse(slug: string) {
       .from(courseTags)
       .innerJoin(tags, eq(courseTags.tagId, tags.id))
       .where(eq(courseTags.courseId, course.id)),
+    getCourseReviewStats(course.id),
   ]);
 
   return {
@@ -117,6 +120,7 @@ async function getCourse(slug: string) {
     instructor: instructorResult[0] || null,
     lessons: courseLessons,
     tags: courseTagRows,
+    reviewStats,
   };
 }
 
@@ -160,10 +164,17 @@ export default async function CourseDetailPage({ params }: Props) {
     knownDurationSeconds: totalSeconds,
     freePreviewCount,
     instructor: course.instructor ? { name: course.instructor.name } : null,
+    verifiedReview: course.reviewStats.totalReviews > 0
+      ? {
+          average: course.reviewStats.avgRating,
+          count: course.reviewStats.totalReviews,
+        }
+      : null,
   }, { now: new Date() });
   const displayPrice = decisionFacts.price.effective;
   const courseReady = decisionFacts.readiness === 'ready';
   const instructorName = decisionFacts.evidence.instructorName;
+  const verifiedReview = decisionFacts.evidence.verifiedReview;
   const instructorAvatarUrl = normalizeUrl(course.instructor?.avatarUrl || null);
 
   const courseSectionItems = [
@@ -266,6 +277,7 @@ export default async function CourseDetailPage({ params }: Props) {
                     {totalSeconds > 0 && <div className="shrink-0 px-4 py-3"><dt className="text-muted-foreground">เวลาวิดีโอ</dt><dd className="mt-1 font-semibold">{durationText}</dd></div>}
                     {freePreviewCount > 0 && <div className="shrink-0 px-4 py-3"><dt className="text-muted-foreground">ทดลองเรียน</dt><dd className="mt-1 font-semibold">{freePreviewCount} บทฟรี</dd></div>}
                     {instructorName && <div className="shrink-0 px-4 py-3"><dt className="text-muted-foreground">ผู้สอน</dt><dd className="mt-1 font-semibold">{instructorName}</dd></div>}
+                    {verifiedReview && <div className="shrink-0 px-4 py-3"><dt className="text-muted-foreground">รีวิวผู้เรียน</dt><dd className="mt-1 font-semibold"><a href="#course-reviews" className="underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30">★ {verifiedReview.average.toFixed(1)} · {verifiedReview.count} รีวิว</a></dd></div>}
                   </dl>
                 </section>
               </div>
@@ -274,7 +286,7 @@ export default async function CourseDetailPage({ params }: Props) {
                 <Card className="overflow-hidden border-white/80 shadow-[var(--academy-shadow-float)] ring-1 ring-foreground/5">
                   <div className="relative bg-muted">
                     {normalizeUrl(course.thumbnailUrl) ? (
-                      <img src={normalizeUrl(course.thumbnailUrl)!} alt={course.title} className="aspect-video w-full object-cover" />
+                      <img src={normalizeUrl(course.thumbnailUrl)!} alt={course.title} width={1200} height={675} sizes="(min-width: 1024px) 40vw, 100vw" className="aspect-video w-full object-cover" />
                     ) : (
                       <div className="aspect-video overflow-hidden"><CourseArtwork title={course.title} slug={course.slug} tags={course.tags} /></div>
                     )}
@@ -344,7 +356,7 @@ export default async function CourseDetailPage({ params }: Props) {
                   <h2 className="text-3xl font-bold tracking-tight" id="course-instructor-title">รู้จักผู้สอน</h2>
                   <Card className="mt-6 border-border/80 shadow-[var(--academy-shadow-card)]"><CardContent className="flex items-center gap-5 p-6">
                     {instructorAvatarUrl ? (
-                      <img src={instructorAvatarUrl} alt="" className="size-16 rounded-2xl object-cover ring-4 ring-primary/10" />
+                      <img src={instructorAvatarUrl} alt="" width={64} height={64} className="size-16 rounded-2xl object-cover ring-4 ring-primary/10" />
                     ) : (
                       <span className="flex size-16 items-center justify-center rounded-2xl bg-primary text-xl font-bold text-primary-foreground ring-4 ring-primary/10" aria-hidden="true">{instructorName.charAt(0)}</span>
                     )}
@@ -360,8 +372,10 @@ export default async function CourseDetailPage({ params }: Props) {
             <Separator />
 
             <section id="course-reviews" className="scroll-mt-24" aria-labelledby="course-reviews-title">
-              <h2 id="course-reviews-title" className="sr-only">รีวิวผู้เรียน</h2>
-              <div className="mt-5"><CourseReviewsWrapper courseSlug={course.slug} /></div>
+              <h2 id="course-reviews-title" className="text-3xl font-bold tracking-tight">รีวิวจากผู้เรียน</h2>
+              <Suspense fallback={<div className="mt-5 h-24 animate-pulse rounded-2xl bg-muted motion-reduce:animate-none" role="status" aria-label="กำลังโหลดรีวิว" />}>
+                <CourseReviewsWrapper courseSlug={course.slug} />
+              </Suspense>
             </section>
 
             {courseReady && (

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,37 +1,39 @@
 import MainContent from '@/components/layout/MainContent';
 import PublicPageHeader from '@/components/layout/PublicPageHeader';
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import BundleCard from '@/components/bundle/BundleCard';
 import CourseCard from '@/components/course/CourseCard';
 import CourseCatalogFilters from '@/components/course/CourseCatalogFilters';
+import CourseCatalogPagination from '@/components/course/CourseCatalogPagination';
 import { FeedbackState } from '@/components/status/FeedbackState';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { db } from '@/lib/db';
-import { bundles, bundleCourses, courses, courseTags, lessons, tags, users } from '@/lib/db/schema';
+import { bundles, bundleCourses, courses, courseTags, lessons, reviews, tags, users } from '@/lib/db/schema';
 import {
   deriveBundleDecisionFacts,
   type BundleCourseDecisionSource,
   type BundleDecisionFacts,
 } from '@/lib/bundle-decision-facts';
 import { deriveCourseDecisionFacts, type CourseDecisionFacts } from '@/lib/course-decision-facts';
-import { and, asc, count, desc, eq, gt, like, sql } from 'drizzle-orm';
+import {
+  buildCourseCatalogHref,
+  clampCourseCatalogPage,
+  normalizeCourseCatalogQuery,
+  type CourseCatalogPrice,
+  type CourseCatalogQueryInput,
+  type CourseCatalogSort,
+} from '@/lib/course-catalog-query';
+import { and, asc, avg, count, desc, eq, like, sql } from 'drizzle-orm';
 
 export const revalidate = 300;
 
-type SearchParamsInput = {
-  search?: string | string[];
-  price?: string | string[];
-  tag?: string | string[];
-  sort?: string | string[];
-  page?: string | string[];
-};
-
 type Props = {
-  searchParams?: Promise<SearchParamsInput>;
+  searchParams?: Promise<CourseCatalogQueryInput>;
 };
 
 interface Tag {
@@ -61,23 +63,6 @@ function getSingleParam(value: string | string[] | undefined): string {
   return Array.isArray(value) ? value[0] ?? '' : value ?? '';
 }
 
-function buildCoursesQuery(params: {
-  search?: string;
-  price?: string;
-  tag?: string;
-  sort?: string;
-  page?: number;
-}) {
-  const query = new URLSearchParams();
-  if (params.search) query.set('search', params.search);
-  if (params.price && params.price !== 'all') query.set('price', params.price);
-  if (params.tag && params.tag !== 'all') query.set('tag', params.tag);
-  if (params.sort && params.sort !== 'newest') query.set('sort', params.sort);
-  if (params.page && params.page > 1) query.set('page', String(params.page));
-  const output = query.toString();
-  return output ? `/courses?${output}` : '/courses';
-}
-
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
   const resolved = searchParams ? await searchParams : {};
   const search = getSingleParam(resolved.search).trim();
@@ -98,7 +83,7 @@ async function getAllTags(): Promise<Tag[]> {
   return db.select({ id: tags.id, name: tags.name, slug: tags.slug }).from(tags).orderBy(tags.name);
 }
 
-async function getPublishedBundles(): Promise<BundleItem[]> {
+async function getPublishedBundles(now: Date): Promise<BundleItem[]> {
   const lessonStatsSubquery = db
     .select({
       courseId: lessons.courseId,
@@ -177,7 +162,6 @@ async function getPublishedBundles(): Promise<BundleItem[]> {
     bundleMap.set(row.id, existing);
   }
 
-  const now = new Date();
   return Array.from(bundleMap.values()).map((bundle) => ({
     id: bundle.id,
     title: bundle.title,
@@ -194,17 +178,25 @@ async function getCoursesData(input: {
   page: number;
   limit: number;
   search: string;
-  priceFilter: string;
+  priceFilter: CourseCatalogPrice;
   tagSlug: string;
-  sort: string;
+  sort: CourseCatalogSort;
+  now: Date;
 }) {
-  const { page, limit, search, priceFilter, tagSlug, sort } = input;
+  const { page, limit, search, priceFilter, tagSlug, sort, now } = input;
   const offset = (page - 1) * limit;
   const conditions = [eq(courses.status, 'published')];
+  const effectivePrice = sql<string>`CASE
+    WHEN ${courses.promoPrice} IS NOT NULL
+      AND (${courses.promoStartsAt} IS NULL OR ${courses.promoStartsAt} <= ${now})
+      AND (${courses.promoEndsAt} IS NULL OR ${courses.promoEndsAt} >= ${now})
+    THEN ${courses.promoPrice}
+    ELSE ${courses.price}
+  END`;
 
   if (search) conditions.push(like(courses.title, `%${search}%`));
-  if (priceFilter === 'free') conditions.push(eq(courses.price, '0'));
-  else if (priceFilter === 'paid') conditions.push(gt(courses.price, '0'));
+  if (priceFilter === 'free') conditions.push(sql`${effectivePrice} = 0`);
+  else if (priceFilter === 'paid') conditions.push(sql`${effectivePrice} > 0`);
 
   if (tagSlug !== 'all') {
     conditions.push(
@@ -222,10 +214,10 @@ async function getCoursesData(input: {
       orderBy = asc(courses.createdAt);
       break;
     case 'price-low':
-      orderBy = asc(courses.price);
+      orderBy = asc(effectivePrice);
       break;
     case 'price-high':
-      orderBy = desc(courses.price);
+      orderBy = desc(effectivePrice);
       break;
     default:
       orderBy = desc(courses.createdAt);
@@ -243,6 +235,16 @@ async function getCoursesData(input: {
     .from(lessons)
     .groupBy(lessons.courseId)
     .as('lesson_stats');
+  const reviewStatsSubquery = db
+    .select({
+      courseId: reviews.courseId,
+      averageRating: avg(reviews.rating).as('average_rating'),
+      reviewCount: count().as('review_count'),
+    })
+    .from(reviews)
+    .where(and(eq(reviews.isHidden, false), eq(reviews.isVerified, true)))
+    .groupBy(reviews.courseId)
+    .as('review_stats');
 
   const [courseRows, totalResult] = await Promise.all([
     db
@@ -262,12 +264,15 @@ async function getCoursesData(input: {
         lessonCount: sql<number>`COALESCE(${lessonStatsSubquery.lessonCount}, 0)`.as('lesson_count'),
         totalDurationSeconds: sql<number>`COALESCE(${lessonStatsSubquery.totalDurationSeconds}, 0)`.as('total_duration_seconds'),
         freePreviewCount: sql<number>`COALESCE(${lessonStatsSubquery.freePreviewCount}, 0)`.as('free_preview_count'),
+        averageRating: reviewStatsSubquery.averageRating,
+        reviewCount: sql<number>`COALESCE(${reviewStatsSubquery.reviewCount}, 0)`.as('review_count'),
       })
       .from(courses)
       .leftJoin(users, eq(courses.instructorId, users.id))
       .leftJoin(lessonStatsSubquery, eq(courses.id, lessonStatsSubquery.courseId))
+      .leftJoin(reviewStatsSubquery, eq(courses.id, reviewStatsSubquery.courseId))
       .where(whereCondition)
-      .orderBy(orderBy)
+      .orderBy(orderBy, asc(courses.id))
       .limit(limit)
       .offset(offset),
     db.select({ total: count() }).from(courses).where(whereCondition),
@@ -293,7 +298,6 @@ async function getCoursesData(input: {
     tagsByCourse.get(row.courseId)!.push({ id: row.tagId, name: row.tagName, slug: row.tagSlug });
   }
 
-  const now = new Date();
   const formattedCourses: CourseListItem[] = courseRows.map((row) => {
     const lessonCount = Number(row.lessonCount) || 0;
     const totalDurationSeconds = Number(row.totalDurationSeconds) || 0;
@@ -322,6 +326,9 @@ async function getCoursesData(input: {
         knownDurationSeconds: totalDurationSeconds,
         freePreviewCount,
         instructor,
+        verifiedReview: Number(row.reviewCount) > 0
+          ? { average: row.averageRating ?? 0, count: Number(row.reviewCount) }
+          : null,
       }, { now }),
       tags: tagsByCourse.get(row.id) || [],
     };
@@ -340,11 +347,48 @@ async function getCoursesData(input: {
 
 export default async function CoursesPage({ searchParams }: Props) {
   const resolved = searchParams ? await searchParams : {};
-  const search = getSingleParam(resolved.search).trim();
-  const priceFilter = getSingleParam(resolved.price) || 'all';
-  const tagFilter = getSingleParam(resolved.tag) || 'all';
-  const sort = getSingleParam(resolved.sort) || 'newest';
-  const currentPage = Math.max(1, parseInt(getSingleParam(resolved.page) || '1', 10) || 1);
+  const allTagsPromise = getAllTags();
+  const allTags = await allTagsPromise;
+  const normalized = normalizeCourseCatalogQuery(
+    resolved,
+    allTags.map((tag) => tag.slug),
+  );
+
+  if (!normalized.isCanonical) {
+    redirect(buildCourseCatalogHref(normalized.query));
+  }
+
+  const catalogHref = buildCourseCatalogHref(normalized.query);
+  const showBundles = catalogHref === '/courses';
+  const now = new Date();
+  const [coursesData, bundlesList] = await Promise.all([
+    getCoursesData({
+      page: normalized.query.page,
+      limit: 12,
+      search: normalized.query.search,
+      priceFilter: normalized.query.price,
+      tagSlug: normalized.query.tag,
+      sort: normalized.query.sort,
+      now,
+    }),
+    showBundles ? getPublishedBundles(now) : Promise.resolve([]),
+  ]);
+  const canonicalPage = clampCourseCatalogPage(
+    normalized.query.page,
+    coursesData.pagination.totalPages,
+  );
+
+  if (canonicalPage !== normalized.query.page) {
+    redirect(buildCourseCatalogHref(normalized.query, { page: canonicalPage }));
+  }
+
+  const {
+    search,
+    price: priceFilter,
+    tag: tagFilter,
+    sort,
+    page: currentPage,
+  } = normalized.query;
   const hasActiveFilters = Boolean(
     search
       || priceFilter !== 'all'
@@ -352,19 +396,12 @@ export default async function CoursesPage({ searchParams }: Props) {
       || sort !== 'newest'
       || currentPage > 1,
   );
-
-  const [coursesData, allTags, bundlesList] = await Promise.all([
-    getCoursesData({ page: currentPage, limit: 12, search, priceFilter, tagSlug: tagFilter, sort }),
-    getAllTags(),
-    getPublishedBundles(),
-  ]);
-
   const { courses: courseList, pagination } = coursesData;
 
   return (
     <>
       <Navbar />
-      <MainContent key={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort })} className="bg-[var(--academy-canvas)]">
+      <MainContent key={catalogHref} className="bg-[var(--academy-canvas)]">
         <PublicPageHeader
           title="เลือกคอร์สที่พาไปถึงงานชิ้นถัดไป"
           description="เปรียบเทียบหัวข้อ ราคา และบทเรียนที่เปิดให้ทดลอง แล้วเลือกจุดเริ่มต้นที่ตรงกับทักษะที่คุณอยากพัฒนาจริง"
@@ -401,13 +438,16 @@ export default async function CoursesPage({ searchParams }: Props) {
             ) : (
               <>
                 <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">{courseList.map((course) => <CourseCard key={course.id} id={course.id} title={course.title} slug={course.slug} description={course.description} thumbnailUrl={course.thumbnailUrl} decisionFacts={course.decisionFacts} tags={course.tags} />)}</div>
-                {pagination.totalPages > 1 ? <nav className="mt-10 flex flex-wrap items-center justify-center gap-2" aria-label="หน้ารายการคอร์ส">{currentPage > 1 ? <Button variant="outline" asChild><Link href={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort, page: currentPage - 1 })}>← ก่อนหน้า</Link></Button> : null}{Array.from({ length: Math.min(5, pagination.totalPages) }, (_, index) => { let pageNumber; if (pagination.totalPages <= 5) pageNumber = index + 1; else if (currentPage <= 3) pageNumber = index + 1; else if (currentPage >= pagination.totalPages - 2) pageNumber = pagination.totalPages - 4 + index; else pageNumber = currentPage - 2 + index; const isActive = currentPage === pageNumber; return <Button key={pageNumber} variant={isActive ? 'default' : 'outline'} size="icon-sm" asChild><Link href={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort, page: pageNumber })} aria-current={isActive ? 'page' : undefined}>{pageNumber}</Link></Button>; })}{currentPage < pagination.totalPages ? <Button variant="outline" asChild><Link href={buildCoursesQuery({ search, price: priceFilter, tag: tagFilter, sort, page: currentPage + 1 })}>ถัดไป →</Link></Button> : null}</nav> : null}
+                <CourseCatalogPagination
+                  query={normalized.query}
+                  totalPages={pagination.totalPages}
+                />
               </>
             )}
           </div>
         </section>
 
-        {bundlesList.length > 0 ? (
+        {showBundles && bundlesList.length > 0 ? (
           <section className="border-t bg-background py-14 sm:py-20" aria-labelledby="courses-bundles-title">
             <div className="container">
               <header className="mb-8 grid gap-4 md:grid-cols-[1fr_auto] md:items-end"><div><h2 id="courses-bundles-title" className="text-3xl font-semibold tracking-[-.03em] sm:text-4xl">ถ้าอยากเรียนต่อเนื่อง ลองดูแบบชุด</h2><p className="mt-2 text-sm leading-6 text-muted-foreground">รวมคอร์สที่ต่อเนื่องกันไว้ในเส้นทางเดียว พร้อมราคาที่เปรียบเทียบได้ชัดเจน</p></div><Badge variant="secondary">{bundlesList.length} เส้นทาง</Badge></header>

--- a/src/components/course/CourseCard.tsx
+++ b/src/components/course/CourseCard.tsx
@@ -57,7 +57,7 @@ export default function CourseCard({
       <Card className="h-full gap-0 overflow-hidden py-0 transition-[transform,box-shadow] duration-200 group-hover:-translate-y-1 group-hover:shadow-[var(--academy-shadow-card-hover)] motion-reduce:transform-none">
         <div className="relative aspect-[16/9] overflow-hidden bg-[var(--academy-navy)] md:aspect-auto md:min-h-52">
           {thumbnailUrl
-            ? <img src={thumbnailUrl} alt={title} loading="lazy" decoding="async" className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03] motion-reduce:transform-none" />
+            ? <img src={thumbnailUrl} alt={title} width={640} height={360} sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 100vw" loading="lazy" decoding="async" className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03] motion-reduce:transform-none" />
             : <CourseArtwork title={title} slug={slug} tags={tags} />}
           <div className="absolute top-4 left-4 flex flex-col items-start gap-2">
             {decisionFacts.readiness === 'preparing' ? <Badge variant="secondary">กำลังเตรียมเนื้อหา</Badge> : null}

--- a/src/components/course/CourseCatalogFilters.tsx
+++ b/src/components/course/CourseCatalogFilters.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Banknote, ListFilter, Search, SlidersHorizontal, Tag, X } from 'lucide-react';
+import { Banknote, Search, SlidersHorizontal, Tag, X } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -18,6 +18,12 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
+import {
+  buildCourseCatalogHref,
+  type CourseCatalogPrice,
+  type CourseCatalogQuery,
+  type CourseCatalogSort,
+} from '@/lib/course-catalog-query';
 
 interface CatalogTag {
   id: string;
@@ -28,9 +34,9 @@ interface CatalogTag {
 interface CourseCatalogFiltersProps {
   tags: CatalogTag[];
   search: string;
-  priceFilter: string;
+  priceFilter: CourseCatalogPrice;
   tagFilter: string;
-  sort: string;
+  sort: CourseCatalogSort;
   totalCourses: number;
   hasActiveFilters: boolean;
 }
@@ -62,8 +68,14 @@ export default function CourseCatalogFilters({
     Boolean(search),
     priceFilter !== 'all',
     tagFilter !== 'all',
-    sort !== 'newest',
   ].filter(Boolean).length;
+  const query: CourseCatalogQuery = {
+    search,
+    price: priceFilter,
+    tag: tagFilter,
+    sort,
+    page: 1,
+  };
 
   const renderFields = (idPrefix: string, mobile = false) => (
     <form
@@ -183,15 +195,49 @@ export default function CourseCatalogFilters({
           ) : null}
         </div>
 
-        {activeFilterCount > 0 ? (
-          <div className="flex gap-2 overflow-x-auto pb-1" aria-label="ตัวกรองที่เลือก">
-            {search ? <Badge variant="secondary" className="shrink-0"><Search aria-hidden="true" />“{search}”</Badge> : null}
-            {priceFilter !== 'all' ? <Badge variant="secondary" className="shrink-0"><Banknote aria-hidden="true" />{PRICE_LABELS[priceFilter]}</Badge> : null}
-            {tagFilter !== 'all' ? <Badge variant="secondary" className="shrink-0"><Tag aria-hidden="true" />{selectedTag ?? tagFilter}</Badge> : null}
-            {sort !== 'newest' ? <Badge variant="secondary" className="shrink-0"><ListFilter aria-hidden="true" />{SORT_LABELS[sort]}</Badge> : null}
-          </div>
-        ) : null}
       </div>
+
+      {activeFilterCount > 0 ? (
+        <div className={'mt-4 flex flex-wrap items-center gap-2'} aria-label={'ตัวกรองที่เลือก'}>
+          <span className={'mr-1 text-xs font-medium text-muted-foreground'}>กำลังกรองด้วย</span>
+          {search ? (
+            <Badge asChild variant={'secondary'}>
+              <Link
+                href={buildCourseCatalogHref(query, { search: '', page: 1 })}
+                aria-label={`ลบคำค้น ${search}`}
+              >
+                <Search data-icon={'inline-start'} aria-hidden={'true'} />
+                “{search}”
+                <X data-icon={'inline-end'} aria-hidden={'true'} />
+              </Link>
+            </Badge>
+          ) : null}
+          {priceFilter !== 'all' ? (
+            <Badge asChild variant={'secondary'}>
+              <Link
+                href={buildCourseCatalogHref(query, { price: 'all', page: 1 })}
+                aria-label={`ลบตัวกรองราคา ${PRICE_LABELS[priceFilter]}`}
+              >
+                <Banknote data-icon={'inline-start'} aria-hidden={'true'} />
+                {PRICE_LABELS[priceFilter]}
+                <X data-icon={'inline-end'} aria-hidden={'true'} />
+              </Link>
+            </Badge>
+          ) : null}
+          {tagFilter !== 'all' ? (
+            <Badge asChild variant={'secondary'}>
+              <Link
+                href={buildCourseCatalogHref(query, { tag: 'all', page: 1 })}
+                aria-label={`ลบตัวกรองหัวข้อ ${selectedTag ?? tagFilter}`}
+              >
+                <Tag data-icon={'inline-start'} aria-hidden={'true'} />
+                {selectedTag ?? tagFilter}
+                <X data-icon={'inline-end'} aria-hidden={'true'} />
+              </Link>
+            </Badge>
+          ) : null}
+        </div>
+      ) : null}
     </aside>
   );
 }

--- a/src/components/course/CourseCatalogPagination.tsx
+++ b/src/components/course/CourseCatalogPagination.tsx
@@ -1,0 +1,70 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+import {
+  buildCourseCatalogHref,
+  getCourseCatalogPageItems,
+  type CourseCatalogQuery,
+} from '@/lib/course-catalog-query';
+
+interface CourseCatalogPaginationProps {
+  query: CourseCatalogQuery;
+  totalPages: number;
+}
+
+export default function CourseCatalogPagination({
+  query,
+  totalPages,
+}: CourseCatalogPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const pageItems = getCourseCatalogPageItems(query.page, totalPages);
+
+  return (
+    <Pagination className="mt-10" aria-label="หน้ารายการคอร์ส">
+      <PaginationContent className="flex-wrap justify-center">
+        {query.page > 1 ? (
+          <PaginationItem>
+            <PaginationPrevious
+              href={buildCourseCatalogHref(query, { page: query.page - 1 })}
+              text="ก่อนหน้า"
+              aria-label="ไปหน้าก่อนหน้า"
+            />
+          </PaginationItem>
+        ) : null}
+
+        {pageItems.map((item) => (
+          <PaginationItem key={item}>
+            {typeof item === 'number' ? (
+              <PaginationLink
+                href={buildCourseCatalogHref(query, { page: item })}
+                isActive={item === query.page}
+                aria-label={String(item)}
+              >
+                {item}
+              </PaginationLink>
+            ) : (
+              <PaginationEllipsis />
+            )}
+          </PaginationItem>
+        ))}
+
+        {query.page < totalPages ? (
+          <PaginationItem>
+            <PaginationNext
+              href={buildCourseCatalogHref(query, { page: query.page + 1 })}
+              text="ถัดไป"
+              aria-label="ไปหน้าถัดไป"
+            />
+          </PaginationItem>
+        ) : null}
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/src/components/course/CourseReviews.tsx
+++ b/src/components/course/CourseReviews.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { MessageSquare, Star } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -16,6 +17,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Spinner } from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import {
+  buildCourseReviewHref,
+  normalizeCourseReviewQuery,
+  type CourseReviewQuery,
+  type CourseReviewSort,
+} from '@/lib/course-review-query';
 import { cn } from '@/lib/utils';
 
 interface Review {
@@ -90,13 +97,23 @@ function ReviewBar({ count, total }: { count: number; total: number }) {
 }
 
 export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const reviewSortParam = searchParams.get('reviewSort') ?? undefined;
+  const reviewRatingParam = searchParams.get('reviewRating') ?? undefined;
+  const reviewPageParam = searchParams.get('reviewPage') ?? undefined;
+  const normalized = useMemo(() => normalizeCourseReviewQuery({
+    reviewSort: reviewSortParam,
+    reviewRating: reviewRatingParam,
+    reviewPage: reviewPageParam,
+  }), [reviewPageParam, reviewRatingParam, reviewSortParam]);
+  const { sort, rating: filterRating, page: currentPage } = normalized.query;
   const [reviews, setReviews] = useState<Review[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
   const [pagination, setPagination] = useState<Pagination | null>(null);
   const [loading, setLoading] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [sort, setSort] = useState('latest');
-  const [filterRating, setFilterRating] = useState<number | null>(null);
+  const [fetchError, setFetchError] = useState('');
 
   // Form
   const [showForm, setShowForm] = useState(false);
@@ -106,30 +123,50 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
   const [submitError, setSubmitError] = useState('');
   const [submitSuccess, setSubmitSuccess] = useState(false);
 
-  const fetchReviews = async () => {
+  const updateReviewQuery = useCallback((overrides: Partial<CourseReviewQuery>) => {
+    router.push(
+      buildCourseReviewHref(pathname, searchParams, normalized.query, overrides),
+      { scroll: false },
+    );
+  }, [normalized.query, pathname, router, searchParams]);
+
+  const fetchReviews = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
+    setFetchError('');
     try {
       const params = new URLSearchParams({
         page: currentPage.toString(),
         sort,
         ...(filterRating ? { rating: filterRating.toString() } : {}),
       });
-      const res = await fetch(`/api/courses/${courseSlug}/reviews?${params}`);
+      const res = await fetch(`/api/courses/${courseSlug}/reviews?${params}`, { signal });
+      if (!res.ok) throw new Error('Review request failed');
       const data = await res.json();
       setReviews(data.reviews || []);
       setStats(data.stats || null);
       setPagination(data.pagination || null);
     } catch (error) {
-      console.error('Error fetching reviews:', error);
+      if (signal?.aborted || (error instanceof DOMException && error.name === 'AbortError')) return;
+      setFetchError('ไม่สามารถโหลดรีวิวได้ในขณะนี้');
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) setLoading(false);
     }
-  };
+  }, [courseSlug, currentPage, filterRating, sort]);
 
   useEffect(() => {
-    fetchReviews();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPage, sort, filterRating]);
+    const controller = new AbortController();
+    void fetchReviews(controller.signal);
+    return () => controller.abort();
+  }, [fetchReviews]);
+
+  useEffect(() => {
+    if (!normalized.isCanonical) {
+      router.replace(
+        buildCourseReviewHref(pathname, searchParams, normalized.query),
+        { scroll: false },
+      );
+    }
+  }, [normalized.isCanonical, normalized.query, pathname, router, searchParams]);
 
   const handleSubmit = async () => {
     if (formRating === 0) {
@@ -153,8 +190,11 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
       setShowForm(false);
       setFormRating(0);
       setFormComment('');
-      setCurrentPage(1);
-      await fetchReviews();
+      if (currentPage === 1) {
+        await fetchReviews();
+      } else {
+        updateReviewQuery({ page: 1 });
+      }
     } catch {
       setSubmitError('เกิดข้อผิดพลาด กรุณาลองใหม่');
     } finally {
@@ -171,11 +211,7 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
   };
 
   return (
-    <section className="mt-8" aria-labelledby="course-reviews-title">
-      <h2 className="mb-5 text-2xl font-bold tracking-tight" id="course-reviews-title">
-        รีวิวจากผู้เรียน
-      </h2>
-
+    <div className="mt-5">
       {/* Stats Summary */}
       {stats && stats.totalReviews > 0 && (
         <Card className="mb-6">
@@ -196,7 +232,10 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
                   type="button"
                   variant="ghost"
                   size="sm"
-                  onClick={() => setFilterRating(filterRating === star ? null : star)}
+                  onClick={() => updateReviewQuery({
+                    rating: filterRating === star ? null : star,
+                    page: 1,
+                  })}
                   className="grid h-auto grid-cols-[1rem_1rem_minmax(0,1fr)_2rem] justify-normal gap-2"
                   data-muted={Boolean(filterRating && filterRating !== star)}
                   aria-pressed={filterRating === star}
@@ -217,7 +256,10 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
         <div className="flex flex-wrap gap-2">
           <NativeSelect
             value={sort}
-            onChange={(e) => { setSort(e.target.value); setCurrentPage(1); }}
+            onChange={(event) => updateReviewQuery({
+              sort: event.target.value as CourseReviewSort,
+              page: 1,
+            })}
             aria-label="เรียงรีวิว"
           >
             <NativeSelectOption value="latest">ล่าสุด</NativeSelectOption>
@@ -229,7 +271,7 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
               type="button"
               variant="ghost"
               size="sm"
-              onClick={() => setFilterRating(null)}
+              onClick={() => updateReviewQuery({ rating: null, page: 1 })}
             >
               ล้างตัวกรอง ({filterRating} ดาว) ✕
             </Button>
@@ -309,6 +351,16 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
         <div className="grid gap-3" role="status" aria-label="กำลังโหลดรีวิว">
           <Skeleton className="h-24 w-full" /><Skeleton className="h-24 w-full" />
         </div>
+      ) : fetchError ? (
+        <Alert variant="destructive">
+          <AlertTitle>โหลดรีวิวไม่สำเร็จ</AlertTitle>
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+            <span>{fetchError}</span>
+            <Button type="button" variant="outline" size="sm" onClick={() => void fetchReviews()}>
+              ลองโหลดรีวิวอีกครั้ง
+            </Button>
+          </AlertDescription>
+        </Alert>
       ) : reviews.length === 0 ? (
         <Empty className="border">
           <EmptyHeader>
@@ -368,7 +420,7 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                onClick={() => updateReviewQuery({ page: Math.max(1, currentPage - 1) })}
                 disabled={currentPage === 1}
               >
                 ก่อนหน้า
@@ -384,7 +436,9 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => setCurrentPage(p => Math.min(pagination.totalPages, p + 1))}
+                onClick={() => updateReviewQuery({
+                  page: Math.min(pagination.totalPages, currentPage + 1),
+                })}
                 disabled={currentPage === pagination.totalPages}
               >
                 ถัดไป
@@ -393,6 +447,6 @@ export default function CourseReviews({ courseSlug, isEnrolled }: CourseReviewsP
           </PaginationContent>
         </Pagination>
       )}
-    </section>
+    </div>
   );
 }

--- a/src/components/course/CourseSectionNav.tsx
+++ b/src/components/course/CourseSectionNav.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 
 interface CourseSectionItem {
   id: string;
@@ -20,6 +19,8 @@ export default function CourseSectionNav({ items }: CourseSectionNavProps) {
     const sections = items
       .map((item) => document.getElementById(item.id))
       .filter((section): section is HTMLElement => Boolean(section));
+
+    if (!('IntersectionObserver' in window)) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -49,15 +50,32 @@ export default function CourseSectionNav({ items }: CourseSectionNavProps) {
 
   return (
     <nav className="sticky top-[4.25rem] z-30 bg-background/92 backdrop-blur-xl supports-backdrop-filter:bg-background/80" aria-label="ส่วนต่าง ๆ ของคอร์ส">
-      <Tabs value={activeSection} onValueChange={navigateToSection} className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-        <TabsList variant="line" className="grid h-14 w-full grid-cols-4 rounded-none p-0 group-data-horizontal/tabs:h-14">
+      <div className="mx-auto max-w-5xl overflow-x-auto px-4 [scrollbar-width:none] sm:px-6 lg:px-8 [&::-webkit-scrollbar]:hidden">
+        <div
+          className="grid h-14 min-w-max"
+          style={{ gridTemplateColumns: `repeat(${items.length}, minmax(0, 1fr))` }}
+        >
           {items.map((item) => (
-            <TabsTrigger key={item.id} value={item.id} className="h-14 min-w-0 px-1 text-xs data-active:text-primary group-data-horizontal/tabs:after:inset-x-auto group-data-horizontal/tabs:after:bottom-0 group-data-horizontal/tabs:after:left-[calc(50%-1rem)] after:w-8 after:rounded-full after:bg-primary sm:px-3 sm:text-sm">
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              aria-current={activeSection === item.id ? 'location' : undefined}
+              onClick={(event) => {
+                event.preventDefault();
+                navigateToSection(item.id);
+              }}
+              className={cn(
+                'relative inline-flex h-14 min-w-28 items-center justify-center px-3 text-center text-xs font-medium whitespace-nowrap text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30 motion-reduce:transition-none sm:min-w-0 sm:text-sm',
+                activeSection === item.id
+                  ? 'text-primary after:absolute after:inset-x-[calc(50%-1rem)] after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
+                  : null,
+              )}
+            >
               {item.label}
-            </TabsTrigger>
+            </a>
           ))}
-        </TabsList>
-      </Tabs>
+        </div>
+      </div>
     </nav>
   );
 }

--- a/src/lib/course-catalog-query.ts
+++ b/src/lib/course-catalog-query.ts
@@ -1,0 +1,117 @@
+export const COURSE_CATALOG_PRICES = ['all', 'free', 'paid'] as const;
+export const COURSE_CATALOG_SORTS = ['newest', 'oldest', 'price-low', 'price-high'] as const;
+
+export type CourseCatalogPrice = (typeof COURSE_CATALOG_PRICES)[number];
+export type CourseCatalogSort = (typeof COURSE_CATALOG_SORTS)[number];
+
+export type CourseCatalogQuery = {
+  search: string;
+  price: CourseCatalogPrice;
+  tag: string;
+  sort: CourseCatalogSort;
+  page: number;
+};
+
+export type CourseCatalogQueryInput = Record<string, string | string[] | undefined>;
+export type CourseCatalogPageItem = number | 'start-ellipsis' | 'end-ellipsis';
+
+const DEFAULT_QUERY: CourseCatalogQuery = {
+  search: '',
+  price: 'all',
+  tag: 'all',
+  sort: 'newest',
+  page: 1,
+};
+
+function singleValue(value: string | string[] | undefined): string {
+  return typeof value === 'string' ? value : Array.isArray(value) ? value[0] ?? '' : '';
+}
+
+function isOneOf<T extends string>(value: string, values: readonly T[]): value is T {
+  return values.includes(value as T);
+}
+
+function parsePage(value: string): number {
+  if (!/^[1-9]\d*$/.test(value)) return 1;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : 1;
+}
+
+function canonicalEntries(query: CourseCatalogQuery): Record<string, string> {
+  return Object.fromEntries(
+    new URL(buildCourseCatalogHref(query), 'https://milerdev.local').searchParams.entries(),
+  );
+}
+
+export function normalizeCourseCatalogQuery(
+  input: CourseCatalogQueryInput,
+  validTagSlugs: Iterable<string>,
+): { query: CourseCatalogQuery; isCanonical: boolean } {
+  const validTags = new Set(validTagSlugs);
+  const rawSearch = singleValue(input.search);
+  const rawPrice = singleValue(input.price);
+  const rawTag = singleValue(input.tag);
+  const rawSort = singleValue(input.sort);
+  const rawPage = singleValue(input.page);
+
+  const query: CourseCatalogQuery = {
+    search: rawSearch.trim(),
+    price: isOneOf(rawPrice, COURSE_CATALOG_PRICES) ? rawPrice : DEFAULT_QUERY.price,
+    tag: rawTag === 'all' || validTags.has(rawTag) ? rawTag : DEFAULT_QUERY.tag,
+    sort: isOneOf(rawSort, COURSE_CATALOG_SORTS) ? rawSort : DEFAULT_QUERY.sort,
+    page: parsePage(rawPage),
+  };
+
+  if (!rawPrice) query.price = DEFAULT_QUERY.price;
+  if (!rawTag) query.tag = DEFAULT_QUERY.tag;
+  if (!rawSort) query.sort = DEFAULT_QUERY.sort;
+  if (!rawPage) query.page = DEFAULT_QUERY.page;
+
+  const expected = canonicalEntries(query);
+  const actualKeys = Object.keys(input).filter((key) => input[key] !== undefined);
+  const isCanonical = actualKeys.length === Object.keys(expected).length
+    && actualKeys.every((key) => (
+      Object.hasOwn(expected, key)
+      && typeof input[key] === 'string'
+      && input[key] === expected[key]
+    ));
+
+  return { query, isCanonical };
+}
+
+export function buildCourseCatalogHref(
+  query: CourseCatalogQuery,
+  overrides: Partial<CourseCatalogQuery> = {},
+): string {
+  const nextQuery = { ...query, ...overrides };
+  const params = new URLSearchParams();
+
+  if (nextQuery.search) params.set('search', nextQuery.search);
+  if (nextQuery.price !== DEFAULT_QUERY.price) params.set('price', nextQuery.price);
+  if (nextQuery.tag !== DEFAULT_QUERY.tag) params.set('tag', nextQuery.tag);
+  if (nextQuery.sort !== DEFAULT_QUERY.sort) params.set('sort', nextQuery.sort);
+  if (nextQuery.page > DEFAULT_QUERY.page) params.set('page', String(nextQuery.page));
+
+  const search = params.toString();
+  return search ? `/courses?${search}` : '/courses';
+}
+
+export function clampCourseCatalogPage(page: number, totalPages: number): number {
+  return Math.min(Math.max(1, page), Math.max(1, totalPages));
+}
+
+export function getCourseCatalogPageItems(
+  currentPage: number,
+  totalPages: number,
+): CourseCatalogPageItem[] {
+  if (totalPages <= 0) return [];
+  if (totalPages <= 7) return Array.from({ length: totalPages }, (_, index) => index + 1);
+
+  const page = clampCourseCatalogPage(currentPage, totalPages);
+  if (page <= 4) return [1, 2, 3, 4, 5, 'end-ellipsis', totalPages];
+  if (page >= totalPages - 3) {
+    return [1, 'start-ellipsis', totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+  }
+
+  return [1, 'start-ellipsis', page - 1, page, page + 1, 'end-ellipsis', totalPages];
+}

--- a/src/lib/course-review-query.ts
+++ b/src/lib/course-review-query.ts
@@ -1,0 +1,70 @@
+export const COURSE_REVIEW_SORTS = ['latest', 'highest', 'lowest'] as const;
+
+export type CourseReviewSort = (typeof COURSE_REVIEW_SORTS)[number];
+
+export type CourseReviewQuery = {
+  sort: CourseReviewSort;
+  rating: number | null;
+  page: number;
+};
+
+export type CourseReviewQueryInput = {
+  reviewSort?: string | string[];
+  reviewRating?: string | string[];
+  reviewPage?: string | string[];
+};
+
+function scalar(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? undefined : value;
+}
+
+export function normalizeCourseReviewQuery(input: CourseReviewQueryInput): {
+  query: CourseReviewQuery;
+  isCanonical: boolean;
+} {
+  const sortValue = scalar(input.reviewSort);
+  const ratingValue = scalar(input.reviewRating);
+  const pageValue = scalar(input.reviewPage);
+  const sort = COURSE_REVIEW_SORTS.includes(sortValue as CourseReviewSort)
+    ? sortValue as CourseReviewSort
+    : 'latest';
+  const parsedRating = ratingValue === undefined ? null : Number(ratingValue);
+  const rating = parsedRating !== null
+    && Number.isInteger(parsedRating)
+    && parsedRating >= 1
+    && parsedRating <= 5
+    ? parsedRating
+    : null;
+  const parsedPage = pageValue === undefined ? 1 : Number(pageValue);
+  const page = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
+  const hasArray = Object.values(input).some(Array.isArray);
+  const isCanonical = !hasArray
+    && (sortValue === undefined || (sortValue === sort && sort !== 'latest'))
+    && (ratingValue === undefined || (rating !== null && ratingValue === String(rating)))
+    && (pageValue === undefined || (pageValue === String(page) && page > 1));
+
+  return { query: { sort, rating, page }, isCanonical };
+}
+
+type SearchParamsSource = Pick<URLSearchParams, 'toString'>;
+
+export function buildCourseReviewHref(
+  pathname: string,
+  current: SearchParamsSource,
+  query: CourseReviewQuery,
+  overrides: Partial<CourseReviewQuery> = {},
+): string {
+  const next = { ...query, ...overrides };
+  const params = new URLSearchParams(current.toString());
+
+  params.delete('reviewSort');
+  params.delete('reviewRating');
+  params.delete('reviewPage');
+
+  if (next.sort !== 'latest') params.set('reviewSort', next.sort);
+  if (next.rating !== null) params.set('reviewRating', String(next.rating));
+  if (next.page > 1) params.set('reviewPage', String(next.page));
+
+  const search = params.toString();
+  return `${pathname}${search ? `?${search}` : ''}#course-reviews`;
+}

--- a/src/lib/course-review-stats.ts
+++ b/src/lib/course-review-stats.ts
@@ -1,0 +1,66 @@
+import { and, avg, count, eq, sql } from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import { reviews } from '@/lib/db/schema';
+
+export type CourseReviewStats = {
+  avgRating: number;
+  totalReviews: number;
+  distribution: Record<1 | 2 | 3 | 4 | 5, number>;
+};
+
+type CourseReviewStatsRow = {
+  avgRating: number | string | null;
+  totalReviews: number | string | null;
+  star5: number | string | null;
+  star4: number | string | null;
+  star3: number | string | null;
+  star2: number | string | null;
+  star1: number | string | null;
+};
+
+function countValue(value: number | string | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+}
+
+export function normalizeCourseReviewStats(
+  row: CourseReviewStatsRow | undefined,
+): CourseReviewStats {
+  const average = Number(row?.avgRating ?? 0);
+
+  return {
+    avgRating: Number.isFinite(average) && average >= 1 && average <= 5 ? average : 0,
+    totalReviews: countValue(row?.totalReviews),
+    distribution: {
+      5: countValue(row?.star5),
+      4: countValue(row?.star4),
+      3: countValue(row?.star3),
+      2: countValue(row?.star2),
+      1: countValue(row?.star1),
+    },
+  };
+}
+
+export async function getCourseReviewStats(
+  courseId: string,
+): Promise<CourseReviewStats> {
+  const [row] = await db
+    .select({
+      avgRating: avg(reviews.rating),
+      totalReviews: count(),
+      star5: sql<number>`sum(case when ${reviews.rating} = 5 then 1 else 0 end)`,
+      star4: sql<number>`sum(case when ${reviews.rating} = 4 then 1 else 0 end)`,
+      star3: sql<number>`sum(case when ${reviews.rating} = 3 then 1 else 0 end)`,
+      star2: sql<number>`sum(case when ${reviews.rating} = 2 then 1 else 0 end)`,
+      star1: sql<number>`sum(case when ${reviews.rating} = 1 then 1 else 0 end)`,
+    })
+    .from(reviews)
+    .where(and(
+      eq(reviews.courseId, courseId),
+      eq(reviews.isHidden, false),
+      eq(reviews.isVerified, true),
+    ));
+
+  return normalizeCourseReviewStats(row);
+}

--- a/tests/components/course-card.test.tsx
+++ b/tests/components/course-card.test.tsx
@@ -74,6 +74,16 @@ describe('shared Home and Catalog CourseCard decision evidence', () => {
     expect(html).not.toContain('<img');
   });
 
+  it('reserves responsive geometry for a real course thumbnail', () => {
+    const html = renderToStaticMarkup(
+      <CourseCard {...baseProps} thumbnailUrl="https://cdn.example.com/course.webp" />,
+    );
+
+    expect(html).toContain('width="640"');
+    expect(html).toContain('height="360"');
+    expect(html).toContain('sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 100vw"');
+  });
+
   it('keeps the regular price in the card footer instead of covering the thumbnail', () => {
     const html = renderToStaticMarkup(<CourseCard {...baseProps} />);
 

--- a/tests/components/course-catalog-filters.test.tsx
+++ b/tests/components/course-catalog-filters.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import CourseCatalogFilters from '@/components/course/CourseCatalogFilters';
+
+describe('Course catalog filter presentation', () => {
+  it('renders removable facets that preserve the other URL-backed state and exclude sort', () => {
+    const html = renderToStaticMarkup(
+      <CourseCatalogFilters
+        tags={[{ id: 'tag-1', name: 'Frontend', slug: 'frontend' }]}
+        search={'React'}
+        priceFilter={'free'}
+        tagFilter={'frontend'}
+        sort={'price-low'}
+        totalCourses={4}
+        hasActiveFilters
+      />,
+    );
+
+    expect(html).toMatch(/aria-label=.ลบคำค้น React./);
+    expect(html).toMatch(/href=.\/courses\?price=free&amp;tag=frontend&amp;sort=price-low./);
+    expect(html).toMatch(/aria-label=.ลบตัวกรองราคา ฟรี./);
+    expect(html).toMatch(/href=.\/courses\?search=React&amp;tag=frontend&amp;sort=price-low./);
+    expect(html).toMatch(/aria-label=.ลบตัวกรองหัวข้อ Frontend./);
+    expect(html).toMatch(/href=.\/courses\?search=React&amp;price=free&amp;sort=price-low./);
+    expect(html.match(/aria-label=.ลบ/g)).toHaveLength(3);
+    expect(html).toContain('ราคาต่ำไปสูง');
+  });
+});

--- a/tests/components/course-catalog-pagination.test.tsx
+++ b/tests/components/course-catalog-pagination.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CourseCatalogPagination from '@/components/course/CourseCatalogPagination';
+
+describe('CourseCatalogPagination', () => {
+  it('renders shared pagination controls while preserving normalized facets', () => {
+    render(
+      <CourseCatalogPagination
+        query={{
+          search: 'React',
+          price: 'paid',
+          tag: 'frontend',
+          sort: 'price-low',
+          page: 6,
+        }}
+        totalPages={12}
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'หน้ารายการคอร์ส' }).getAttribute('data-slot'),
+    ).toBe('pagination');
+    expect(screen.getByRole('link', { name: '6' }).getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('link', { name: '7' }).getAttribute('href')).toBe(
+      '/courses?search=React&price=paid&tag=frontend&sort=price-low&page=7',
+    );
+    expect(screen.getAllByText('More pages')).toHaveLength(2);
+  });
+});

--- a/tests/components/course-reviews.test.tsx
+++ b/tests/components/course-reviews.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CourseReviews from '@/components/course/CourseReviews';
+
+const navigationMocks = vi.hoisted(() => ({
+  pathname: '/courses/typescript',
+  query: '',
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigationMocks.pathname,
+  useRouter: () => ({ push: navigationMocks.push, replace: navigationMocks.replace }),
+  useSearchParams: () => new URLSearchParams(navigationMocks.query),
+}));
+
+const emptyReviewResponse = {
+  reviews: [],
+  stats: { avgRating: 0, totalReviews: 0, distribution: {} },
+  pagination: { page: 3, limit: 10, total: 0, totalPages: 0 },
+};
+
+describe('CourseReviews', () => {
+  beforeEach(() => {
+    navigationMocks.query = 'reviewSort=lowest&reviewRating=2&reviewPage=3';
+    navigationMocks.push.mockReset();
+    navigationMocks.replace.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('loads namespaced review state from the URL', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(emptyReviewResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(<CourseReviews courseSlug="typescript" isEnrolled={false} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      '/api/courses/typescript/reviews?page=3&sort=lowest&rating=2',
+    );
+  });
+
+  it('shows a retryable error instead of interpreting a failed request as empty', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'failed' }), { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(emptyReviewResponse), { status: 200 }));
+
+    render(<CourseReviews courseSlug="typescript" isEnrolled={false} />);
+
+    const retry = await screen.findByRole('button', { name: 'ลองโหลดรีวิวอีกครั้ง' });
+    expect(screen.queryByText('ยังไม่มีรีวิว')).toBeNull();
+    fireEvent.click(retry);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('adds user-selected review state to browser history and resets the page', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(emptyReviewResponse), { status: 200 }),
+    );
+
+    render(<CourseReviews courseSlug="typescript" isEnrolled={false} />);
+    await screen.findByText('ไม่พบรีวิวที่ตรงกับตัวกรอง');
+    fireEvent.change(screen.getByRole('combobox', { name: 'เรียงรีวิว' }), {
+      target: { value: 'highest' },
+    });
+
+    expect(navigationMocks.push).toHaveBeenCalledWith(
+      '/courses/typescript?reviewSort=highest&reviewRating=2#course-reviews',
+      { scroll: false },
+    );
+  });
+
+  it('reloads from restored URL state after browser navigation', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(emptyReviewResponse), { status: 200 }),
+    );
+    const { rerender } = render(
+      <CourseReviews courseSlug="typescript" isEnrolled={false} />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    navigationMocks.query = 'reviewSort=highest&reviewPage=2';
+    rerender(<CourseReviews courseSlug="typescript" isEnrolled={false} />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(String(fetchMock.mock.calls[1][0])).toBe(
+      '/api/courses/typescript/reviews?page=2&sort=highest',
+    );
+  });
+});

--- a/tests/components/course-section-nav.test.tsx
+++ b/tests/components/course-section-nav.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CourseSectionNav from '@/components/course/CourseSectionNav';
+
+describe('CourseSectionNav', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/courses/typescript');
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: true }),
+    });
+    window.scrollTo = vi.fn();
+  });
+
+  it('uses anchor navigation for the dynamic list of course sections', () => {
+    const html = renderToStaticMarkup(
+      <CourseSectionNav
+        items={[
+          { id: 'course-overview', label: 'รายละเอียดคอร์ส' },
+          { id: 'course-curriculum', label: 'เนื้อหาคอร์ส' },
+          { id: 'course-reviews', label: 'รีวิวผู้เรียน' },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('href="#course-overview"');
+    expect(html).toContain('href="#course-curriculum"');
+    expect(html).toContain('href="#course-reviews"');
+    expect(html).not.toContain('role="tablist"');
+    expect(html).not.toContain('role="tab"');
+    expect(html).toContain('grid-template-columns:repeat(3, minmax(0, 1fr))');
+  });
+
+  it('uses non-animated scrolling when reduced motion is requested', () => {
+    render(
+      <>
+        <section id="course-overview" />
+        <section id="course-reviews" />
+        <CourseSectionNav items={[
+          { id: 'course-overview', label: 'รายละเอียดคอร์ส' },
+          { id: 'course-reviews', label: 'รีวิวผู้เรียน' },
+        ]} />
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'รีวิวผู้เรียน' }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: -118, behavior: 'auto' });
+    expect(window.location.hash).toBe('#course-reviews');
+  });
+});

--- a/tests/lib/course-catalog-query.test.ts
+++ b/tests/lib/course-catalog-query.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCourseCatalogHref,
+  clampCourseCatalogPage,
+  getCourseCatalogPageItems,
+  normalizeCourseCatalogQuery,
+} from '@/lib/course-catalog-query';
+
+describe('Course catalog URL contract', () => {
+  it('normalizes unsupported facets and duplicate values to the default catalog', () => {
+    const result = normalizeCourseCatalogQuery({
+      search: ['  React  ', 'ignored'],
+      price: 'cheap',
+      tag: 'missing-tag',
+      sort: 'popular',
+      page: '-2',
+      source: 'unexpected',
+    }, ['frontend']);
+
+    expect(result.query).toEqual({
+      search: 'React',
+      price: 'all',
+      tag: 'all',
+      sort: 'newest',
+      page: 1,
+    });
+    expect(result.isCanonical).toBe(false);
+    expect(buildCourseCatalogHref(result.query)).toBe('/courses?search=React');
+  });
+
+  it('keeps an allowed canonical query unchanged', () => {
+    const result = normalizeCourseCatalogQuery({
+      search: 'React',
+      price: 'paid',
+      tag: 'frontend',
+      sort: 'price-low',
+      page: '3',
+    }, ['frontend']);
+
+    expect(result.query).toEqual({
+      search: 'React',
+      price: 'paid',
+      tag: 'frontend',
+      sort: 'price-low',
+      page: 3,
+    });
+    expect(result.isCanonical).toBe(true);
+  });
+
+  it('omits defaults and resets page when one facet changes', () => {
+    const href = buildCourseCatalogHref({
+      search: 'React',
+      price: 'free',
+      tag: 'frontend',
+      sort: 'price-high',
+      page: 4,
+    }, { price: 'all', page: 1 });
+
+    expect(href).toBe('/courses?search=React&tag=frontend&sort=price-high');
+  });
+
+  it.each([
+    [0, 1],
+    [2, 2],
+    [4, 4],
+  ])('clamps page 10 against %i total pages', (totalPages, expectedPage) => {
+    expect(clampCourseCatalogPage(10, totalPages)).toBe(expectedPage);
+  });
+
+  it('keeps first and last page context with ellipses around the current page', () => {
+    expect(getCourseCatalogPageItems(6, 12)).toEqual([
+      1,
+      'start-ellipsis',
+      5,
+      6,
+      7,
+      'end-ellipsis',
+      12,
+    ]);
+    expect(getCourseCatalogPageItems(2, 4)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/tests/lib/course-review-query.test.ts
+++ b/tests/lib/course-review-query.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCourseReviewHref,
+  normalizeCourseReviewQuery,
+} from '@/lib/course-review-query';
+
+describe('course review URL state', () => {
+  it('normalizes invalid and duplicate review parameters to defaults', () => {
+    expect(normalizeCourseReviewQuery({
+      reviewSort: ['oldest', 'highest'],
+      reviewRating: '9',
+      reviewPage: '-2',
+    })).toEqual({
+      query: { sort: 'latest', rating: null, page: 1 },
+      isCanonical: false,
+    });
+  });
+
+  it('accepts namespaced sort, rating, and page state', () => {
+    expect(normalizeCourseReviewQuery({
+      reviewSort: 'lowest',
+      reviewRating: '2',
+      reviewPage: '3',
+    })).toEqual({
+      query: { sort: 'lowest', rating: 2, page: 3 },
+      isCanonical: true,
+    });
+  });
+
+  it('does not treat the string null as a canonical rating', () => {
+    expect(normalizeCourseReviewQuery({ reviewRating: 'null' })).toEqual({
+      query: { sort: 'latest', rating: null, page: 1 },
+      isCanonical: false,
+    });
+  });
+
+  it('preserves unrelated URL state and omits review defaults', () => {
+    const current = new URLSearchParams('ref=facebook&reviewSort=highest&reviewRating=5&reviewPage=4');
+
+    expect(buildCourseReviewHref('/courses/typescript', current, {
+      sort: 'highest',
+      rating: 5,
+      page: 4,
+    }, { rating: null, page: 1 })).toBe(
+      '/courses/typescript?ref=facebook&reviewSort=highest#course-reviews',
+    );
+  });
+});

--- a/tests/lib/course-review-stats.test.ts
+++ b/tests/lib/course-review-stats.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeCourseReviewStats } from '@/lib/course-review-stats';
+
+describe('normalizeCourseReviewStats', () => {
+  it('normalizes MySQL aggregate strings for verified review evidence', () => {
+    expect(normalizeCourseReviewStats({
+      avgRating: '4.75',
+      totalReviews: 8,
+      star5: '6',
+      star4: 1,
+      star3: 1,
+      star2: null,
+      star1: null,
+    })).toEqual({
+      avgRating: 4.75,
+      totalReviews: 8,
+      distribution: { 5: 6, 4: 1, 3: 1, 2: 0, 1: 0 },
+    });
+  });
+
+  it('returns an empty truthful aggregate when no visible reviews exist', () => {
+    expect(normalizeCourseReviewStats(undefined)).toEqual({
+      avgRating: 0,
+      totalReviews: 0,
+      distribution: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize catalog search/price/tag/sort/page into canonical URLs and use effective promotional price for filtering and sorting
- add removable filter chips, shared pagination, deterministic ordering, verified review evidence, and truthful preparing states
- change Course Detail section navigation to real anchors, share verified review stats, namespace review URL state, and distinguish API errors from empty reviews
- reserve image geometry and preserve the existing Home/Course Detail composition and enrollment boundaries

## Verification
- `npm run lint`
- `npm test -- --run` (182 files, 939 tests)
- `npm run test:e2e:required` (3 passed)
- `npm run build`
- Playwright runtime checks at 320, 390, 768, 1024, and 1440 px: no document-level horizontal overflow; catalog Back behavior and Course Detail anchors verified; no browser console errors/warnings

Closes #47