### PR TITLE
[UI Rollout 23] ย้าย Bundle journey มาใช้ decision facts

### DIFF
--- a/e2e/required/public-product-auth.spec.ts
+++ b/e2e/required/public-product-auth.spec.ts
@@ -99,6 +99,18 @@ test('mobile guest returns to the exact Bundle after registration', async ({ pag
 
   await page.goto(destination);
   await expect(page.getByRole('heading', { level: 1, name: bundle!.title })).toBeVisible();
+  await expect(page.getByRole('main').getByText('ชุดคอร์ส · 2 คอร์ส', { exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', {
+    level: 3,
+    name: E2E_FIXTURES.courses.paid.title,
+  })).toBeVisible();
+  await expect(page.getByRole('heading', {
+    level: 3,
+    name: E2E_FIXTURES.courses.free.title,
+  })).toBeVisible();
+  await expect(page.getByRole('complementary', { name: 'สรุปและสมัครชุดคอร์ส' })
+    .getByText('ซื้อแยกวันนี้', { exact: true })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
   await page.getByRole('button', { name: /Bundle/ }).first().click();
   await registerAndReturnTo(page, destination, 'Mobile Bundle');
 

--- a/src/app/bundles/[slug]/page.tsx
+++ b/src/app/bundles/[slug]/page.tsx
@@ -1,19 +1,29 @@
 import MainContent from '@/components/layout/MainContent';
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import BundleCourseRow from '@/components/bundle/BundleCourseRow';
+import BundleEvidenceSummary from '@/components/bundle/BundleEvidenceSummary';
 import BundleEnrollButton from '@/components/bundle/BundleEnrollButton';
+import BundlePriceSummary from '@/components/bundle/BundlePriceSummary';
 import Footer from '@/components/layout/Footer';
 import Navbar from '@/components/layout/Navbar';
 import NavigationBreadcrumbs from '@/components/layout/NavigationBreadcrumbs';
 import { auth } from '@/lib/auth';
 import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
 import { db } from '@/lib/db';
-import { bundleCourses, bundles, courses, enrollments, lessons } from '@/lib/db/schema';
+import {
+  bundleCourses,
+  bundles,
+  courses,
+  enrollments,
+  lessons,
+  reviews,
+  users,
+} from '@/lib/db/schema';
 import { getExcerpt } from '@/lib/sanitize';
 import { requirePublishedBundleCourses } from '@/lib/bundle-commerce';
 import { absoluteUrl, serializeJsonLd, SITE_URL } from '@/lib/seo';
-import { and, asc, count, eq, inArray } from 'drizzle-orm';
+import { and, asc, avg, count, eq, inArray, sql } from 'drizzle-orm';
 import AnalyticsViewEvent from '@/components/analytics/AnalyticsViewEvent';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
@@ -39,6 +49,27 @@ async function getBundle(slug: string) {
 
   if (!bundle || bundle.status !== 'published') return null;
 
+  const lessonStatsSubquery = db
+    .select({
+      courseId: lessons.courseId,
+      lessonCount: count().as('bundle_detail_lesson_count'),
+      totalDurationSeconds: sql<number>`COALESCE(SUM(${lessons.videoDuration}), 0)`.as('bundle_detail_duration_seconds'),
+      freePreviewCount: sql<number>`COALESCE(SUM(CASE WHEN ${lessons.isFreePreview} = 1 THEN 1 ELSE 0 END), 0)`.as('bundle_detail_preview_count'),
+    })
+    .from(lessons)
+    .groupBy(lessons.courseId)
+    .as('bundle_detail_lesson_stats');
+  const reviewStatsSubquery = db
+    .select({
+      courseId: reviews.courseId,
+      averageRating: avg(reviews.rating).as('bundle_detail_average_rating'),
+      reviewCount: count().as('bundle_detail_review_count'),
+    })
+    .from(reviews)
+    .where(and(eq(reviews.isHidden, false), eq(reviews.isVerified, true)))
+    .groupBy(reviews.courseId)
+    .as('bundle_detail_review_stats');
+
   const bCourses = await db
     .select({
       courseId: bundleCourses.courseId,
@@ -52,9 +83,18 @@ async function getBundle(slug: string) {
       courseThumbnail: courses.thumbnailUrl,
       courseDescription: courses.description,
       courseStatus: courses.status,
+      courseInstructorName: users.name,
+      courseLessonCount: sql<number>`COALESCE(${lessonStatsSubquery.lessonCount}, 0)`.as('bundle_detail_course_lesson_count'),
+      courseDurationSeconds: sql<number>`COALESCE(${lessonStatsSubquery.totalDurationSeconds}, 0)`.as('bundle_detail_course_duration_seconds'),
+      coursePreviewCount: sql<number>`COALESCE(${lessonStatsSubquery.freePreviewCount}, 0)`.as('bundle_detail_course_preview_count'),
+      courseAverageRating: reviewStatsSubquery.averageRating,
+      courseReviewCount: sql<number>`COALESCE(${reviewStatsSubquery.reviewCount}, 0)`.as('bundle_detail_course_review_count'),
     })
     .from(bundleCourses)
     .innerJoin(courses, eq(bundleCourses.courseId, courses.id))
+    .leftJoin(users, eq(courses.instructorId, users.id))
+    .leftJoin(lessonStatsSubquery, eq(courses.id, lessonStatsSubquery.courseId))
+    .leftJoin(reviewStatsSubquery, eq(courses.id, reviewStatsSubquery.courseId))
     .where(eq(bundleCourses.bundleId, bundle.id))
     .orderBy(asc(bundleCourses.orderIndex));
 
@@ -67,19 +107,9 @@ async function getBundle(slug: string) {
     return null;
   }
 
-  const coursesWithLessons = await Promise.all(
-    bCourses.map(async (course) => {
-      const [result] = await db
-        .select({ lessonCount: count() })
-        .from(lessons)
-        .where(eq(lessons.courseId, course.courseId));
-      return { ...course, lessonCount: result?.lessonCount || 0 };
-    }),
-  );
-
   return {
     ...bundle,
-    courses: coursesWithLessons,
+    courses: bCourses,
   };
 }
 
@@ -103,7 +133,18 @@ function getBundleDecisionFacts(
             startsAt: course.coursePromoStartsAt,
             endsAt: course.coursePromoEndsAt,
           },
-      lessonCount: course.lessonCount,
+      lessonCount: Number(course.courseLessonCount) || 0,
+      knownDurationSeconds: Number(course.courseDurationSeconds) || 0,
+      freePreviewCount: Number(course.coursePreviewCount) || 0,
+      instructor: course.courseInstructorName
+        ? { name: course.courseInstructorName }
+        : null,
+      verifiedReview: Number(course.courseReviewCount) > 0
+        ? {
+            average: course.courseAverageRating ?? 0,
+            count: Number(course.courseReviewCount),
+          }
+        : null,
       owned: options.ownedCourseIds?.has(course.courseId) ?? false,
     })),
   }, { now: options.now });
@@ -218,35 +259,22 @@ export default async function BundleDetailPage({ params }: Props) {
               ]}
             />
 
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_28rem] lg:items-end">
+            <div className={'flex flex-col gap-8'}>
               <div>
-                <Badge variant="outline">LEARNING PATH / {String(decisionFacts.evidence.courseCount).padStart(2, '0')} COURSES</Badge>
-                <h1 className="mt-5 max-w-4xl text-4xl font-bold tracking-tight sm:text-5xl">{bundle.title}</h1>
-                {bundle.description ? <p className="mt-5 max-w-3xl text-lg leading-8 text-muted-foreground">{bundle.description}</p> : null}
+                <Badge variant={'outline'}>
+                  ชุดคอร์ส · {decisionFacts.evidence.courseCount} คอร์ส
+                </Badge>
+                <h1 className={'mt-5 max-w-4xl text-4xl font-bold tracking-tight sm:text-5xl'}>
+                  {bundle.title}
+                </h1>
+                {bundle.description ? (
+                  <p className={'mt-5 max-w-3xl text-lg leading-8 text-muted-foreground'}>
+                    {bundle.description}
+                  </p>
+                ) : null}
               </div>
 
-              <dl className="grid grid-cols-2 gap-3" aria-label={'ข้อมูลชุดคอร์ส'}>
-                <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
-                  <dt className="text-sm text-muted-foreground">คอร์ส</dt>
-                  <dd className="text-lg font-semibold">{decisionFacts.evidence.courseCount}</dd>
-                </div>
-                <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
-                  <dt className="text-sm text-muted-foreground">บทเรียน</dt>
-                  <dd className="text-lg font-semibold">{decisionFacts.evidence.totalLessons}</dd>
-                </div>
-                <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
-                  <dt className="text-sm text-muted-foreground">ราคาชุด</dt>
-                  <dd className="text-lg font-semibold">{decisionFacts.price.isFree ? 'ฟรี' : decisionFacts.price.bundleFormatted}</dd>
-                </div>
-                <div className="flex flex-col gap-1 rounded-lg border bg-background p-4">
-                  <dt className="text-sm text-muted-foreground">เทียบซื้อแยกวันนี้</dt>
-                  <dd className="text-lg font-semibold">
-                    {decisionFacts.price.comparison.kind === 'savings'
-                      ? `${decisionFacts.price.comparison.percent}%`
-                      : decisionFacts.price.comparison.kind === 'equal' ? 'เท่ากัน' : 'ซื้อแยกถูกกว่า'}
-                  </dd>
-                </div>
-              </dl>
+              <BundleEvidenceSummary evidence={decisionFacts.evidence} />
             </div>
           </div>
         </header>
@@ -264,36 +292,14 @@ export default async function BundleDetailPage({ params }: Props) {
               <ol className="grid gap-5">
                 {decisionFacts.courses.map((course, index) => {
                   const courseContent = courseContentById.get(course.id);
-                  const thumbnail = normalizeUrl(courseContent?.courseThumbnail ?? null);
                   return (
                     <li key={course.id}>
-                      <Card className="overflow-hidden transition hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md">
-                      <Link className="grid sm:grid-cols-[12rem_minmax(0,1fr)]" href={`/courses/${course.slug}`}>
-                        <div
-                          className="flex min-h-40 items-start bg-slate-900 bg-cover bg-center p-4"
-                          style={thumbnail ? { backgroundImage: `url(${thumbnail})` } : undefined}
-                          aria-hidden={true}
-                        >
-                          <Badge>{String(index + 1).padStart(2, '0')}</Badge>
-                        </div>
-                        <div className="p-5">
-                          <div className="mb-3 flex flex-wrap justify-between gap-2 text-xs font-semibold text-muted-foreground">
-                            <span>คอร์สที่ {index + 1}</span>
-                            <span>{course.lessonCount} บทเรียน</span>
-                          </div>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <h3 className="text-xl font-semibold tracking-tight">{course.title}</h3>
-                            {course.owned ? <Badge variant="secondary">มีสิทธิ์เรียนแล้ว</Badge> : null}
-                          </div>
-                          {courseContent?.courseDescription ? (
-                            <p className="mt-2 line-clamp-2 text-sm leading-6 text-muted-foreground">{getExcerpt(courseContent.courseDescription, 120)}</p>
-                          ) : null}
-                          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t pt-4 text-sm">
-                            <span>ซื้อแยกวันนี้ {course.price.effectiveFormatted}</span>
-                            <strong>ดูรายละเอียด <span aria-hidden={true}>→</span></strong>
-                          </div>
-                        </div>
-                      </Link></Card>
+                      <BundleCourseRow
+                        course={course}
+                        description={courseContent?.courseDescription ?? null}
+                        thumbnailUrl={courseContent?.courseThumbnail ?? null}
+                        position={index + 1}
+                      />
                     </li>
                   );
                 })}
@@ -307,33 +313,24 @@ export default async function BundleDetailPage({ params }: Props) {
                 </CardHeader>
 
                 <CardContent className="flex flex-col gap-6">
-                <div className="rounded-lg bg-muted p-5">
-                  <span className="text-sm text-muted-foreground">ราคาชุดคอร์ส</span>
-                  <strong className="mt-1 block text-3xl tracking-tight">{decisionFacts.price.isFree ? 'ฟรี' : decisionFacts.price.bundleFormatted}</strong>
-                  <p className="mt-2 flex flex-col gap-1 text-sm">
-                    <span className="text-muted-foreground">ซื้อแยกวันนี้ {decisionFacts.price.separateCurrentFormatted}</span>
-                    <b className={decisionFacts.price.comparison.kind === 'savings' ? 'text-primary' : undefined}>
-                      {decisionFacts.price.comparison.label}
-                    </b>
-                  </p>
-                </div>
+                  <BundlePriceSummary price={decisionFacts.price} />
 
-                <dl className="grid gap-3 text-sm [&_div]:flex [&_div]:justify-between [&_div]:gap-4 [&_dt]:text-muted-foreground [&_dd]:font-medium">
-                  <div><dt>คอร์สทั้งหมด</dt><dd>{decisionFacts.evidence.courseCount} คอร์ส</dd></div>
-                  <div><dt>เนื้อหาทั้งหมด</dt><dd>{decisionFacts.evidence.totalLessons} บทเรียน</dd></div>
-                  <div><dt>Certificate</dt><dd>ทุกคอร์ส</dd></div>
-                  <div><dt>การเข้าถึง</dt><dd>ตลอดชีพ</dd></div>
-                </dl>
+                  <dl className="grid gap-3 text-sm [&_div]:flex [&_div]:justify-between [&_div]:gap-4 [&_dt]:text-muted-foreground [&_dd]:font-medium">
+                    <div><dt>คอร์สทั้งหมด</dt><dd>{decisionFacts.evidence.courseCount} คอร์ส</dd></div>
+                    <div><dt>เนื้อหาทั้งหมด</dt><dd>{decisionFacts.evidence.totalLessons} บทเรียน</dd></div>
+                    <div><dt>Certificate</dt><dd>ทุกคอร์ส</dd></div>
+                    <div><dt>การเข้าถึง</dt><dd>ตลอดชีพ</dd></div>
+                  </dl>
 
-                <BundleEnrollButton
-                  bundleId={bundle.id}
-                  bundleSlug={bundle.slug}
-                  decisionFacts={{
-                    price: decisionFacts.price,
-                    ownership: decisionFacts.ownership,
-                    actions: decisionFacts.actions,
-                  }}
-                />
+                  <BundleEnrollButton
+                    bundleId={bundle.id}
+                    bundleSlug={bundle.slug}
+                    decisionFacts={{
+                      price: decisionFacts.price,
+                      ownership: decisionFacts.ownership,
+                      actions: decisionFacts.actions,
+                    }}
+                  />
                 </CardContent>
                 <CardFooter><p className="text-xs leading-5 text-muted-foreground">ตรวจสอบคอร์สและยอดชำระก่อนยืนยัน ระบบจะเปิดสิทธิ์หลังการชำระเงินได้รับการตรวจสอบแล้ว</p></CardFooter>
               </Card>

--- a/src/components/bundle/BundleCard.tsx
+++ b/src/components/bundle/BundleCard.tsx
@@ -21,7 +21,7 @@ export default function BundleCard({ title, description, decisionFacts }: Bundle
       <Card className="h-full">
         <CardHeader>
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <Badge>Bundle · {decisionFacts.evidence.courseCount} คอร์ส</Badge>
+            <Badge>ชุดคอร์ส · {decisionFacts.evidence.courseCount} คอร์ส</Badge>
             {decisionFacts.readiness === 'preparing' ? (
               <Badge variant="secondary">กำลังเตรียมเนื้อหา</Badge>
             ) : (

--- a/src/components/bundle/BundleCourseRow.tsx
+++ b/src/components/bundle/BundleCourseRow.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import type { BundleDecisionFacts } from '@/lib/bundle-decision-facts';
+import { formatCourseDuration } from '@/lib/course-duration';
+import { getExcerpt } from '@/lib/sanitize';
+
+type BundleCourseRowProps = {
+  course: BundleDecisionFacts['courses'][number];
+  description: string | null;
+  thumbnailUrl: string | null;
+  position: number;
+};
+
+function normalizeUrl(url: string | null): string | null {
+  if (!url || url.trim() === '') return null;
+  return url.startsWith('http') ? url : `https://${url}`;
+}
+
+export default function BundleCourseRow({
+  course,
+  description,
+  thumbnailUrl: rawThumbnailUrl,
+  position,
+}: BundleCourseRowProps) {
+  const thumbnailUrl = normalizeUrl(rawThumbnailUrl);
+  const durationText = formatCourseDuration(course.evidence.knownDurationSeconds);
+  const review = course.evidence.verifiedReview;
+
+  return (
+    <Card className={'h-full gap-0 overflow-hidden py-0 transition-[transform,box-shadow] duration-200 hover:-translate-y-0.5 hover:shadow-md motion-reduce:transform-none'}>
+      <Link
+        className={'grid h-full min-w-0 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/30 sm:grid-cols-[12rem_minmax(0,1fr)]'}
+        href={`/courses/${course.slug}`}
+      >
+        <div className={'relative aspect-[16/9] overflow-hidden bg-[var(--academy-navy)] sm:aspect-auto sm:min-h-52'}>
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt={course.title}
+              width={640}
+              height={360}
+              sizes={'(min-width: 1024px) 12rem, 100vw'}
+              loading={'lazy'}
+              decoding={'async'}
+              className={'size-full object-cover'}
+            />
+          ) : null}
+          <Badge className={'absolute top-4 left-4'}>
+            {String(position).padStart(2, '0')}
+          </Badge>
+        </div>
+
+        <div className={'flex min-w-0 flex-col'}>
+          <CardHeader className={'pt-5'}>
+            <div className={'flex flex-wrap gap-2'}>
+              <Badge variant={course.readiness === 'ready' ? 'outline' : 'secondary'}>
+                {course.readiness === 'ready' ? 'พร้อมเรียน' : 'กำลังเตรียมเนื้อหา'}
+              </Badge>
+              {course.owned ? <Badge variant={'secondary'}>มีสิทธิ์เรียนแล้ว</Badge> : null}
+              {course.evidence.freePreviewCount > 0 ? (
+                <Badge variant={'secondary'}>ทดลองเรียน {course.evidence.freePreviewCount} บท</Badge>
+              ) : null}
+            </div>
+            <CardTitle>
+              <h3 className={'break-words text-xl leading-snug font-semibold tracking-tight'}>
+                {course.title}
+              </h3>
+            </CardTitle>
+            {description ? (
+              <CardDescription className={'line-clamp-2 break-words leading-6'}>
+                {getExcerpt(description, 120)}
+              </CardDescription>
+            ) : null}
+          </CardHeader>
+
+          <CardContent className={'flex flex-1 flex-wrap content-start gap-x-4 gap-y-2 text-xs text-muted-foreground'}>
+            <span>{course.evidence.lessonCount} บทเรียน</span>
+            {durationText ? <span>{durationText}</span> : null}
+            {course.evidence.instructorName ? (
+              <span>สอนโดย {course.evidence.instructorName}</span>
+            ) : null}
+            {review ? <span>★ {review.average.toFixed(1)} · {review.count} รีวิว</span> : null}
+          </CardContent>
+
+          <CardFooter className={'mt-5 flex-wrap justify-between gap-3 border-t py-5 text-sm'}>
+            <span className={'flex flex-wrap items-baseline gap-2'}>
+              <span>ราคาปัจจุบัน</span>
+              <strong>{course.price.effectiveFormatted}</strong>
+              {course.price.hasActiveDiscount ? (
+                <s className={'text-muted-foreground'}>{course.price.regularFormatted}</s>
+              ) : null}
+            </span>
+            <strong className={'text-primary'}>ดูรายละเอียด <span aria-hidden={true}>→</span></strong>
+          </CardFooter>
+        </div>
+      </Link>
+    </Card>
+  );
+}

--- a/src/components/bundle/BundleEvidenceSummary.tsx
+++ b/src/components/bundle/BundleEvidenceSummary.tsx
@@ -1,0 +1,32 @@
+import type { BundleDecisionFacts } from '@/lib/bundle-decision-facts';
+import { formatCourseDuration } from '@/lib/course-duration';
+
+type BundleEvidenceSummaryProps = {
+  evidence: BundleDecisionFacts['evidence'];
+};
+
+export default function BundleEvidenceSummary({ evidence }: BundleEvidenceSummaryProps) {
+  const durationText = formatCourseDuration(evidence.knownDurationSeconds);
+  const items = [
+    { label: 'คอร์ส', value: `${evidence.courseCount} คอร์ส` },
+    { label: 'บทเรียน', value: `${evidence.totalLessons} บทเรียน` },
+    ...(durationText ? [{ label: 'ระยะเวลา', value: durationText }] : []),
+    ...(evidence.freePreviewCount > 0
+      ? [{ label: 'บททดลอง', value: `ทดลองเรียน ${evidence.freePreviewCount} บท` }]
+      : []),
+  ];
+
+  return (
+    <dl
+      className={'grid gap-3 sm:grid-cols-2 lg:grid-cols-4'}
+      aria-label={'ข้อมูลชุดคอร์ส'}
+    >
+      {items.map((item) => (
+        <div key={item.label} className={'min-w-0 rounded-lg border bg-background p-4'}>
+          <dt className={'text-sm text-muted-foreground'}>{item.label}</dt>
+          <dd className={'mt-1 break-words text-lg font-semibold'}>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/components/bundle/BundlePriceSummary.tsx
+++ b/src/components/bundle/BundlePriceSummary.tsx
@@ -1,0 +1,34 @@
+import type { BundleDecisionFacts } from '@/lib/bundle-decision-facts';
+
+type BundlePriceSummaryProps = {
+  price: BundleDecisionFacts['price'];
+};
+
+export default function BundlePriceSummary({ price }: BundlePriceSummaryProps) {
+  const showRegularContext = price.separateRegular !== price.separateCurrent;
+
+  return (
+    <div className={'rounded-lg bg-muted p-5'}>
+      <p className={'text-sm text-muted-foreground'}>ราคาชุด</p>
+      <strong className={'mt-1 block text-3xl tracking-tight'}>
+        {price.isFree ? 'ฟรี' : price.bundleFormatted}
+      </strong>
+      <dl className={'mt-4 flex flex-col gap-2 text-sm'}>
+        <div className={'flex flex-wrap justify-between gap-2'}>
+          <dt className={'text-muted-foreground'}>ซื้อแยกวันนี้</dt>
+          <dd className={'font-medium'}>{price.separateCurrentFormatted}</dd>
+        </div>
+        <div className={'flex flex-wrap justify-between gap-2'}>
+          <dt>เปรียบเทียบ</dt>
+          <dd className={'font-semibold'}>{price.comparison.label}</dd>
+        </div>
+        {showRegularContext ? (
+          <div className={'flex flex-wrap justify-between gap-2 text-muted-foreground'}>
+            <dt>ราคาปกติรวม</dt>
+            <dd>{price.separateRegularFormatted}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </div>
+  );
+}

--- a/src/components/course/CourseCard.tsx
+++ b/src/components/course/CourseCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { getExcerpt } from '@/lib/sanitize';
 import type { CourseDecisionFacts } from '@/lib/course-decision-facts';
+import { formatCourseDuration } from '@/lib/course-duration';
 import CourseArtwork from '@/components/course/CourseArtwork';
 
 interface Tag { id: string; name: string; slug: string }
@@ -23,16 +24,6 @@ function normalizeUrl(url: string | null): string | null {
   return url.startsWith('http') ? url : `https://${url}`;
 }
 
-function formatCourseDuration(totalSeconds?: number): string | null {
-  if (!totalSeconds || totalSeconds < 60) return null;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (hours > 0 && minutes > 0) return `${hours} ชม. ${minutes} นาที`;
-  if (hours > 0) return `${hours} ชม.`;
-  return `${minutes} นาที`;
-}
-
 export default function CourseCard({
   title,
   slug,
@@ -49,7 +40,7 @@ export default function CourseCard({
   const instructorName = evidence.instructorName;
   const lessonCount = evidence.lessonCount;
   const thumbnailUrl = normalizeUrl(rawThumbnailUrl);
-  const durationText = formatCourseDuration(evidence.knownDurationSeconds ?? undefined);
+  const durationText = formatCourseDuration(evidence.knownDurationSeconds);
   const hasFreePreview = evidence.freePreviewCount > 0;
 
   return (

--- a/src/lib/bundle-decision-facts.ts
+++ b/src/lib/bundle-decision-facts.ts
@@ -1,5 +1,6 @@
 import {
   deriveCourseDecisionFacts,
+  type CourseDecisionFacts,
   type CourseDecisionSource,
 } from '@/lib/course-decision-facts';
 
@@ -23,6 +24,10 @@ export type BundleCourseDecisionSource = {
   regularPrice: number | string;
   promotion?: CourseDecisionSource['promotion'];
   lessonCount: number;
+  knownDurationSeconds?: number | null;
+  freePreviewCount?: number | null;
+  instructor?: CourseDecisionSource['instructor'];
+  verifiedReview?: CourseDecisionSource['verifiedReview'];
   owned?: boolean;
 };
 
@@ -47,12 +52,16 @@ export type BundleDecisionFacts = {
     bundleFormatted: string;
     separateCurrent: number;
     separateCurrentFormatted: string;
+    separateRegular: number;
+    separateRegularFormatted: string;
     isFree: boolean;
     comparison: BundlePriceComparison;
   };
   evidence: {
     courseCount: number;
     totalLessons: number;
+    knownDurationSeconds: number | null;
+    freePreviewCount: number;
   };
   courses: Array<{
     id: string;
@@ -62,6 +71,7 @@ export type BundleDecisionFacts = {
     readiness: 'ready' | 'preparing';
     lessonCount: number;
     owned: boolean;
+    evidence: CourseDecisionFacts['evidence'];
     price: {
       regular: number;
       effective: number;
@@ -174,6 +184,10 @@ export function deriveBundleDecisionFacts(
       regularPrice: course.regularPrice,
       promotion: course.promotion,
       lessonCount: course.lessonCount,
+      knownDurationSeconds: course.knownDurationSeconds,
+      freePreviewCount: course.freePreviewCount,
+      instructor: course.instructor,
+      verifiedReview: course.verifiedReview,
     }, options);
 
     return {
@@ -184,6 +198,7 @@ export function deriveBundleDecisionFacts(
       readiness: decisionFacts.readiness,
       lessonCount: decisionFacts.evidence.lessonCount,
       owned: course.owned === true,
+      evidence: decisionFacts.evidence,
       price: {
         regular: decisionFacts.price.regular,
         effective: decisionFacts.price.effective,
@@ -199,6 +214,10 @@ export function deriveBundleDecisionFacts(
     0,
   );
   const separateCurrent = fromCurrencyUnits(separateCurrentUnits);
+  const separateRegular = fromCurrencyUnits(courses.reduce(
+    (total, course) => total + toCurrencyUnits(course.price.regular),
+    0,
+  ));
   const comparison = comparisonFor(bundlePrice, separateCurrent);
   const readiness = courses.length > 0 && courses.every((course) => course.readiness === 'ready')
     ? 'ready'
@@ -225,12 +244,22 @@ export function deriveBundleDecisionFacts(
       bundleFormatted,
       separateCurrent,
       separateCurrentFormatted: thbFormatter.format(separateCurrent),
+      separateRegular,
+      separateRegularFormatted: thbFormatter.format(separateRegular),
       isFree: bundlePrice === 0,
       comparison,
     },
     evidence: {
       courseCount: courses.length,
       totalLessons: courses.reduce((total, course) => total + course.lessonCount, 0),
+      knownDurationSeconds: courses.reduce(
+        (total, course) => total + (course.evidence.knownDurationSeconds ?? 0),
+        0,
+      ) || null,
+      freePreviewCount: courses.reduce(
+        (total, course) => total + course.evidence.freePreviewCount,
+        0,
+      ),
     },
     courses,
     ownership: {
@@ -250,7 +279,7 @@ export function deriveBundleDecisionFacts(
       acquisition,
       complete: {
         kind: 'continue-learning',
-        label: 'ลงทะเบียนครบแล้ว — เข้าเรียน',
+        label: 'ไปการเรียนของฉัน',
         href: '/dashboard',
       },
     },

--- a/src/lib/course-duration.ts
+++ b/src/lib/course-duration.ts
@@ -1,0 +1,10 @@
+export function formatCourseDuration(totalSeconds: number | null | undefined): string | null {
+  if (!totalSeconds || totalSeconds < 60) return null;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0 && minutes > 0) return `${hours} ชม. ${minutes} นาที`;
+  if (hours > 0) return `${hours} ชม.`;
+  return `${minutes} นาที`;
+}

--- a/tests/components/bundle-card.test.tsx
+++ b/tests/components/bundle-card.test.tsx
@@ -44,6 +44,7 @@ describe('BundleCard', () => {
     );
 
     expect(html).toContain('ประหยัด ฿500 (25%)');
+    expect(html).toContain('ชุดคอร์ส · 2 คอร์ส');
     expect(html).toContain('ซื้อแยกวันนี้ ฿2,000');
     expect(html.indexOf('TypeScript')).toBeLessThan(html.indexOf('Next.js'));
     expect(html).not.toContain('รีวิว');

--- a/tests/components/bundle-course-row.test.tsx
+++ b/tests/components/bundle-course-row.test.tsx
@@ -1,0 +1,98 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import BundleCourseRow from '@/components/bundle/BundleCourseRow';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
+
+const NOW = new Date('2026-09-02T05:00:00.000Z');
+
+function includedCourse(overrides: {
+  lessonCount?: number;
+  thumbnailUrl?: string | null;
+} = {}) {
+  const facts = deriveBundleDecisionFacts({
+    slug: 'full-stack',
+    price: '1500.00',
+    courses: [{
+      id: 'typescript',
+      title: 'TypeScript สำหรับงานจริงที่มีชื่อคอร์สภาษาไทยยาวมาก',
+      slug: 'typescript',
+      orderIndex: 0,
+      regularPrice: '1000.00',
+      promotion: { price: '800.00' },
+      lessonCount: overrides.lessonCount ?? 6,
+      knownDurationSeconds: 5_460,
+      freePreviewCount: 2,
+      instructor: { name: 'Miler' },
+      verifiedReview: { average: 4.8, count: 24 },
+      owned: true,
+    }],
+  }, { now: NOW });
+
+  return {
+    course: facts.courses[0]!,
+    thumbnailUrl: overrides.thumbnailUrl ?? null,
+  };
+}
+
+describe('BundleCourseRow', () => {
+  it('renders the included Course state and evidence from decision facts', () => {
+    const { course } = includedCourse();
+    const html = renderToStaticMarkup(
+      <BundleCourseRow
+        course={course}
+        description={'เรียนจากพื้นฐานจนทำโปรเจกต์จริง'}
+        thumbnailUrl={'cdn.example.test/typescript.jpg'}
+        position={1}
+      />,
+    );
+
+    expect(html).toContain('พร้อมเรียน');
+    expect(html).toContain('มีสิทธิ์เรียนแล้ว');
+    expect(html).toContain('6 บทเรียน');
+    expect(html).toContain('1 ชม. 31 นาที');
+    expect(html).toContain('ทดลองเรียน 2 บท');
+    expect(html).toContain('สอนโดย Miler');
+    expect(html).toContain('4.8 · 24 รีวิว');
+    expect(html).toContain('ราคาปัจจุบัน');
+    expect(html).toContain('฿800');
+    expect(html).toContain('฿1,000');
+    expect(html).toContain('/courses/typescript');
+    expect(html).toContain('src="https://cdn.example.test/typescript.jpg"');
+    expect(html).toContain('width="640"');
+    expect(html).toContain('height="360"');
+    expect(html).toContain('sizes="(min-width: 1024px) 12rem, 100vw"');
+    expect(html.match(/<a\b/g)).toHaveLength(1);
+  });
+
+  it('shows truthful preparing state without inventing optional evidence', () => {
+    const facts = deriveBundleDecisionFacts({
+      slug: 'preparing-path',
+      price: '500.00',
+      courses: [{
+        id: 'preparing',
+        title: 'คอร์สที่กำลังเตรียมบทเรียน',
+        slug: 'preparing',
+        orderIndex: 0,
+        regularPrice: '500.00',
+        lessonCount: 0,
+      }],
+    }, { now: NOW });
+
+    const html = renderToStaticMarkup(
+      <BundleCourseRow
+        course={facts.courses[0]!}
+        description={null}
+        thumbnailUrl={null}
+        position={1}
+      />,
+    );
+
+    expect(html).toContain('กำลังเตรียมเนื้อหา');
+    expect(html).not.toContain('พร้อมเรียน');
+    expect(html).not.toContain('ทดลองเรียน');
+    expect(html).not.toContain('สอนโดย');
+    expect(html).not.toContain('รีวิว');
+    expect(html.match(/<a\b/g)).toHaveLength(1);
+  });
+});

--- a/tests/components/bundle-enroll-button.test.tsx
+++ b/tests/components/bundle-enroll-button.test.tsx
@@ -92,7 +92,7 @@ describe('bundle enrollment purchase contract', () => {
     );
 
     expect(html).toContain(`href=${quote}/dashboard${quote}`);
-    expect(html).toContain('ลงทะเบียนครบแล้ว');
+    expect(html).toContain('ไปการเรียนของฉัน');
     expect(html).not.toContain('<button');
   });
 

--- a/tests/components/bundle-enroll-interactions.test.tsx
+++ b/tests/components/bundle-enroll-interactions.test.tsx
@@ -237,7 +237,7 @@ describe('bundle enrollment interactions', () => {
     expect(verifyButton.disabled).toBe(false);
 
     await user.click(verifyButton);
-    expect(await screen.findByRole('link', { name: /เข้าเรียน/ })).toBeTruthy();
+    expect(await screen.findByRole('link', { name: /ไปการเรียนของฉัน/ })).toBeTruthy();
 
     const verificationCalls = fetchMock.mock.calls.filter(([input]) => (
       urlOf(input) === BUNDLE_PAYMENT_CONTRACT.slipEndpoint

--- a/tests/components/bundle-evidence-summary.test.tsx
+++ b/tests/components/bundle-evidence-summary.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import BundleEvidenceSummary from '@/components/bundle/BundleEvidenceSummary';
+
+describe('BundleEvidenceSummary', () => {
+  it('renders decision evidence without repeating price claims in the hero', () => {
+    const html = renderToStaticMarkup(
+      <BundleEvidenceSummary
+        evidence={{
+          courseCount: 3,
+          totalLessons: 48,
+          knownDurationSeconds: 33_600,
+          freePreviewCount: 4,
+        }}
+      />,
+    );
+
+    expect(html).toContain('3 คอร์ส');
+    expect(html).toContain('48 บทเรียน');
+    expect(html).toContain('9 ชม. 20 นาที');
+    expect(html).toContain('ทดลองเรียน 4 บท');
+    expect(html).not.toContain('ราคา');
+    expect(html.match(/<dt\b/g)).toHaveLength(4);
+    expect(html.match(/<dd\b/g)).toHaveLength(4);
+  });
+});

--- a/tests/components/bundle-price-summary.test.tsx
+++ b/tests/components/bundle-price-summary.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import BundlePriceSummary from '@/components/bundle/BundlePriceSummary';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
+
+describe('BundlePriceSummary', () => {
+  it('uses current separate prices for savings and regular prices as secondary context', () => {
+    const facts = deriveBundleDecisionFacts({
+      slug: 'full-stack',
+      price: '1500.00',
+      courses: [
+        {
+          id: 'typescript',
+          title: 'TypeScript',
+          slug: 'typescript',
+          orderIndex: 0,
+          regularPrice: '1000.00',
+          promotion: { price: '800.00' },
+          lessonCount: 6,
+        },
+        {
+          id: 'nextjs',
+          title: 'Next.js',
+          slug: 'nextjs',
+          orderIndex: 1,
+          regularPrice: '1200.00',
+          lessonCount: 8,
+        },
+      ],
+    }, { now: new Date('2026-09-02T05:00:00.000Z') });
+
+    const html = renderToStaticMarkup(<BundlePriceSummary price={facts.price} />);
+
+    expect(html).toContain('ราคาชุด');
+    expect(html).toContain('฿1,500');
+    expect(html).toContain('ซื้อแยกวันนี้');
+    expect(html).toContain('฿2,000');
+    expect(html).toContain('ประหยัด ฿500 (25%)');
+    expect(html).toContain('ราคาปกติรวม');
+    expect(html).toContain('฿2,200');
+    expect(html).not.toMatch(/<s(?:\s|>)/);
+  });
+});

--- a/tests/components/public-content.test.tsx
+++ b/tests/components/public-content.test.tsx
@@ -10,7 +10,6 @@ const announcementsPageSource = readFileSync('src/app/announcements/page.tsx', '
 const announcementFeedSource = readFileSync('src/components/content/AnnouncementFeed.tsx', 'utf8');
 const privacySource = readFileSync('src/app/privacy/page.tsx', 'utf8');
 const termsSource = readFileSync('src/app/terms/page.tsx', 'utf8');
-const bundleDetailSource = readFileSync('src/app/bundles/[slug]/page.tsx', 'utf8');
 const legalDocumentSource = readFileSync('src/components/content/LegalDocument.tsx', 'utf8');
 const announcementApiSource = readFileSync('src/app/api/announcements/route.ts', 'utf8');
 
@@ -118,13 +117,5 @@ describe('public content contracts', () => {
     expect(html).toContain(`href=${quote}#legal-one${quote}`);
     expect(html).toContain(`id=${quote}legal-one${quote}`);
     expect(html).toContain(`tabindex=${quote}-1${quote}`);
-  });
-
-  it('pairs bundle summary labels and values with description-list semantics', () => {
-    const summary = bundleDetailSource.match(/<dl[^>]*aria-label=\{'ข้อมูลชุดคอร์ส'\}[\s\S]*?<\/dl>/)?.[0];
-
-    expect(summary).toBeTruthy();
-    expect(summary?.match(/<dt\b/g)).toHaveLength(4);
-    expect(summary?.match(/<dd\b/g)).toHaveLength(4);
   });
 });

--- a/tests/lib/bundle-decision-facts.test.ts
+++ b/tests/lib/bundle-decision-facts.test.ts
@@ -53,6 +53,63 @@ describe('ProductDecisionFacts for Bundle', () => {
     });
   });
 
+  it('projects truthful evidence for every included Course and the Bundle summary', () => {
+    const facts = bundleFacts('1500.00', [
+      course('typescript', 0, {
+        lessonCount: 6,
+        knownDurationSeconds: 5_460,
+        freePreviewCount: 2,
+        instructor: { name: 'Miler' },
+        verifiedReview: { average: '4.8', count: 24 },
+      }),
+      course('nextjs', 1, {
+        lessonCount: 4,
+        knownDurationSeconds: 1_800,
+        freePreviewCount: 1,
+      }),
+    ]);
+
+    expect({
+      courseEvidence: facts.courses[0]?.evidence,
+      bundleEvidence: facts.evidence,
+    }).toEqual({
+      courseEvidence: {
+        lessonCount: 6,
+        knownDurationSeconds: 5_460,
+        freePreviewCount: 2,
+        instructorName: 'Miler',
+        verifiedReview: { average: 4.8, count: 24 },
+      },
+      bundleEvidence: {
+        courseCount: 2,
+        totalLessons: 10,
+        knownDurationSeconds: 7_260,
+        freePreviewCount: 3,
+      },
+    });
+  });
+
+  it('keeps the regular total as context while savings use current separate prices', () => {
+    const facts = bundleFacts('1500.00', [
+      course('typescript', 0, {
+        regularPrice: '1000.00',
+        promotion: {
+          price: '800.00',
+          startsAt: new Date('2026-09-01T05:00:00.000Z'),
+          endsAt: new Date('2026-09-03T05:00:00.000Z'),
+        },
+      }),
+      course('nextjs', 1, { regularPrice: '1200.00' }),
+    ]);
+
+    expect(facts.price).toMatchObject({
+      separateCurrent: 2000,
+      separateRegular: 2200,
+      separateRegularFormatted: '฿2,200',
+      comparison: { kind: 'savings', amount: 500, percent: 25 },
+    });
+  });
+
   it.each([
     ['savings', '1500.00', 'savings', 500, 25],
     ['equal', '2000.00', 'equal', 0, null],
@@ -115,7 +172,7 @@ describe('ProductDecisionFacts for Bundle', () => {
     expect(facts.ownership.status).toBe('complete');
     expect(facts.actions.complete).toEqual({
       kind: 'continue-learning',
-      label: 'ลงทะเบียนครบแล้ว — เข้าเรียน',
+      label: 'ไปการเรียนของฉัน',
       href: '/dashboard',
     });
     expect(facts.evidence).not.toHaveProperty('verifiedReview');

--- a/tests/lib/course-duration.test.ts
+++ b/tests/lib/course-duration.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCourseDuration } from '@/lib/course-duration';
+
+describe('formatCourseDuration', () => {
+  it.each([
+    [5_460, '1 ชม. 31 นาที'],
+    [3_600, '1 ชม.'],
+    [1_800, '30 นาที'],
+    [59, null],
+    [null, null],
+  ] as const)('formats %s seconds as concise Thai evidence', (seconds, expected) => {
+    expect(formatCourseDuration(seconds)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- make Bundle discovery and detail render canonical readiness, ownership, evidence, and price comparisons from ProductDecisionFacts
- replace per-course lesson queries with bulk lesson, instructor, preview, duration, and verified-review aggregates
- add responsive accessible Bundle course rows and mobile browser coverage without changing payment or enrollment policy

## Verification
- npm run lint
- npm test -- --run — 186 files, 949 tests passed
- npm run build
- npm run test:e2e:required — 3 tests passed
- git diff --check
- UTF-8 mojibake scan on changed files

Closes #48