### PR TITLE
[UI Rollout 24] เพิ่ม order review และ payment-method journey

### DIFF
--- a/e2e/required/order-review.spec.ts
+++ b/e2e/required/order-review.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test, type Page } from '@playwright/test';
+import { E2E_FIXTURES } from '../fixtures';
+import { installRequiredE2EProviderMocks } from './provider-mock-adapter.mjs';
+
+async function registerBuyer(page: Page, destination: string) {
+  const unique = crypto.randomUUID().replaceAll('-', '');
+  const password = 'Aa1!' + unique;
+  await page.goto(`/register?callbackUrl=${encodeURIComponent(destination)}`);
+  await page.locator('input[name=name]').fill('ผู้ซื้อทดสอบรายการ ' + unique.slice(0, 6));
+  await page.locator('input[name=email]').fill(`order-review-${unique}@example.test`);
+  await page.locator('input[name=password]').fill(password);
+  await page.locator('input[name=confirmPassword]').fill(password);
+  await page.locator('button[type=submit]').click();
+  await page.waitForURL((url) => url.pathname === destination);
+}
+
+for (const type of ['course', 'bundle'] as const) {
+  test(`${type} reviews authoritative price and recovers a mocked PromptPay rejection without duplicate payment`, async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== 'string') throw new Error('Required baseURL is missing');
+    const network = await installRequiredE2EProviderMocks(page, baseURL);
+    const fixture = type === 'course' ? E2E_FIXTURES.courses.longThai : E2E_FIXTURES.bundle;
+    const destination = `/${type === 'course' ? 'courses' : 'bundles'}/${fixture.slug}`;
+    await registerBuyer(page, destination);
+    const trigger = page.getByRole('button', { name: type === 'course' ? /ซื้อคอร์สนี้/ : /ซื้อ Bundle/ }).first();
+    const dialog = page.getByRole('dialog', { name: 'เลือกช่องทางชำระเงิน' });
+
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    for (const width of [320, 390, 768, 1440]) {
+      await page.setViewportSize({ width, height: 900 });
+      await trigger.click();
+      await expect(dialog.getByText(fixture.title, { exact: true })).toBeVisible();
+      await expect(dialog.getByText('ยอดชำระ (THB)', { exact: true })).toBeVisible();
+      await expect(dialog.getByRole('button', { name: /Stripe/ })).toBeEnabled();
+      const fits = await dialog.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return rect.left >= 0 && rect.right <= window.innerWidth && element.scrollWidth <= element.clientWidth;
+      });
+      expect(fits, `order review must fit ${width}px`).toBe(true);
+      await page.keyboard.press('Tab');
+      expect(await dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+      await page.keyboard.press('Escape');
+      await expect(dialog).not.toBeVisible();
+      await expect(trigger).toBeFocused();
+    }
+
+    // Cancellation is advisory: the query does not claim payment or grant access.
+    await page.goto(`${destination}?payment=cancelled`);
+    await expect(page.getByText('กลับจากหน้าชำระเงิน', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: fixture.title })).toBeVisible();
+    await page.goBack();
+    await expect(page).toHaveURL(new RegExp(fixture.slug + '$'));
+    await page.goForward();
+    await expect(page.getByText('กลับจากหน้าชำระเงิน', { exact: true })).toBeVisible();
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await trigger.click();
+    const intentResponse = page.waitForResponse((response) => response.url().endsWith('/api/promptpay/intents') && response.request().method() === 'POST');
+    await dialog.getByRole('button', { name: /PromptPay/ }).click();
+    const created = await intentResponse;
+    expect(created.status()).toBe(201);
+    const intent = await created.json() as { paymentId: string; amount: number; expiresAt: string };
+    expect(intent.amount).toBe(Number(fixture.price));
+    const transfer = page.getByRole('dialog', { name: 'โอนเงินและแนบสลิป' });
+    await expect(transfer.getByText(intent.paymentId, { exact: true })).toBeVisible();
+    await expect(transfer.getByText(/เวลาไทย/)).toBeVisible();
+    await expect(transfer.getByText(/ข้อมูลส่วนบุคคล/)).toBeVisible();
+
+    let intentCreations = 0;
+    page.on('request', (request) => { if (request.url().endsWith('/api/promptpay/intents') && request.method() === 'POST') intentCreations += 1; });
+    await transfer.getByRole('button', { name: 'ปิดและเก็บรายการไว้' }).click();
+    await expect(trigger).toBeFocused();
+    await trigger.click();
+    await expect(transfer.getByText(intent.paymentId, { exact: true })).toBeVisible();
+
+    const slipEndpoint = type === 'course' ? '/api/slip/verify' : '/api/bundles/slip/verify';
+    let releaseResponse!: () => void;
+    const responseGate = new Promise<void>((resolve) => { releaseResponse = resolve; });
+    await page.route(`**${slipEndpoint}`, async (route) => {
+      const actualResponse = await route.fetch();
+      await responseGate;
+      await route.fulfill({ response: actualResponse });
+    });
+    // Synthetic fixture proof: the server's provider adapter blocks all real SlipOK traffic.
+    await transfer.getByLabel('แนบสลิปการโอนเงิน').setInputFiles({ name: 'fixture.png', mimeType: 'image/png', buffer: Buffer.from('fixture-only') });
+    await transfer.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }).click();
+    await expect(transfer.getByRole('button', { name: 'กำลังตรวจสอบสลิป...' })).toBeDisabled();
+    await page.keyboard.press('Escape');
+    await expect(transfer).toBeVisible();
+    releaseResponse();
+    await expect(transfer.getByText('ยังดำเนินการไม่สำเร็จ', { exact: true })).toBeVisible();
+    await expect(transfer.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeEnabled();
+    await transfer.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }).click();
+    await expect(transfer.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeEnabled();
+    await transfer.getByRole('button', { name: 'ตรวจสถานะอีกครั้ง' }).click();
+    await expect(transfer.getByText('รายการนี้ยังรอหลักฐานการชำระเงิน', { exact: true })).toBeVisible();
+    expect(intentCreations).toBe(0);
+    expect(network.blockedRequests).toEqual([]);
+  });
+}

--- a/src/app/api/checkout/review/route.ts
+++ b/src/app/api/checkout/review/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { auth } from '@/lib/auth';
+import { loadOrderReview, OrderReviewError } from '@/lib/order-review';
+import { checkRateLimit, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
+
+const reviewSchema = z.object({
+  courseId: z.string().trim().min(1).max(36).optional(),
+  bundleId: z.string().trim().min(1).max(36).optional(),
+  couponCode: z.string().trim().min(1).max(100).optional(),
+}).strict().refine((value) => Boolean(value.courseId) !== Boolean(value.bundleId))
+  .refine((value) => !value.bundleId || !value.couponCode);
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: 'กรุณาเข้าสู่ระบบ' }, { status: 401 });
+  const limit = checkRateLimit(`order-review:${session.user.id}`, rateLimits.sensitive);
+  if (!limit.success) return rateLimitResponse(limit.resetTime);
+  const parsed = reviewSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ error: 'ข้อมูลรายการไม่ถูกต้อง' }, { status: 400 });
+  try {
+    const review = await loadOrderReview(session.user.id, parsed.data);
+    return NextResponse.json({ review }, { headers: { 'Cache-Control': 'private, no-store' } });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof OrderReviewError ? error.message : 'ยังตรวจสอบรายการไม่ได้ กรุณาลองใหม่' }, {
+      status: error instanceof OrderReviewError ? error.status : 500,
+    });
+  }
+}

--- a/src/app/api/promptpay/intents/route.ts
+++ b/src/app/api/promptpay/intents/route.ts
@@ -17,6 +17,7 @@ import {
   lessons,
   payments,
 } from '@/lib/db/schema';
+import { loadPromptPayPresentation } from '@/lib/promptpay-presentation';
 import { PROMPTPAY_INTENT_TTL_MS } from '@/lib/promptpay-intent';
 import { checkRateLimit, rateLimits, rateLimitResponse } from '@/lib/rate-limit';
 
@@ -24,6 +25,7 @@ const intentSchema = z.object({
   courseId: z.string().min(1).max(36).optional(),
   bundleId: z.string().min(1).max(36).optional(),
   couponId: z.string().min(1).max(36).optional(),
+  expectedAmount: z.string().regex(/^\d{1,8}\.\d{2}$/).optional(),
 }).strict().superRefine((value, context) => {
   if (Boolean(value.courseId) === Boolean(value.bundleId)) {
     context.addIssue({ code: 'custom', message: 'Exactly one payment target is required' });
@@ -46,7 +48,7 @@ export async function POST(request: Request) {
     const rateLimit = checkRateLimit(`promptpay-intent:${session.user.id}`, rateLimits.sensitive);
     if (!rateLimit.success) return rateLimitResponse(rateLimit.resetTime);
 
-    const parsed = intentSchema.safeParse(await request.json());
+    const parsed = intentSchema.safeParse(await request.json().catch(() => null));
     if (!parsed.success) {
       return NextResponse.json({ error: 'Invalid payment target' }, { status: 400 });
     }
@@ -110,7 +112,11 @@ export async function POST(request: Request) {
           couponId = coupon.id;
         }
 
+        amount = Math.round(amount * 100) / 100;
         if (!Number.isFinite(amount) || amount <= 0) unavailable('PAYMENT_AMOUNT_INVALID', 400);
+        if (parsed.data.expectedAmount !== undefined && parsed.data.expectedAmount !== amount.toFixed(2)) {
+          unavailable('ราคาเปลี่ยนแปลง กรุณาตรวจสอบรายการและยืนยันยอดใหม่');
+        }
         await tx.insert(payments).values({
           id: paymentId,
           userId: session.user.id,
@@ -172,6 +178,9 @@ export async function POST(request: Request) {
 
       const amount = Number(bundle.price);
       if (!Number.isFinite(amount) || amount <= 0) unavailable('PAYMENT_AMOUNT_INVALID', 400);
+      if (parsed.data.expectedAmount !== undefined && parsed.data.expectedAmount !== amount.toFixed(2)) {
+        unavailable('ราคาเปลี่ยนแปลง กรุณาตรวจสอบรายการและยืนยันยอดใหม่');
+      }
       await tx.insert(payments).values({
         id: paymentId,
         userId: session.user.id,
@@ -199,5 +208,21 @@ export async function POST(request: Request) {
     const message = error instanceof Error && status !== 500 ? error.message : 'Failed to create payment intent';
     if (status === 500) console.error('Error creating PromptPay intent:', error);
     return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function GET(request: Request) {
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: 'กรุณาเข้าสู่ระบบ' }, { status: 401 });
+  const limit = checkRateLimit(`promptpay-status:${session.user.id}`, rateLimits.sensitive);
+  if (!limit.success) return rateLimitResponse(limit.resetTime);
+  const parsed = z.string().min(1).max(36).safeParse(new URL(request.url).searchParams.get('paymentId'));
+  if (!parsed.success) return NextResponse.json({ error: 'ข้อมูลรายการไม่ถูกต้อง' }, { status: 400 });
+  try {
+    const result = await loadPromptPayPresentation(session.user.id, parsed.data);
+    if (!result) return NextResponse.json({ error: 'ไม่พบรายการ' }, { status: 404 });
+    return NextResponse.json(result, { headers: { 'Cache-Control': 'private, no-store' } });
+  } catch {
+    return NextResponse.json({ error: 'ยังตรวจสอบสถานะไม่ได้' }, { status: 503 });
   }
 }

--- a/src/app/api/stripe/bundle-checkout/route.ts
+++ b/src/app/api/stripe/bundle-checkout/route.ts
@@ -14,6 +14,7 @@ import { measurementRecorder } from '@/lib/measurement-recorder';
 const stripeBundleCheckoutRequestSchema = z.object({
     bundleId: z.string().trim().min(1).max(36),
     exposureId: analyticsExposureIdSchema.optional(),
+    expectedAmount: z.string().regex(/^\d{1,8}\.\d{2}$/).optional(),
 }).strict();
 
 
@@ -109,6 +110,10 @@ export async function POST(request: Request) {
         }
 
         const courseNames = bCourses.map(c => c.courseTitle).join(', ');
+
+        if (parsed.data.expectedAmount !== undefined && parsed.data.expectedAmount !== priceNumber.toFixed(2)) {
+            return NextResponse.json({ error: 'ราคาเปลี่ยนแปลง กรุณาตรวจสอบรายการและยืนยันยอดใหม่' }, { status: 409 });
+        }
 
         // A checkout session is an immutable payment attempt. Reusing and repricing
         // an older pending row would let multiple Stripe sessions point at mutable

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -16,6 +16,7 @@ const stripeCheckoutRequestSchema = z.object({
     courseId: z.string().trim().min(1).max(36),
     couponId: z.string().trim().min(1).max(36).optional(),
     exposureId: analyticsExposureIdSchema.optional(),
+    expectedAmount: z.string().regex(/^\d{1,8}\.\d{2}$/).optional(),
 }).strict();
 
 
@@ -105,11 +106,20 @@ export async function POST(request: Request) {
             }
         }
 
+        if (couponId && appliedCouponId !== couponId) {
+            return NextResponse.json({ error: 'คูปองนี้ใช้ไม่ได้แล้ว กรุณาตรวจสอบรายการใหม่' }, { status: 400 });
+        }
+
+        priceNumber = Math.round(priceNumber * 100) / 100;
         if (priceNumber <= 0) {
             return NextResponse.json(
                 { error: "This course is free" },
                 { status: 400 }
             );
+        }
+
+        if (parsed.data.expectedAmount !== undefined && parsed.data.expectedAmount !== priceNumber.toFixed(2)) {
+            return NextResponse.json({ error: 'ราคาเปลี่ยนแปลง กรุณาตรวจสอบรายการและยืนยันยอดใหม่' }, { status: 409 });
         }
 
         // A checkout session is an immutable payment attempt. Reusing and repricing

--- a/src/app/bundles/[slug]/page.tsx
+++ b/src/app/bundles/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import PaymentCancellationNotice from '@/components/checkout/PaymentCancellationNotice';
 import MainContent from '@/components/layout/MainContent';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -31,6 +32,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/componen
 export const dynamic = 'force-dynamic';
 
 interface Props {
+  searchParams?: Promise<{ payment?: string | string[] }>;
   params: Promise<{ slug: string }>;
 }
 
@@ -184,8 +186,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function BundleDetailPage({ params }: Props) {
+export default async function BundleDetailPage({ params, searchParams }: Props) {
   const { slug } = await params;
+  const cancelled = (await searchParams)?.payment === 'cancelled';
   const bundle = await getBundle(slug);
 
   if (!bundle) notFound();
@@ -248,6 +251,7 @@ export default async function BundleDetailPage({ params }: Props) {
       <Navbar />
       <AnalyticsViewEvent productType="bundle" productId={bundle.id}>
         <MainContent className="min-h-screen bg-background text-foreground">
+          {cancelled ? <PaymentCancellationNotice /> : null}
         <header className="border-b bg-muted/30">
           <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
             <NavigationBreadcrumbs

--- a/src/app/courses/[slug]/page.tsx
+++ b/src/app/courses/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import PaymentCancellationNotice from '@/components/checkout/PaymentCancellationNotice';
 import MainContent from '@/components/layout/MainContent';
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
@@ -35,6 +36,7 @@ function normalizeUrl(url: string | null): string | null {
 export const revalidate = 3600;
 
 interface Props {
+  searchParams?: Promise<{ payment?: string | string[] }>;
   params: Promise<{ slug: string }>;
 }
 
@@ -124,8 +126,9 @@ async function getCourse(slug: string) {
   };
 }
 
-export default async function CourseDetailPage({ params }: Props) {
+export default async function CourseDetailPage({ params, searchParams }: Props) {
   const { slug } = await params;
+  const cancelled = (await searchParams)?.payment === 'cancelled';
   const course = await getCourse(slug);
 
   if (!course) {
@@ -243,6 +246,7 @@ export default async function CourseDetailPage({ params }: Props) {
       <CourseDetailProvider>
         <AnalyticsViewEvent productType="course" productId={course.id}>
           <MainContent className="min-h-screen bg-background text-foreground">
+          {cancelled ? <PaymentCancellationNotice /> : null}
 
           <header className="bg-[radial-gradient(circle_at_12%_8%,var(--color-accent-soft),transparent_36%),linear-gradient(180deg,var(--academy-canvas),var(--background))]">
             <div className="mx-auto grid max-w-7xl gap-10 px-4 py-12 sm:px-6 lg:grid-cols-[minmax(0,1fr)_25rem] lg:gap-14 lg:px-8 lg:py-20">

--- a/src/components/bundle/BundleEnrollButton.tsx
+++ b/src/components/bundle/BundleEnrollButton.tsx
@@ -1,504 +1,76 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useRef, useState } from 'react';
-import { CircleAlert, CircleCheck, CreditCard, ImagePlus, Smartphone, X } from 'lucide-react';
-import DialogShell from '@/components/ui/DialogShell';
+import { CircleAlert, CircleCheck } from 'lucide-react';
+import CheckoutDialog, { CHECKOUT_CONTRACT } from '@/components/checkout/CheckoutDialog';
 import Modal from '@/components/ui/Modal';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
-import { Field, FieldLabel } from '@/components/ui/field';
-import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { trackClientAnalyticsEvent } from '@/components/analytics/analytics-client';
 import { useProductExposureId } from '@/components/analytics/AnalyticsViewEvent';
 import type { BundleDecisionFacts } from '@/lib/bundle-decision-facts';
 
-type BundleEnrollmentDecisionFacts = Pick<
-  BundleDecisionFacts,
-  'price' | 'ownership' | 'actions'
->;
-
 interface BundleEnrollButtonProps {
   bundleId: string;
   bundleSlug: string;
-  decisionFacts: BundleEnrollmentDecisionFacts;
+  decisionFacts: Pick<BundleDecisionFacts, 'price' | 'ownership' | 'actions'>;
 }
 
-type PaymentStep = 'idle' | 'method' | 'transfer' | 'verifying';
-
 export const BUNDLE_PAYMENT_CONTRACT = {
-  enrollEndpoint: '/api/bundles/enroll',
-  stripeEndpoint: '/api/stripe/bundle-checkout',
-  intentEndpoint: '/api/promptpay/intents',
-  slipEndpoint: '/api/bundles/slip/verify',
-  slipFields: {
-    file: 'slip',
-    paymentId: 'paymentId',
-  },
-  allowedSlipTypes: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'] as readonly string[],
-  maxSlipBytes: 5 * 1024 * 1024,
+  ...CHECKOUT_CONTRACT,
+  enrollEndpoint: '/api/bundles/enroll', stripeEndpoint: '/api/stripe/bundle-checkout',
+  slipEndpoint: '/api/bundles/slip/verify', slipFields: { file: 'slip', paymentId: 'paymentId' },
 } as const;
 
-export default function BundleEnrollButton({
-  bundleId,
-  bundleSlug,
-  decisionFacts,
-}: BundleEnrollButtonProps) {
-  const price = decisionFacts.price.bundle;
+export default function BundleEnrollButton({ bundleId, bundleSlug, decisionFacts }: BundleEnrollButtonProps) {
   const router = useRouter();
   const session = useSession()?.data;
   const exposureId = useProductExposureId();
   const [loading, setLoading] = useState(false);
   const [enrolled, setEnrolled] = useState(false);
-  const [paymentStep, setPaymentStep] = useState<PaymentStep>('idle');
-  const [slipFile, setSlipFile] = useState<File | null>(null);
-  const [slipPreview, setSlipPreview] = useState<string | null>(null);
-  const [verifyError, setVerifyError] = useState<string | null>(null);
-  const [promptPayIntent, setPromptPayIntent] = useState<{ paymentId: string; amount: number } | null>(null);
-  const enrollmentTriggerRef = useRef<HTMLButtonElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [modal, setModal] = useState<{
-    isOpen: boolean;
-    type: 'success' | 'error';
-    title: string;
-    message: string;
-  }>({ isOpen: false, type: 'success', title: '', message: '' });
-
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const handleEnroll = async () => {
     if (!session) {
       router.push(`/login?callbackUrl=/bundles/${bundleSlug}`);
       return;
     }
-
-    if (price > 0) {
-      trackClientAnalyticsEvent({
-        eventName: 'checkout_opened',
-        bundleId,
-        placement: 'bundle_detail',
-      });
-      setPaymentStep('method');
+    if (decisionFacts.price.bundle > 0) {
+      trackClientAnalyticsEvent({ eventName: 'checkout_opened', bundleId, placement: 'bundle_detail' });
+      setOpen(true);
       return;
     }
-
     setLoading(true);
     try {
-      const res = await fetch(BUNDLE_PAYMENT_CONTRACT.enrollEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundleId }),
+      const response = await fetch(BUNDLE_PAYMENT_CONTRACT.enrollEndpoint, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ bundleId }),
       });
-      const data = await res.json();
-
-      if (res.ok) {
-        setEnrolled(true);
-        setModal({
-          isOpen: true,
-          type: 'success',
-          title: 'ลงทะเบียนสำเร็จ!',
-          message: `คุณลงทะเบียน Bundle เรียบร้อยแล้ว (${data.totalEnrolled} คอร์ส)`,
-        });
-      } else {
-        setModal({
-          isOpen: true,
-          type: 'error',
-          title: 'เกิดข้อผิดพลาด',
-          message: data.error || 'ไม่สามารถลงทะเบียนได้',
-        });
-      }
-    } catch {
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'เกิดข้อผิดพลาด',
-        message: 'ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่',
-      });
-    } finally {
-      setLoading(false);
-    }
+      const data = await response.json();
+      if (response.ok) { setEnrolled(true); router.refresh(); }
+      else setError(data.error || 'ไม่สามารถลงทะเบียนได้');
+    } catch { setError('ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่'); }
+    finally { setLoading(false); }
   };
-
-  const handleStripePayment = async () => {
-    setLoading(true);
-    try {
-      const res = await fetch(BUNDLE_PAYMENT_CONTRACT.stripeEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundleId, ...(exposureId && { exposureId }) }),
-      });
-      const data = await res.json();
-      if (res.ok && data.url) {
-        window.location.href = data.url;
-        return;
-      }
-
-      setPaymentStep('idle');
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'เกิดข้อผิดพลาด',
-        message: data.error || 'ไม่สามารถสร้างหน้าชำระเงินได้ กรุณาลองใหม่',
-      });
-    } catch {
-      setPaymentStep('idle');
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'เกิดข้อผิดพลาด',
-        message: 'ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    if (!BUNDLE_PAYMENT_CONTRACT.allowedSlipTypes.includes(file.type)) {
-      resetSlipState();
-      setVerifyError('รองรับเฉพาะไฟล์ JPG, PNG, WEBP เท่านั้น');
-      return;
-    }
-    if (file.size > BUNDLE_PAYMENT_CONTRACT.maxSlipBytes) {
-      resetSlipState();
-      setVerifyError('ไฟล์ต้องมีขนาดไม่เกิน 5MB');
-      return;
-    }
-
-    setSlipFile(file);
-    setVerifyError(null);
-    const reader = new FileReader();
-    reader.onload = (readerEvent) => setSlipPreview(readerEvent.target?.result as string);
-    reader.readAsDataURL(file);
-  };
-
-  const handlePromptPayPayment = async () => {
-    setLoading(true);
-    setVerifyError(null);
-    try {
-      const res = await fetch(BUNDLE_PAYMENT_CONTRACT.intentEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundleId }),
-      });
-      const data = await res.json();
-      if (!res.ok || !data.paymentId || typeof data.amount !== 'number') {
-        setModal({ isOpen: true, type: 'error', title: 'ไม่สามารถเริ่มรายการชำระเงิน', message: data.error || 'กรุณาลองใหม่' });
-        return;
-      }
-      setPromptPayIntent({ paymentId: data.paymentId, amount: data.amount });
-      setPaymentStep('transfer');
-    } catch {
-      setModal({ isOpen: true, type: 'error', title: 'ไม่สามารถเริ่มรายการชำระเงิน', message: 'ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่' });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleSlipVerify = async () => {
-    if (!slipFile || !promptPayIntent) return;
-    setPaymentStep('verifying');
-    setVerifyError(null);
-
-    try {
-      const formData = new FormData();
-      formData.append(BUNDLE_PAYMENT_CONTRACT.slipFields.file, slipFile);
-      formData.append(BUNDLE_PAYMENT_CONTRACT.slipFields.paymentId, promptPayIntent.paymentId);
-
-      const res = await fetch(BUNDLE_PAYMENT_CONTRACT.slipEndpoint, {
-        method: 'POST',
-        body: formData,
-      });
-      const data = await res.json();
-
-      if (res.ok && data.success) {
-        setEnrolled(true);
-        setPaymentStep('idle');
-        setPromptPayIntent(null);
-        resetSlipState();
-        setModal({
-          isOpen: true,
-          type: 'success',
-          title: 'ชำระเงินสำเร็จ!',
-          message: `ตรวจสอบสลิปเรียบร้อย ลงทะเบียน ${data.enrolled?.length || 0} คอร์สสำเร็จ`,
-        });
-      } else {
-        setPaymentStep('transfer');
-        setVerifyError(data.error || 'ไม่สามารถตรวจสอบสลิปได้ กรุณาลองใหม่');
-      }
-    } catch {
-      setPaymentStep('transfer');
-      setVerifyError('เกิดข้อผิดพลาดในการเชื่อมต่อ กรุณาลองใหม่');
-    }
-  };
-
-  const resetSlipState = () => {
-    setSlipFile(null);
-    setSlipPreview(null);
-    setVerifyError(null);
-    if (fileInputRef.current) fileInputRef.current.value = '';
-  };
-
-  const handleModalClose = () => {
-    setModal({ ...modal, isOpen: false });
-    if (modal.type === 'success') router.refresh();
-  };
-
-  const closeTransfer = () => {
-    if (paymentStep === 'verifying') return;
-    setPaymentStep('idle');
-    resetSlipState();
-  };
-
-  const renderOwnershipNotice = () => decisionFacts.ownership.disclosure ? (
-    <Alert>
-      <CircleAlert aria-hidden="true" />
-      <AlertTitle>มีบางคอร์สอยู่ในบัญชีแล้ว</AlertTitle>
-      <AlertDescription>{decisionFacts.ownership.disclosure}</AlertDescription>
-    </Alert>
-  ) : null;
 
   if (enrolled || decisionFacts.ownership.status === 'complete') {
-    return (
-      <Button asChild className="w-full">
-        <Link href={decisionFacts.actions.complete.href}>
-          <CircleCheck data-icon="inline-start" aria-hidden="true" />
-          {decisionFacts.actions.complete.label}
-        </Link>
-      </Button>
-    );
+    return <Button asChild className="w-full"><Link href={decisionFacts.actions.complete.href}><CircleCheck data-icon="inline-start" aria-hidden="true" />{decisionFacts.actions.complete.label}</Link></Button>;
   }
-
+  const disclosure = decisionFacts.ownership.disclosure ? <Alert><CircleAlert aria-hidden="true" /><AlertTitle>มีบางคอร์สอยู่ในบัญชีแล้ว</AlertTitle><AlertDescription>{decisionFacts.ownership.disclosure}</AlertDescription></Alert> : null;
   if (decisionFacts.actions.acquisition.kind === 'unavailable') {
-    return (
-      <div className="flex flex-col gap-4">
-        {renderOwnershipNotice()}
-        <Empty className="border">
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <CircleAlert aria-hidden="true" />
-            </EmptyMedia>
-            <EmptyTitle>Bundle นี้กำลังเตรียมเนื้อหา</EmptyTitle>
-            <EmptyDescription>จะเปิดรับสมัครเมื่อทุกคอร์สใน Bundle มีบทเรียนพร้อมแล้ว</EmptyDescription>
-          </EmptyHeader>
-          <Button type="button" className="w-full" disabled>{decisionFacts.actions.acquisition.label}</Button>
-        </Empty>
-      </div>
-    );
+    return <div className="flex flex-col gap-4">{disclosure}<Empty className="border"><EmptyHeader><EmptyMedia variant="icon"><CircleAlert aria-hidden="true" /></EmptyMedia><EmptyTitle>Bundle นี้กำลังเตรียมเนื้อหา</EmptyTitle><EmptyDescription>จะเปิดรับสมัครเมื่อทุกคอร์สใน Bundle มีบทเรียนพร้อมแล้ว</EmptyDescription></EmptyHeader></Empty></div>;
   }
-
   return (
     <>
-      {decisionFacts.ownership.disclosure ? (
-        <div className="mb-4">{renderOwnershipNotice()}</div>
-      ) : null}
-      <Button
-        ref={enrollmentTriggerRef}
-        className="w-full"
-        type="button"
-        onClick={handleEnroll}
-        disabled={loading}
-        aria-busy={loading}
-      >
-        {loading && <Spinner data-icon="inline-start" aria-hidden="true" />}
-        {loading
-          ? 'กำลังดำเนินการ...'
-          : decisionFacts.actions.acquisition.label}
-      </Button>
-
-      <DialogShell
-        isOpen={paymentStep === 'method'}
-        onClose={() => setPaymentStep('idle')}
-        title={'เลือกช่องทางชำระเงิน'}
-        description={<span>ยอดชำระ <strong>{decisionFacts.price.bundleFormatted}</strong></span>}
-        body={(
-          <div className="flex flex-col gap-4" data-payment-step="method">
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle>ตรวจสอบรายการ Bundle</CardTitle>
-                <CardDescription>ยอดนี้อ้างอิงราคาซื้อแยกของแต่ละคอร์ส ณ ตอนนี้</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <dl className="grid gap-3 text-sm">
-                  <div className="flex items-center justify-between gap-4">
-                    <dt className="text-muted-foreground">ซื้อแยกวันนี้</dt>
-                    <dd>{decisionFacts.price.separateCurrentFormatted}</dd>
-                  </div>
-                  <div className="flex items-center justify-between gap-4">
-                    <dt className="text-muted-foreground">ราคา Bundle</dt>
-                    <dd><strong>{decisionFacts.price.bundleFormatted}</strong></dd>
-                  </div>
-                  <div className="flex items-center justify-between gap-4">
-                    <dt className="text-muted-foreground">เปรียบเทียบ</dt>
-                    <dd><strong>{decisionFacts.price.comparison.label}</strong></dd>
-                  </div>
-                </dl>
-              </CardContent>
-            </Card>
-            {renderOwnershipNotice()}
-            <ToggleGroup
-            type="single"
-            orientation="vertical"
-            variant="outline"
-            className="w-full"
-            aria-label="ช่องทางชำระเงิน"
-            onValueChange={(value) => {
-              if (value === 'promptpay') void handlePromptPayPayment();
-              if (value === 'stripe') {
-                setPaymentStep('idle');
-                void handleStripePayment();
-              }
-            }}
-          >
-            <ToggleGroupItem
-              value="promptpay"
-              disabled={loading}
-              className="h-auto w-full justify-start p-4 text-left whitespace-normal"
-            >
-              <Smartphone aria-hidden="true" />
-              <span className="flex flex-col items-start gap-1">
-                <strong>โอนเงิน / PromptPay</strong>
-                <span>โอนเงินแล้วแนบสลิปเพื่อตรวจสอบอัตโนมัติ</span>
-              </span>
-            </ToggleGroupItem>
-
-            <ToggleGroupItem
-              value="stripe"
-              disabled={loading}
-              className="h-auto w-full justify-start p-4 text-left whitespace-normal"
-            >
-              <CreditCard aria-hidden="true" />
-              <span className="flex flex-col items-start gap-1">
-                <strong>{loading ? 'กำลังเปิดหน้าชำระเงิน...' : 'บัตรเครดิต / เดบิต'}</strong>
-                <span>ชำระผ่าน Stripe (Visa, Mastercard)</span>
-              </span>
-            </ToggleGroupItem>
-            </ToggleGroup>
-          </div>
-        )}
-        dismissOnBackdrop={true}
-        returnFocusRef={enrollmentTriggerRef}
-        size={'wide'}
-      >
-        <Button type="button" variant="outline" onClick={() => setPaymentStep('idle')}>ยกเลิก</Button>
-      </DialogShell>
-
-      <DialogShell
-        isOpen={paymentStep === 'transfer' || paymentStep === 'verifying'}
-        onClose={closeTransfer}
-        title={'โอนเงินและแนบสลิป'}
-        description={<span>ยอดที่ระบบจะตรวจสอบ <strong>฿{(promptPayIntent?.amount ?? price).toLocaleString()}</strong></span>}
-        body={(
-          <div className="flex flex-col gap-5" data-payment-step={paymentStep}>
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle>ข้อมูลสำหรับโอนเงิน</CardTitle>
-                <CardDescription>ตรวจสอบชื่อบัญชีและจำนวนเงินก่อนโอน</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <dl className="grid gap-3">
-                  <div className="flex items-center justify-between gap-4"><dt>ธนาคาร</dt><dd><strong>{process.env.NEXT_PUBLIC_BANK_NAME || 'กสิกรไทย (KBank)'}</strong></dd></div>
-                  <div className="flex items-center justify-between gap-4"><dt>เลขบัญชี</dt><dd><strong className="font-mono">{process.env.NEXT_PUBLIC_BANK_ACCOUNT || 'xxx-x-xxxxx-x'}</strong></dd></div>
-                  <div className="flex items-center justify-between gap-4"><dt>ชื่อบัญชี</dt><dd><strong>{process.env.NEXT_PUBLIC_BANK_ACCOUNT_NAME || 'MilerDev'}</strong></dd></div>
-                  <div className="flex items-center justify-between gap-4"><dt>จำนวนเงิน</dt><dd><strong>฿{(promptPayIntent?.amount ?? price).toLocaleString()}</strong></dd></div>
-                </dl>
-              </CardContent>
-            </Card>
-
-            <Field data-invalid={Boolean(verifyError) || undefined}>
-              <FieldLabel htmlFor="bundle-slip-upload">แนบสลิปการโอนเงิน</FieldLabel>
-              {!slipPreview ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="h-auto w-full flex-col py-8 whitespace-normal"
-                >
-                  <ImagePlus data-icon="inline-start" aria-hidden="true" />
-                  <span>คลิกเพื่อเลือกรูปสลิป</span>
-                  <span>JPG, PNG, WEBP (ไม่เกิน 5MB)</span>
-                </Button>
-              ) : (
-                <div className="relative overflow-hidden rounded-xl border bg-muted">
-                  <Image src={slipPreview} alt="สลิป" width={720} height={900} unoptimized className="h-auto w-full" />
-                  <Button
-                    type="button"
-                    onClick={resetSlipState}
-                    variant="destructive"
-                    size="icon-sm"
-                    className="absolute top-2 right-2"
-                    aria-label="ลบรูปสลิปที่เลือก"
-                  >
-                    <X data-icon="inline-start" aria-hidden="true" />
-                  </Button>
-                </div>
-              )}
-              <Input
-                id="bundle-slip-upload"
-                ref={fileInputRef}
-                className="sr-only"
-                type="file"
-                tabIndex={-1}
-                accept="image/jpeg,image/jpg,image/png,image/webp"
-                onChange={handleFileChange}
-                aria-invalid={Boolean(verifyError) || undefined}
-              />
-            </Field>
-
-            {verifyError ? (
-              <Alert variant="destructive">
-                <CircleAlert aria-hidden="true" />
-                <AlertTitle>ตรวจสอบสลิปไม่สำเร็จ</AlertTitle>
-                <AlertDescription>{verifyError}</AlertDescription>
-              </Alert>
-            ) : null}
-          </div>
-        )}
-        dismissOnBackdrop={paymentStep !== 'verifying'}
-        returnFocusRef={enrollmentTriggerRef}
-        size={'wide'}
-      >
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => { setPaymentStep('method'); setPromptPayIntent(null); resetSlipState(); }}
-          disabled={paymentStep === 'verifying'}
-        >
-          กลับ
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSlipVerify}
-          disabled={!slipFile || !promptPayIntent || paymentStep === 'verifying'}
-          aria-busy={paymentStep === 'verifying'}
-        >
-          {paymentStep === 'verifying' ? (
-            <>
-              <Spinner data-icon="inline-start" aria-hidden="true" />
-              กำลังตรวจสอบสลิป...
-            </>
-          ) : 'ตรวจสอบและชำระเงิน'}
-        </Button>
-      </DialogShell>
-
-      <Modal
-        isOpen={modal.isOpen}
-        onClose={handleModalClose}
-        returnFocusRef={enrollmentTriggerRef}
-        type={modal.type}
-        title={modal.title}
-        buttonText={modal.type === 'success' ? 'เรียบร้อย' : 'ตกลง'}
-      >
-        {modal.message}
-      </Modal>
+      {disclosure}
+      <Button ref={triggerRef} type="button" onClick={handleEnroll} disabled={loading} className="w-full" aria-busy={loading}>{loading ? <><Spinner data-icon="inline-start" aria-hidden="true" />กำลังดำเนินการ...</> : decisionFacts.actions.acquisition.label}</Button>
+      <CheckoutDialog key={`${session?.user.id}:${bundleId}`} open={open} onClose={() => setOpen(false)} target={{ type: 'bundle', id: bundleId }} exposureId={exposureId} returnFocusRef={triggerRef} onEnrolled={() => { setEnrolled(true); router.refresh(); }} />
+      <Modal isOpen={Boolean(error)} onClose={() => setError(null)} returnFocusRef={triggerRef} type="error" title="เกิดข้อผิดพลาด">{error}</Modal>
     </>
   );
 }

--- a/src/components/checkout/CheckoutDialog.tsx
+++ b/src/components/checkout/CheckoutDialog.tsx
@@ -145,7 +145,7 @@ export default function CheckoutDialog({ open, onClose, target, exposureId, retu
       });
       const data = await response.json();
       if (!response.ok) {
-        if (response.status >= 500) setUncertain(true);
+        if (response.status >= 500 && method !== 'free') setUncertain(true);
         setReview(null);
         setError(data.error || 'ยังเริ่มรายการไม่ได้ กรุณาตรวจสอบรายการอีกครั้ง');
         return;
@@ -163,8 +163,11 @@ export default function CheckoutDialog({ open, onClose, target, exposureId, retu
         setError('ยังยืนยันผลการเริ่มรายการไม่ได้ กรุณาดูประวัติการชำระเงินก่อนลองใหม่');
       }
     } catch {
-      setUncertain(true);
-      setError('การเชื่อมต่อขาดหาย ยังยืนยันผลรายการไม่ได้ อย่าชำระซ้ำ กรุณาดูประวัติการชำระเงิน');
+      setReview(null);
+      setUncertain(method !== 'free');
+      setError(method === 'free'
+        ? 'ยังยืนยันผลการลงทะเบียนไม่ได้ กรุณาตรวจสอบรายการอีกครั้งเพื่อดูสิทธิ์เรียนล่าสุด'
+        : 'การเชื่อมต่อขาดหาย ยังยืนยันผลรายการไม่ได้ อย่าชำระซ้ำ กรุณาดูประวัติการชำระเงิน');
     } finally {
       busyRef.current = false;
       setLoading(false);
@@ -181,7 +184,7 @@ export default function CheckoutDialog({ open, onClose, target, exposureId, retu
       if (!response.ok || !data.presentation) throw new Error();
       setPresentation(data.presentation);
       setUncertain(!data.canSubmitSlip);
-      if (data.canSubmitSlip) setError(null);
+      setError(null);
       if (data.presentation.payment.state === 'completed-ready') {
         onEnrolled();
         onClose();
@@ -303,14 +306,14 @@ export default function CheckoutDialog({ open, onClose, target, exposureId, retu
                   </Field>
                 </FieldGroup>
               ) : null}
-              {!review && (error || couponError) && !uncertain ? <Button type="button" variant="outline" disabled={pending} onClick={() => refreshReview()}>ตรวจสอบรายการใหม่โดยไม่ใช้คูปอง</Button> : null}
+              {!review && (error || couponError) && !uncertain ? <Button type="button" variant="outline" className="h-auto min-h-11 whitespace-normal py-3" disabled={pending} onClick={() => refreshReview()}>ตรวจสอบรายการใหม่โดยไม่ใช้คูปอง</Button> : null}
               {review?.action === 'unavailable' ? <Alert><AlertTitle>ยังไม่เปิดรับสมัคร</AlertTitle><AlertDescription>สินค้านี้ยังไม่พร้อมรับการลงทะเบียน กรุณากลับมาตรวจสอบภายหลัง</AlertDescription></Alert> : null}
               {review?.action === 'owned' ? <Button asChild><Link href="/dashboard">ไปการเรียนของฉัน</Link></Button> : null}
               {review?.action === 'pay' && !uncertain ? <div className="flex flex-col gap-3" role="group" aria-label="ช่องทางชำระเงิน">
                 <Button type="button" variant="outline" className="h-auto min-h-11 whitespace-normal py-3" disabled={pending} onClick={() => startPayment('stripe')}><CreditCard data-icon="inline-start" aria-hidden="true" />ชำระด้วยบัตรผ่าน Stripe</Button>
                 <Button type="button" variant="outline" className="h-auto min-h-11 whitespace-normal py-3" disabled={pending} onClick={() => startPayment('promptpay')}><Smartphone data-icon="inline-start" aria-hidden="true" />โอนเงิน / PromptPay</Button>
               </div> : null}
-              {review?.action === 'enroll-free' && !uncertain ? <Button type="button" disabled={pending} onClick={() => startPayment('free')}>{review.coupon ? 'ลงทะเบียนเรียนฟรี (คูปอง 100%)' : 'ยืนยันลงทะเบียนเรียนฟรี'}</Button> : null}
+              {review?.action === 'enroll-free' && !uncertain ? <Button type="button" className="h-auto min-h-11 whitespace-normal py-3" disabled={pending} onClick={() => startPayment('free')}>{review.coupon ? 'ลงทะเบียนเรียนฟรี (คูปอง 100%)' : 'ยืนยันลงทะเบียนเรียนฟรี'}</Button> : null}
               {loading ? <p role="status"><Spinner aria-hidden="true" />กำลังดำเนินการ...</p> : null}
             </>
           )}

--- a/src/components/checkout/CheckoutDialog.tsx
+++ b/src/components/checkout/CheckoutDialog.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useId, useRef, useState, type RefObject } from 'react';
+import { CreditCard, Smartphone, X } from 'lucide-react';
+import DialogShell from '@/components/ui/DialogShell';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
+import OrderReviewSummary, { formatOrderAmount } from './OrderReviewSummary';
+import type { OrderReview } from '@/lib/order-review';
+import type { PaymentPresentation } from '@/lib/payment-presentation';
+
+export const CHECKOUT_CONTRACT = {
+  reviewEndpoint: '/api/checkout/review',
+  intentEndpoint: '/api/promptpay/intents',
+  allowedSlipTypes: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'] as readonly string[],
+  maxSlipBytes: 5 * 1024 * 1024,
+};
+
+type Intent = { paymentId: string; amount: number; itemTitle: string; expiresAt: string };
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  target: { type: 'course' | 'bundle'; id: string };
+  exposureId: string | null | undefined;
+  returnFocusRef: RefObject<HTMLButtonElement | null>;
+  onEnrolled: () => void;
+};
+
+export default function CheckoutDialog({ open, onClose, target, exposureId, returnFocusRef, onEnrolled }: Props) {
+  const [review, setReview] = useState<OrderReview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [couponCode, setCouponCode] = useState('');
+  const [couponError, setCouponError] = useState<string | null>(null);
+  const [intent, setIntent] = useState<Intent | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [uncertain, setUncertain] = useState(false);
+  const [presentation, setPresentation] = useState<PaymentPresentation | null>(null);
+  const [expired, setExpired] = useState(false);
+  const [slipFile, setSlipFile] = useState<File | null>(null);
+  const [slipPreview, setSlipPreview] = useState<string | null>(null);
+  const [slipError, setSlipError] = useState<string | null>(null);
+  const busyRef = useRef(false);
+  const reviewRequest = useRef(0);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const couponId = useId();
+  const slipId = useId();
+  const body = target.type === 'course' ? { courseId: target.id } : { bundleId: target.id };
+  const endpoints = target.type === 'course'
+    ? { stripe: '/api/stripe/checkout', slip: '/api/slip/verify', enroll: '/api/enroll' }
+    : { stripe: '/api/stripe/bundle-checkout', slip: '/api/bundles/slip/verify', enroll: '/api/bundles/enroll' };
+
+  useEffect(() => {
+    if (!open || intent) return;
+    const controller = new AbortController();
+    const version = ++reviewRequest.current;
+    // Every fresh opening revalidates product/ownership facts. Coupons are reapplied explicitly.
+    fetch(CHECKOUT_CONTRACT.reviewEndpoint, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(target.type === 'course' ? { courseId: target.id } : { bundleId: target.id }),
+      signal: controller.signal,
+    }).then(async (response) => {
+      const data = await response.json();
+      if (!response.ok || !data.review) throw new Error(data.error || 'ยังตรวจสอบรายการไม่ได้');
+      if (!controller.signal.aborted && version === reviewRequest.current) setReview(data.review);
+    }).catch((reason) => {
+      if (!controller.signal.aborted && version === reviewRequest.current) setError(reason instanceof Error ? reason.message : 'ยังตรวจสอบรายการไม่ได้');
+    });
+    return () => controller.abort();
+  }, [open, intent, target.type, target.id]);
+
+  useEffect(() => {
+    if (!intent) return;
+    const remaining = new Date(intent.expiresAt).getTime() - Date.now();
+    const timer = setTimeout(() => setExpired(true), Math.min(2_147_483_647, Math.max(0, remaining)));
+    return () => clearTimeout(timer);
+  }, [intent]);
+
+  useEffect(() => {
+    if (!slipFile) return;
+    const url = URL.createObjectURL(slipFile);
+    setSlipPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [slipFile]);
+
+  const close = () => {
+    if (busyRef.current) return;
+    if (!intent && !uncertain) setError(null);
+    setCouponError(null);
+    reviewRequest.current += 1;
+    setReview(null);
+    setCouponCode('');
+    setSlipFile(null);
+    setSlipPreview(null);
+    onClose();
+  };
+
+  const refreshReview = async (code?: string) => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setLoading(true);
+    if (!intent && !uncertain) setError(null);
+    setCouponError(null);
+    reviewRequest.current += 1;
+    setReview(null);
+    try {
+      const response = await fetch(CHECKOUT_CONTRACT.reviewEndpoint, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...body, ...(code ? { couponCode: code } : {}) }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.review) {
+        if (code) setCouponError(data.error || 'คูปองนี้ใช้ไม่ได้');
+        else setError(data.error || 'ยังตรวจสอบรายการไม่ได้');
+        return;
+      }
+      setReview(data.review);
+      if (!code) setCouponCode('');
+    } catch {
+      setError('ไม่สามารถเชื่อมต่อได้ กรุณาตรวจสอบรายการอีกครั้ง');
+    } finally {
+      busyRef.current = false;
+      setLoading(false);
+    }
+  };
+
+  const startPayment = async (method: 'stripe' | 'promptpay' | 'free') => {
+    if (busyRef.current || !review || intent) return;
+    busyRef.current = true;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(method === 'stripe' ? endpoints.stripe : method === 'promptpay' ? CHECKOUT_CONTRACT.intentEndpoint : endpoints.enroll, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...body, ...(review.coupon ? { couponId: review.coupon.id } : {}),
+          ...(method !== 'free' ? { expectedAmount: review.price.amountDue } : {}),
+          ...(method === 'stripe' && exposureId ? { exposureId } : {}),
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        if (response.status >= 500) setUncertain(true);
+        setReview(null);
+        setError(data.error || 'ยังเริ่มรายการไม่ได้ กรุณาตรวจสอบรายการอีกครั้ง');
+        return;
+      }
+      if (method === 'free') {
+        onEnrolled();
+        onClose();
+      } else if (method === 'stripe' && data.url) {
+        window.location.assign(data.url);
+      } else if (method === 'promptpay' && data.paymentId && typeof data.amount === 'number' && data.expiresAt) {
+        setExpired(false);
+        setIntent(data);
+      } else {
+        setUncertain(true);
+        setError('ยังยืนยันผลการเริ่มรายการไม่ได้ กรุณาดูประวัติการชำระเงินก่อนลองใหม่');
+      }
+    } catch {
+      setUncertain(true);
+      setError('การเชื่อมต่อขาดหาย ยังยืนยันผลรายการไม่ได้ อย่าชำระซ้ำ กรุณาดูประวัติการชำระเงิน');
+    } finally {
+      busyRef.current = false;
+      setLoading(false);
+    }
+  };
+
+  const checkAttempt = async () => {
+    if (!intent || busyRef.current) return;
+    busyRef.current = true;
+    setLoading(true);
+    try {
+      const response = await fetch(`${CHECKOUT_CONTRACT.intentEndpoint}?paymentId=${encodeURIComponent(intent.paymentId)}`, { cache: 'no-store' });
+      const data = await response.json();
+      if (!response.ok || !data.presentation) throw new Error();
+      setPresentation(data.presentation);
+      setUncertain(!data.canSubmitSlip);
+      if (data.canSubmitSlip) setError(null);
+      if (data.presentation.payment.state === 'completed-ready') {
+        onEnrolled();
+        onClose();
+      }
+    } catch {
+      setUncertain(true);
+      setError('ยังตรวจสอบสถานะไม่ได้ อย่าชำระซ้ำ กรุณาตรวจสถานะอีกครั้งหรือติดต่อพร้อมเลขอ้างอิง');
+    } finally {
+      busyRef.current = false;
+      setLoading(false);
+    }
+  };
+
+  const verifySlip = async () => {
+    if (busyRef.current || !intent || !slipFile || uncertain || expired || Date.now() >= new Date(intent.expiresAt).getTime()) return;
+    busyRef.current = true;
+    setVerifying(true);
+    setError(null);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 40_000);
+    try {
+      const form = new FormData();
+      form.append('slip', slipFile);
+      form.append('paymentId', intent.paymentId);
+      const response = await fetch(endpoints.slip, { method: 'POST', body: form, signal: controller.signal });
+      const data = await response.json();
+      if (response.ok && data.success) {
+        setUncertain(true);
+        setSlipFile(null);
+        setSlipPreview(null);
+        const statusResponse = await fetch(`${CHECKOUT_CONTRACT.intentEndpoint}?paymentId=${encodeURIComponent(intent.paymentId)}`, { cache: 'no-store', signal: controller.signal });
+        const status = await statusResponse.json();
+        if (!statusResponse.ok || !status.presentation) throw new Error('Status unavailable');
+        setPresentation(status.presentation);
+        if (status.presentation.payment.state === 'completed-ready') {
+          onEnrolled();
+          onClose();
+        }
+      } else {
+        // Only a definite rejection permits resubmitting the same proof/attempt.
+        setUncertain(response.status !== 400);
+        setError(response.status === 400 ? data.error || 'สลิปไม่ผ่านการตรวจสอบ กรุณาตรวจสอบสลิปเดิมและลองใหม่' : 'ผลการตรวจสอบยังไม่ยืนยัน อย่าชำระหรือส่งสลิปซ้ำ กรุณาตรวจสถานะอีกครั้ง');
+      }
+    } catch {
+      setUncertain(true);
+      setError('การตรวจสอบใช้เวลานานหรือการเชื่อมต่อขาดหาย อย่าชำระหรือส่งสลิปซ้ำ กรุณาตรวจสถานะอีกครั้ง');
+    } finally {
+      clearTimeout(timeout);
+      busyRef.current = false;
+      setVerifying(false);
+    }
+  };
+
+  const selectSlip = (file?: File) => {
+    if (busyRef.current) return;
+    setSlipFile(null);
+    setSlipPreview(null);
+    setSlipError(null);
+    if (!file) return;
+    if (!CHECKOUT_CONTRACT.allowedSlipTypes.includes(file.type)) setSlipError('รองรับเฉพาะไฟล์ JPG, PNG, WEBP เท่านั้น');
+    else if (file.size > CHECKOUT_CONTRACT.maxSlipBytes) setSlipError('ไฟล์ต้องมีขนาดไม่เกิน 5MB');
+    else setSlipFile(file);
+  };
+  const pending = loading || verifying;
+
+  return (
+    <DialogShell
+      isOpen={open} onClose={close} returnFocusRef={returnFocusRef} size="wide"
+      title={intent ? 'โอนเงินและแนบสลิป' : 'เลือกช่องทางชำระเงิน'}
+      description={intent ? 'ใช้รายการและยอดนี้ในการตรวจสอบสลิป หากโอนแล้วอย่าชำระซ้ำ' : 'ทบทวนสินค้า ยอดชำระ และสิทธิ์เรียนก่อนเลือกวิธีชำระเงิน'}
+      body={(
+        <div className="flex min-w-0 flex-col gap-4" aria-busy={pending}>
+          {error ? <Alert variant="destructive"><AlertTitle>ยังดำเนินการไม่สำเร็จ</AlertTitle><AlertDescription>{error}</AlertDescription></Alert> : null}
+          {intent ? (
+            <>
+              <p className="break-words font-medium">{intent.itemTitle}</p>
+              <dl className="grid gap-3 text-sm [&>div]:flex [&>div]:flex-wrap [&>div]:justify-between [&>div]:gap-2 [&_dd]:min-w-0 [&_dd]:break-all">
+                <div><dt>ยอดที่ระบบจะตรวจสอบ (THB)</dt><dd><strong>{formatOrderAmount(intent.amount)}</strong></dd></div>
+                <div><dt>เลขอ้างอิง</dt><dd>{intent.paymentId}</dd></div>
+                <div><dt>หมดเวลา</dt><dd>{new Date(intent.expiresAt).toLocaleString('th-TH', { timeZone: 'Asia/Bangkok' })} (เวลาไทย)</dd></div>
+              </dl>
+              {expired ? <Alert><AlertTitle>รายการพร้อมเพย์หมดเวลาแล้ว</AlertTitle><AlertDescription>หากโอนเงินแล้วอย่าชำระซ้ำ กรุณาติดต่อพร้อมเลขอ้างอิงเพื่อตรวจสอบรายการ</AlertDescription></Alert> : null}
+              {presentation ? <Alert><AlertTitle>{presentation.payment.heading}</AlertTitle><AlertDescription>{presentation.payment.description}</AlertDescription></Alert> : null}
+              {verifying ? <p role="status">กำลังตรวจสอบสลิป กรุณารอผล อย่าชำระหรือส่งสลิปซ้ำ</p> : null}
+              {!expired && !uncertain ? (
+                <>
+                  <dl className="grid gap-2 text-sm [&_dd]:break-words">
+                    <div><dt>ธนาคาร</dt><dd>{process.env.NEXT_PUBLIC_BANK_NAME || 'กสิกรไทย (KBank)'}</dd></div>
+                    <div><dt>เลขบัญชี</dt><dd>{process.env.NEXT_PUBLIC_BANK_ACCOUNT || 'xxx-x-xxxxx-x'}</dd></div>
+                    <div><dt>ชื่อบัญชี</dt><dd>{process.env.NEXT_PUBLIC_BANK_ACCOUNT_NAME || 'MilerDev'}</dd></div>
+                  </dl>
+                  <p className="text-sm text-muted-foreground">แนบเฉพาะสลิปของรายการนี้ สลิปมีข้อมูลส่วนบุคคลและจะส่งให้ผู้ให้บริการตรวจสอบการโอนเงิน กรุณาอย่าส่งเอกสารอื่นหรือข้อมูลที่ไม่เกี่ยวข้อง</p>
+                  <Field data-invalid={Boolean(slipError) || undefined}>
+                    <FieldLabel htmlFor={slipId}>แนบสลิปการโอนเงิน</FieldLabel>
+                    <Input ref={fileRef} id={slipId} type="file" accept="image/jpeg,image/jpg,image/png,image/webp" disabled={pending} aria-invalid={Boolean(slipError) || undefined} aria-describedby={slipError ? `${slipId}-error` : undefined} onChange={(event) => selectSlip(event.target.files?.[0])} />
+                    <p className="text-sm text-muted-foreground">JPG, PNG, WEBP (ไม่เกิน 5MB)</p>
+                    {slipError ? <FieldError id={`${slipId}-error`}>{slipError}</FieldError> : null}
+                  </Field>
+                  {slipFile && slipPreview ? <div className="relative">
+                    <Image src={slipPreview} alt="สลิปที่เลือก" width={720} height={900} unoptimized className="h-auto max-h-64 w-full object-contain" />
+                    <Button type="button" variant="outline" size="icon" disabled={pending} className="absolute top-2 right-2" aria-label="ลบรูปสลิปที่เลือก" onClick={() => { selectSlip(); if (fileRef.current) fileRef.current.value = ''; }}><X data-icon="inline-start" aria-hidden="true" /></Button>
+                  </div> : null}
+                </>
+              ) : null}
+              <Button type="button" variant="outline" disabled={pending} onClick={checkAttempt}>ตรวจสถานะอีกครั้ง</Button>
+              {(expired || uncertain) ? <Button asChild variant="outline"><Link href="/contact">ติดต่อพร้อมเลขอ้างอิง</Link></Button> : null}
+            </>
+          ) : (
+            <>
+              {review ? <OrderReviewSummary review={review} /> : !error && !couponError ? <p role="status">กำลังตรวจสอบรายการ...</p> : null}
+              {target.type === 'course' && !uncertain ? (
+                <FieldGroup>
+                  <Field data-invalid={Boolean(couponError) || undefined}>
+                    <FieldLabel htmlFor={couponId}>มีโค้ดส่วนลด?</FieldLabel>
+                    <Input id={couponId} value={couponCode} disabled={pending} maxLength={100} aria-invalid={Boolean(couponError) || undefined} aria-describedby={couponError ? `${couponId}-error` : undefined} onChange={(event) => setCouponCode(event.target.value.toUpperCase())} onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void refreshReview(couponCode.trim()); } }} />
+                    {couponError ? <FieldError id={`${couponId}-error`}>{couponError}</FieldError> : null}
+                    <Button type="button" variant="outline" disabled={pending || !couponCode.trim()} onClick={() => refreshReview(couponCode.trim())}>ใช้โค้ด</Button>
+                    {review?.coupon ? <><p role="status">ใช้คูปอง {review.coupon.code} แล้ว</p><Button type="button" variant="outline" disabled={pending} onClick={() => refreshReview()}>ลบคูปอง</Button></> : null}
+                  </Field>
+                </FieldGroup>
+              ) : null}
+              {!review && (error || couponError) && !uncertain ? <Button type="button" variant="outline" disabled={pending} onClick={() => refreshReview()}>ตรวจสอบรายการใหม่โดยไม่ใช้คูปอง</Button> : null}
+              {review?.action === 'unavailable' ? <Alert><AlertTitle>ยังไม่เปิดรับสมัคร</AlertTitle><AlertDescription>สินค้านี้ยังไม่พร้อมรับการลงทะเบียน กรุณากลับมาตรวจสอบภายหลัง</AlertDescription></Alert> : null}
+              {review?.action === 'owned' ? <Button asChild><Link href="/dashboard">ไปการเรียนของฉัน</Link></Button> : null}
+              {review?.action === 'pay' && !uncertain ? <div className="flex flex-col gap-3" role="group" aria-label="ช่องทางชำระเงิน">
+                <Button type="button" variant="outline" className="h-auto min-h-11 whitespace-normal py-3" disabled={pending} onClick={() => startPayment('stripe')}><CreditCard data-icon="inline-start" aria-hidden="true" />ชำระด้วยบัตรผ่าน Stripe</Button>
+                <Button type="button" variant="outline" className="h-auto min-h-11 whitespace-normal py-3" disabled={pending} onClick={() => startPayment('promptpay')}><Smartphone data-icon="inline-start" aria-hidden="true" />โอนเงิน / PromptPay</Button>
+              </div> : null}
+              {review?.action === 'enroll-free' && !uncertain ? <Button type="button" disabled={pending} onClick={() => startPayment('free')}>{review.coupon ? 'ลงทะเบียนเรียนฟรี (คูปอง 100%)' : 'ยืนยันลงทะเบียนเรียนฟรี'}</Button> : null}
+              {loading ? <p role="status"><Spinner aria-hidden="true" />กำลังดำเนินการ...</p> : null}
+            </>
+          )}
+          {(intent || uncertain) ? <Button asChild variant="outline"><Link href="/dashboard/payments">ดูประวัติการชำระเงิน</Link></Button> : null}
+        </div>
+      )}
+    >
+      <Button type="button" variant="outline" disabled={pending} onClick={close}>{intent ? 'ปิดและเก็บรายการไว้' : 'ยกเลิก'}</Button>
+      {intent && !expired && !uncertain ? <Button type="button" disabled={pending || !slipFile} aria-busy={verifying} onClick={verifySlip}>{verifying ? <><Spinner data-icon="inline-start" aria-hidden="true" />กำลังตรวจสอบสลิป...</> : 'ตรวจสอบและชำระเงิน'}</Button> : null}
+    </DialogShell>
+  );
+}

--- a/src/components/checkout/OrderReviewSummary.tsx
+++ b/src/components/checkout/OrderReviewSummary.tsx
@@ -1,0 +1,28 @@
+import type { OrderReview } from '@/lib/order-review';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function formatOrderAmount(amount: string | number) {
+  return new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(amount));
+}
+
+export default function OrderReviewSummary({ review }: { review: OrderReview }) {
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle>{review.target.type === 'bundle' ? 'ตรวจสอบรายการ Bundle' : 'ตรวจสอบรายการคอร์ส'}</CardTitle>
+        <CardDescription className="break-words">{review.target.title}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex min-w-0 flex-col gap-3">
+        <dl className="grid gap-3 text-sm [&>div]:flex [&>div]:flex-wrap [&>div]:justify-between [&>div]:gap-2 [&_dd]:min-w-0 [&_dd]:break-words">
+          {review.comparison ? <div><dt>ซื้อแยกวันนี้</dt><dd>{formatOrderAmount(review.comparison.separate)}</dd></div> : null}
+          <div><dt>ราคาก่อนใช้คูปอง</dt><dd>{formatOrderAmount(review.price.original)}</dd></div>
+          <div><dt>ส่วนลดคูปอง</dt><dd>{formatOrderAmount(review.price.discount)}</dd></div>
+          <div><dt>ยอดชำระ (THB)</dt><dd><strong>{formatOrderAmount(review.price.amountDue)}</strong></dd></div>
+        </dl>
+        {review.comparison ? <p className="text-sm">{review.comparison.label}</p> : null}
+        <p className="text-sm">{review.access.description}</p>
+        <p className="text-sm text-muted-foreground">ระบบจะตรวจสอบราคาและสิทธิ์อีกครั้งก่อนเริ่มรายการ</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/checkout/PaymentCancellationNotice.tsx
+++ b/src/components/checkout/PaymentCancellationNotice.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+
+export default function PaymentCancellationNotice() {
+  return (
+    <Alert className="mx-auto my-4 max-w-7xl">
+      <AlertTitle>กลับจากหน้าชำระเงิน</AlertTitle>
+      <AlertDescription>
+        <p>คุณกลับมายังสินค้าที่เลือกหลังยกเลิกหน้าชำระเงิน สามารถทบทวนรายการและเลือกวิธีชำระเงินใหม่ได้</p>
+        <p>การกลับมาหน้านี้ยังไม่ยืนยันผลการชำระเงิน หากมีการหักเงินแล้ว อย่าชำระซ้ำ <Link className="underline underline-offset-4" href="/dashboard/payments">ตรวจสอบประวัติการชำระเงิน</Link></p>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/course/EnrollButton.tsx
+++ b/src/components/course/EnrollButton.tsx
@@ -1,34 +1,13 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-import Image from 'next/image';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import {
-  CircleAlert,
-  CreditCard,
-  ImagePlus,
-  PlayCircle,
-  Smartphone,
-  TicketPercent,
-  X,
-} from 'lucide-react';
-import DialogShell from '@/components/ui/DialogShell';
+import { PlayCircle } from 'lucide-react';
+import CheckoutDialog, { CHECKOUT_CONTRACT } from '@/components/checkout/CheckoutDialog';
 import Modal from '@/components/ui/Modal';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Field, FieldError, FieldLabel } from '@/components/ui/field';
-import { Input } from '@/components/ui/input';
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from '@/components/ui/input-group';
 import { Spinner } from '@/components/ui/spinner';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { trackClientAnalyticsEvent } from '@/components/analytics/analytics-client';
 import { useProductExposureId } from '@/components/analytics/AnalyticsViewEvent';
 
@@ -39,20 +18,11 @@ interface EnrollButtonProps {
   onEnrollmentChange?: (enrolled: boolean) => void;
 }
 
-type PaymentStep = 'idle' | 'method' | 'transfer' | 'verifying';
-
 export const COURSE_PAYMENT_CONTRACT = {
-  enrollEndpoint: '/api/enroll',
-  stripeEndpoint: '/api/stripe/checkout',
-  couponEndpoint: '/api/coupons/validate',
-  intentEndpoint: '/api/promptpay/intents',
-  slipEndpoint: '/api/slip/verify',
-  slipFields: {
-    file: 'slip',
-    paymentId: 'paymentId',
-  },
-  allowedSlipTypes: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'] as readonly string[],
-  maxSlipBytes: 5 * 1024 * 1024,
+  ...CHECKOUT_CONTRACT,
+  enrollEndpoint: '/api/enroll', stripeEndpoint: '/api/stripe/checkout',
+  couponEndpoint: '/api/coupons/validate', slipEndpoint: '/api/slip/verify',
+  slipFields: { file: 'slip', paymentId: 'paymentId' },
 } as const;
 
 export default function EnrollButton({ courseId, courseSlug, price, onEnrollmentChange }: EnrollButtonProps) {
@@ -60,30 +30,14 @@ export default function EnrollButton({ courseId, courseSlug, price, onEnrollment
   const sessionResult = useSession();
   const session = sessionResult?.data;
   const status = sessionResult?.status ?? 'unauthenticated';
+  const sessionUserId = session?.user.id;
   const exposureId = useProductExposureId();
-  const [loading, setLoading] = useState(false);
   const [enrolled, setEnrolled] = useState(false);
   const [checking, setChecking] = useState(true);
-  const [paymentStep, setPaymentStep] = useState<PaymentStep>('idle');
-  const [slipFile, setSlipFile] = useState<File | null>(null);
-  const [slipPreview, setSlipPreview] = useState<string | null>(null);
-  const [verifyError, setVerifyError] = useState<string | null>(null);
-  const [promptPayIntent, setPromptPayIntent] = useState<{ paymentId: string; amount: number } | null>(null);
-  const enrollmentTriggerRef = useRef<HTMLButtonElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [couponCode, setCouponCode] = useState('');
-  const [couponLoading, setCouponLoading] = useState(false);
-  const [couponError, setCouponError] = useState<string | null>(null);
-  const [appliedCoupon, setAppliedCoupon] = useState<{
-    couponId: string; code: string; discountAmount: number; finalPrice: number; description: string | null;
-  } | null>(null);
-  const [modal, setModal] = useState<{ isOpen: boolean; type: 'success' | 'error'; title: string; message: string }>({
-    isOpen: false,
-    type: 'success',
-    title: '',
-    message: '',
-  });
-
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const updateEnrolled = useCallback((value: boolean) => {
     setEnrolled(value);
     onEnrollmentChange?.(value);
@@ -91,578 +45,51 @@ export default function EnrollButton({ courseId, courseSlug, price, onEnrollment
 
   useEffect(() => {
     if (status === 'loading') return;
-    
-    if (!session) {
+    if (!sessionUserId) {
       updateEnrolled(false);
       setChecking(false);
       return;
     }
-
-    fetch(`/api/enrollments/check?courseId=${courseId}`)
-      .then((res) => res.json())
-      .then((data) => {
-        updateEnrolled(data.enrolled);
-      })
-      .catch((error) => {
-        console.error(error);
-        updateEnrolled(false);
-      })
-      .finally(() => setChecking(false));
-  }, [session, status, courseId, updateEnrolled]);
+    const controller = new AbortController();
+    fetch(`/api/enrollments/check?courseId=${encodeURIComponent(courseId)}`, { signal: controller.signal })
+      .then((response) => response.json())
+      .then((data) => { if (!controller.signal.aborted) updateEnrolled(data.enrolled === true); })
+      .catch(() => { if (!controller.signal.aborted) updateEnrolled(false); })
+      .finally(() => { if (!controller.signal.aborted) setChecking(false); });
+    return () => controller.abort();
+  }, [sessionUserId, status, courseId, updateEnrolled]);
 
   const handleEnroll = async () => {
     if (!session) {
       router.push(`/login?callbackUrl=/courses/${courseSlug}`);
       return;
     }
-
-    // ถ้าคอร์สมีราคา → แสดงตัวเลือกช่องทางชำระเงิน
     if (price > 0) {
-      trackClientAnalyticsEvent({
-        eventName: 'checkout_opened',
-        courseId,
-        placement: 'course_detail',
-      });
-      setPaymentStep('method');
+      trackClientAnalyticsEvent({ eventName: 'checkout_opened', courseId, placement: 'course_detail' });
+      setOpen(true);
       return;
     }
-
-    // ถ้าคอร์สฟรี → ลงทะเบียนเลย
     setLoading(true);
     try {
-      const res = await fetch('/api/enrollments', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ courseId }),
+      const response = await fetch('/api/enrollments', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ courseId }),
       });
-
-      const data = await res.json();
-
-      if (res.ok) {
-        updateEnrolled(true);
-        setModal({
-          isOpen: true,
-          type: 'success',
-          title: 'ลงทะเบียนสำเร็จ!',
-          message: 'ยินดีด้วย! คุณลงทะเบียนคอร์สนี้เรียบร้อยแล้ว',
-        });
-      } else {
-        if (data.error === 'คุณลงทะเบียนคอร์สนี้แล้ว') {
-          updateEnrolled(true);
-        } else {
-          setModal({
-            isOpen: true,
-            type: 'error',
-            title: 'เกิดข้อผิดพลาด',
-            message: data.error || 'ไม่สามารถลงทะเบียนได้ กรุณาลองใหม่',
-          });
-        }
-      }
-    } catch (error) {
-      console.error('Enrollment error:', error);
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'เกิดข้อผิดพลาด',
-        message: 'ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่อีกครั้ง',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const effectivePrice = appliedCoupon ? appliedCoupon.finalPrice : price;
-
-  const handleApplyCoupon = async () => {
-    if (!couponCode.trim()) return;
-    setCouponLoading(true);
-    setCouponError(null);
-    try {
-      const res = await fetch(COURSE_PAYMENT_CONTRACT.couponEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: couponCode, courseId, originalPrice: price }),
-      });
-      const data = await res.json();
-      if (data.valid) {
-        setAppliedCoupon({
-          couponId: data.couponId,
-          code: data.code,
-          discountAmount: data.discountAmount,
-          finalPrice: data.finalPrice,
-          description: data.description,
-        });
-        setCouponError(null);
-      } else {
-        setCouponError(data.error || 'คูปองไม่ถูกต้อง');
-        setAppliedCoupon(null);
-      }
+      const data = await response.json();
+      if (response.ok) updateEnrolled(true);
+      else setError(data.error || 'ไม่สามารถลงทะเบียนได้ กรุณาลองใหม่');
     } catch {
-      setCouponError('เกิดข้อผิดพลาด');
-    } finally {
-      setCouponLoading(false);
-    }
+      setError('ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่');
+    } finally { setLoading(false); }
   };
-
-  const handleRemoveCoupon = () => {
-    setAppliedCoupon(null);
-    setCouponCode('');
-    setCouponError(null);
-  };
-
-  const handleCouponEnrollment = async () => {
-    if (!appliedCoupon || effectivePrice !== 0) return;
-
-    setLoading(true);
-    try {
-      const res = await fetch(COURSE_PAYMENT_CONTRACT.enrollEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ courseId, couponId: appliedCoupon.couponId }),
-      });
-      const data = await res.json();
-
-      if (res.ok) {
-        updateEnrolled(true);
-        setPaymentStep('idle');
-        setModal({
-          isOpen: true,
-          type: 'success',
-          title: 'ลงทะเบียนสำเร็จ!',
-          message: 'ใช้คูปองส่วนลด 100% ลงทะเบียนเรียบร้อยแล้ว',
-        });
-      } else {
-        setModal({
-          isOpen: true,
-          type: 'error',
-          title: 'เกิดข้อผิดพลาด',
-          message: data.error || 'ไม่สามารถลงทะเบียนได้',
-        });
-      }
-    } catch {
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'เกิดข้อผิดพลาด',
-        message: 'ไม่สามารถเชื่อมต่อได้',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleStripePayment = async () => {
-    setLoading(true);
-    try {
-      const res = await fetch(COURSE_PAYMENT_CONTRACT.stripeEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          courseId,
-          ...(appliedCoupon && { couponId: appliedCoupon.couponId }),
-          ...(exposureId && { exposureId }),
-        }),
-      });
-
-      const data = await res.json();
-
-      if (res.ok && data.url) {
-        window.location.href = data.url;
-        return;
-      } else {
-        setPaymentStep('idle');
-        setModal({
-          isOpen: true,
-          type: 'error',
-          title: 'เกิดข้อผิดพลาด',
-          message: data.error || 'ไม่สามารถสร้างหน้าชำระเงินได้ กรุณาลองใหม่',
-        });
-      }
-    } catch {
-      setPaymentStep('idle');
-      setModal({
-        isOpen: true,
-        type: 'error',
-        title: 'เกิดข้อผิดพลาด',
-        message: 'ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่',
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handlePromptPayPayment = async () => {
-    setLoading(true);
-    setVerifyError(null);
-    try {
-      const res = await fetch(COURSE_PAYMENT_CONTRACT.intentEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ courseId, ...(appliedCoupon && { couponId: appliedCoupon.couponId }) }),
-      });
-      const data = await res.json();
-      if (!res.ok || !data.paymentId || typeof data.amount !== 'number') {
-        setModal({ isOpen: true, type: 'error', title: 'ไม่สามารถเริ่มรายการชำระเงิน', message: data.error || 'กรุณาลองใหม่' });
-        return;
-      }
-      setPromptPayIntent({ paymentId: data.paymentId, amount: data.amount });
-      setPaymentStep('transfer');
-    } catch {
-      setModal({ isOpen: true, type: 'error', title: 'ไม่สามารถเริ่มรายการชำระเงิน', message: 'ไม่สามารถเชื่อมต่อได้ กรุณาลองใหม่' });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    // Validate file type
-    if (!COURSE_PAYMENT_CONTRACT.allowedSlipTypes.includes(file.type)) {
-      resetSlipState();
-      setVerifyError('รองรับเฉพาะไฟล์ JPG, PNG, WEBP เท่านั้น');
-      return;
-    }
-
-    // Validate file size (max 5MB)
-    if (file.size > COURSE_PAYMENT_CONTRACT.maxSlipBytes) {
-      resetSlipState();
-      setVerifyError('ไฟล์ต้องมีขนาดไม่เกิน 5MB');
-      return;
-    }
-
-    setSlipFile(file);
-    setVerifyError(null);
-
-    // Create preview
-    const reader = new FileReader();
-    reader.onload = (ev) => {
-      setSlipPreview(ev.target?.result as string);
-    };
-    reader.readAsDataURL(file);
-  };
-
-  const handleSlipVerify = async () => {
-    if (!slipFile || !promptPayIntent) return;
-
-    setPaymentStep('verifying');
-    setVerifyError(null);
-
-    try {
-      const formData = new FormData();
-      formData.append(COURSE_PAYMENT_CONTRACT.slipFields.file, slipFile);
-      formData.append(COURSE_PAYMENT_CONTRACT.slipFields.paymentId, promptPayIntent.paymentId);
-
-      const res = await fetch(COURSE_PAYMENT_CONTRACT.slipEndpoint, {
-        method: 'POST',
-        body: formData,
-      });
-
-      const data = await res.json();
-
-      if (res.ok && data.success) {
-        updateEnrolled(true);
-        setPaymentStep('idle');
-        setPromptPayIntent(null);
-        resetSlipState();
-        setModal({
-          isOpen: true,
-          type: 'success',
-          title: 'ชำระเงินสำเร็จ!',
-          message: 'ตรวจสอบสลิปเรียบร้อย คุณสามารถเริ่มเรียนได้เลย',
-        });
-      } else {
-        setPaymentStep('transfer');
-        setVerifyError(data.error || 'ไม่สามารถตรวจสอบสลิปได้ กรุณาลองใหม่');
-      }
-    } catch {
-      setPaymentStep('transfer');
-      setVerifyError('เกิดข้อผิดพลาดในการเชื่อมต่อ กรุณาลองใหม่');
-    }
-  };
-
-  const resetSlipState = () => {
-    setSlipFile(null);
-    setSlipPreview(null);
-    setVerifyError(null);
-    if (fileInputRef.current) fileInputRef.current.value = '';
-  };
-
-  const handleModalClose = () => {
-    const wasSuccess = modal.type === 'success';
-    setModal({ ...modal, isOpen: false });
-    if (wasSuccess) {
-      router.push(`/courses/${courseSlug}/learn`);
-    }
-  };
-
-  const handleGoToLearn = () => {
-    router.push(`/courses/${courseSlug}/learn`);
-  };
-
-  if (checking) {
-    return (
-      <Button type="button" className="w-full" disabled aria-busy="true">
-        <Spinner data-icon="inline-start" aria-hidden="true" />
-        กำลังตรวจสอบ...
-      </Button>
-    );
-  }
 
   return (
     <>
-      {enrolled ? (
-        <Button
-          type="button"
-          onClick={handleGoToLearn}
-          className="w-full"
-        >
-          <PlayCircle data-icon="inline-start" aria-hidden="true" />
-          เข้าเรียน
-        </Button>
-      ) : (
-        <Button
-          ref={enrollmentTriggerRef}
-          type="button"
-          onClick={handleEnroll}
-          disabled={loading}
-          className="w-full"
-          aria-busy={loading}
-        >
-          {loading && <Spinner data-icon="inline-start" aria-hidden="true" />}
-          {loading ? 'กำลังดำเนินการ...' : price === 0 ? (
-            'ลงทะเบียนเรียนฟรี'
-          ) : (
-            `ซื้อคอร์สนี้ ฿${price.toLocaleString()}`
-          )}
-        </Button>
-      )}
-
-      {/* Payment Method Selection Modal */}
-      <DialogShell
-        isOpen={paymentStep === 'method'}
-        onClose={() => setPaymentStep('idle')}
-        title={'เลือกช่องทางชำระเงิน'}
-        description={appliedCoupon ? (
-          <span className="flex flex-wrap items-center gap-2">
-            <s>฿{price.toLocaleString()}</s>
-            <strong>฿{effectivePrice.toLocaleString()}</strong>
-            <Badge variant="secondary">คูปอง {appliedCoupon.code} ลด ฿{appliedCoupon.discountAmount.toLocaleString()}</Badge>
-          </span>
-        ) : (
-          <span>ยอดชำระ <strong>฿{price.toLocaleString()}</strong></span>
-        )}
-        body={(
-          <div className="flex flex-col gap-5">
-            <Field data-invalid={Boolean(couponError) || undefined}>
-              <FieldLabel htmlFor="course-coupon-code">มีโค้ดส่วนลด?</FieldLabel>
-              {appliedCoupon ? (
-                <Alert>
-                  <TicketPercent aria-hidden="true" />
-                  <AlertTitle>ใช้คูปอง {appliedCoupon.code} แล้ว</AlertTitle>
-                  <AlertDescription>
-                    {appliedCoupon.description || `ลด ฿${appliedCoupon.discountAmount.toLocaleString()}`}
-                    <div className="mt-3"><Button type="button" variant="destructive" size="sm" onClick={handleRemoveCoupon}>ลบคูปอง</Button></div>
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <InputGroup>
-                  <InputGroupInput
-                    id="course-coupon-code"
-                    value={couponCode}
-                    onChange={e => setCouponCode(e.target.value.toUpperCase())}
-                    onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), handleApplyCoupon())}
-                    placeholder="ใส่โค้ดส่วนลด"
-                    aria-invalid={Boolean(couponError) || undefined}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                    onClick={handleApplyCoupon}
-                    disabled={couponLoading || !couponCode.trim()}
-                    >
-                      {couponLoading && <Spinner data-icon="inline-start" aria-hidden="true" />}
-                      {couponLoading ? 'กำลังตรวจ' : 'ใช้โค้ด'}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              )}
-              {couponError && <FieldError>{couponError}</FieldError>}
-            </Field>
-
-            {effectivePrice === 0 && appliedCoupon ? null : (
-              <ToggleGroup
-                type="single"
-                orientation="vertical"
-                variant="outline"
-                className="w-full"
-                aria-label="ช่องทางชำระเงิน"
-                onValueChange={(value) => {
-                  if (value === 'stripe') void handleStripePayment();
-                  if (value === 'promptpay') void handlePromptPayPayment();
-                }}
-              >
-                  <ToggleGroupItem
-                    value="stripe"
-                    disabled={loading}
-                    className="h-auto w-full justify-start p-4 text-left whitespace-normal"
-                  >
-                    <CreditCard aria-hidden="true" />
-                    <span className="flex flex-col items-start gap-1">
-                      <strong>บัตรเครดิต / เดบิต</strong>
-                      <span>Visa, Mastercard ผ่าน Stripe</span>
-                    </span>
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="promptpay"
-                    disabled={loading}
-                    className="h-auto w-full justify-start p-4 text-left whitespace-normal"
-                  >
-                    <Smartphone aria-hidden="true" />
-                    <span className="flex flex-col items-start gap-1">
-                      <strong>โอนเงิน / PromptPay</strong>
-                      <span>โอนแล้วแนบสลิป ตรวจสอบอัตโนมัติ</span>
-                    </span>
-                  </ToggleGroupItem>
-              </ToggleGroup>
-            )}
-          </div>
-        )}
-        dismissOnBackdrop={true}
-        returnFocusRef={enrollmentTriggerRef}
-        size={'wide'}
-      >
-        <Button
-          type="button"
-          onClick={() => setPaymentStep('idle')}
-          variant="outline"
-        >
-          ยกเลิก
-        </Button>
-        {effectivePrice === 0 && appliedCoupon ? (
-          <Button
-            type="button"
-            onClick={handleCouponEnrollment}
-            disabled={loading}
-            aria-busy={loading}
-          >
-            {loading && <Spinner data-icon="inline-start" aria-hidden="true" />}
-            {loading ? 'กำลังดำเนินการ...' : 'ลงทะเบียนเรียนฟรี (คูปอง 100%)'}
-          </Button>
-        ) : null}
-      </DialogShell>
-
-      {/* Bank Transfer / Slip Upload Modal */}
-      <DialogShell
-        isOpen={paymentStep === 'transfer' || paymentStep === 'verifying'}
-        onClose={() => { if (paymentStep !== 'verifying') { setPaymentStep('idle'); resetSlipState(); } }}
-        title={'โอนเงินและแนบสลิป'}
-        description={<span>ยอดที่ระบบจะตรวจสอบ <strong>฿{(promptPayIntent?.amount ?? effectivePrice).toLocaleString()}</strong></span>}
-        body={(
-          <div className="flex flex-col gap-5">
-            <Card size="sm">
-              <CardHeader>
-                <CardTitle>ข้อมูลสำหรับโอนเงิน</CardTitle>
-                <CardDescription>ตรวจสอบชื่อบัญชีและจำนวนเงินก่อนโอน</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <dl className="grid gap-3">
-                  <div className="flex items-center justify-between gap-4"><dt>ธนาคาร</dt><dd><strong>{process.env.NEXT_PUBLIC_BANK_NAME || 'กสิกรไทย (KBank)'}</strong></dd></div>
-                  <div className="flex items-center justify-between gap-4"><dt>เลขบัญชี</dt><dd><strong className="font-mono">{process.env.NEXT_PUBLIC_BANK_ACCOUNT || 'xxx-x-xxxxx-x'}</strong></dd></div>
-                  <div className="flex items-center justify-between gap-4"><dt>ชื่อบัญชี</dt><dd><strong>{process.env.NEXT_PUBLIC_BANK_ACCOUNT_NAME || 'MilerDev'}</strong></dd></div>
-                  <div className="flex items-center justify-between gap-4"><dt>จำนวนเงิน</dt><dd><strong>฿{(promptPayIntent?.amount ?? effectivePrice).toLocaleString()}</strong></dd></div>
-                </dl>
-              </CardContent>
-            </Card>
-
-            <Field data-invalid={Boolean(verifyError) || undefined}>
-              <FieldLabel htmlFor="course-slip-upload">แนบสลิปการโอนเงิน</FieldLabel>
-
-              {!slipPreview ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="h-auto w-full flex-col py-8 whitespace-normal"
-                >
-                  <ImagePlus data-icon="inline-start" aria-hidden="true" />
-                  <span>คลิกเพื่อเลือกรูปสลิป</span>
-                  <span>JPG, PNG, WEBP (ไม่เกิน 5MB)</span>
-                </Button>
-              ) : (
-                <div className="relative overflow-hidden rounded-xl border bg-muted">
-                  <Image src={slipPreview} alt="สลิป" width={720} height={900} unoptimized className="h-auto w-full" />
-                  <Button
-                    type="button"
-                    onClick={() => resetSlipState()}
-                    variant="destructive"
-                    size="icon-sm"
-                    className="absolute top-2 right-2"
-                    aria-label="ลบรูปสลิปที่เลือก"
-                  >
-                    <X data-icon="inline-start" aria-hidden="true" />
-                  </Button>
-                </div>
-              )}
-
-              <Input
-                id="course-slip-upload"
-                ref={fileInputRef}
-                type="file"
-                tabIndex={-1}
-                accept="image/jpeg,image/jpg,image/png,image/webp"
-                onChange={handleFileChange}
-                className="sr-only"
-                aria-invalid={Boolean(verifyError) || undefined}
-              />
-            </Field>
-
-            {verifyError && (
-              <Alert variant="destructive">
-                <CircleAlert aria-hidden="true" />
-                <AlertTitle>ตรวจสอบสลิปไม่สำเร็จ</AlertTitle>
-                <AlertDescription>{verifyError}</AlertDescription>
-              </Alert>
-            )}
-          </div>
-        )}
-        dismissOnBackdrop={paymentStep !== 'verifying'}
-        returnFocusRef={enrollmentTriggerRef}
-        size={'wide'}
-      >
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => { setPaymentStep('method'); setPromptPayIntent(null); resetSlipState(); }}
-          disabled={paymentStep === 'verifying'}
-        >
-          กลับ
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSlipVerify}
-          disabled={!slipFile || !promptPayIntent || paymentStep === 'verifying'}
-          aria-busy={paymentStep === 'verifying'}
-        >
-          {paymentStep === 'verifying' ? (
-            <>
-              <Spinner data-icon="inline-start" aria-hidden="true" />
-              กำลังตรวจสอบสลิป...
-            </>
-          ) : 'ตรวจสอบและชำระเงิน'}
-        </Button>
-      </DialogShell>
-
-      <Modal
-        isOpen={modal.isOpen}
-        onClose={handleModalClose}
-        returnFocusRef={enrollmentTriggerRef}
-        type={modal.type}
-        title={modal.title}
-        buttonText={modal.type === 'success' ? 'เริ่มเรียนเลย' : 'ตกลง'}
-      >
-        {modal.message}
-      </Modal>
+      <Button ref={triggerRef} type="button" className="w-full" disabled={checking || loading} aria-busy={checking || loading} onClick={enrolled ? () => router.push(`/courses/${courseSlug}/learn`) : handleEnroll}>
+        {checking || loading ? <Spinner data-icon="inline-start" aria-hidden="true" /> : enrolled ? <PlayCircle data-icon="inline-start" aria-hidden="true" /> : null}
+        {checking ? 'กำลังตรวจสอบ...' : loading ? 'กำลังดำเนินการ...' : enrolled ? 'เข้าเรียน' : price === 0 ? 'ลงทะเบียนเรียนฟรี' : `ซื้อคอร์สนี้ ฿${price.toLocaleString()}`}
+      </Button>
+      <CheckoutDialog key={`${sessionUserId}:${courseId}`} open={open} onClose={() => setOpen(false)} target={{ type: 'course', id: courseId }} exposureId={exposureId} returnFocusRef={triggerRef} onEnrolled={() => updateEnrolled(true)} />
+      <Modal isOpen={Boolean(error)} onClose={() => setError(null)} returnFocusRef={triggerRef} type="error" title="เกิดข้อผิดพลาด">{error}</Modal>
     </>
   );
 }

--- a/src/lib/order-review.ts
+++ b/src/lib/order-review.ts
@@ -1,0 +1,98 @@
+import 'server-only';
+
+import { and, count, eq, inArray } from 'drizzle-orm';
+import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
+import { deriveCourseDecisionFacts } from '@/lib/course-decision-facts';
+import { calculateDiscount, validateCouponEligibility } from '@/lib/coupon';
+import { db } from '@/lib/db';
+import { bundleCourses, bundles, coupons, couponUsages, courses, enrollments, lessons } from '@/lib/db/schema';
+
+export type OrderReview = {
+  target: { type: 'course' | 'bundle'; id: string; title: string; href: string };
+  price: { original: string; discount: string; amountDue: string; currency: 'THB' };
+  coupon: { id: string; code: string; description: string | null } | null;
+  access: { ownedCount: number; totalCount: number; description: string };
+  comparison: { separate: string; label: string } | null;
+  action: 'pay' | 'enroll-free' | 'owned' | 'unavailable';
+};
+
+export class OrderReviewError extends Error {
+  constructor(message: string, readonly status: number = 400) { super(message); }
+}
+
+export async function loadOrderReview(
+  userId: string,
+  input: { courseId?: string; bundleId?: string; couponCode?: string },
+): Promise<OrderReview> {
+  const now = new Date();
+  if (input.courseId) {
+    const course = await db.query.courses.findFirst({
+      where: and(eq(courses.id, input.courseId), eq(courses.status, 'published')),
+      with: { lessons: { columns: { id: true } } },
+    });
+    if (!course) throw new OrderReviewError('ไม่พบคอร์สที่เปิดขาย', 404);
+    const owned = await db.query.enrollments.findFirst({
+      where: and(eq(enrollments.userId, userId), eq(enrollments.courseId, course.id)),
+      columns: { id: true },
+    });
+    const facts = deriveCourseDecisionFacts({
+      slug: course.slug, regularPrice: course.price, lessonCount: course.lessons.length,
+      promotion: course.promoPrice === null ? null : {
+        price: course.promoPrice, startsAt: course.promoStartsAt, endsAt: course.promoEndsAt,
+      },
+    }, { now });
+    let coupon: OrderReview['coupon'] = null;
+    let amount = facts.price.effective;
+    if (input.couponCode) {
+      const record = await db.query.coupons.findFirst({ where: eq(coupons.code, input.couponCode.toUpperCase()) });
+      if (!record) throw new OrderReviewError('ไม่พบคูปองนี้');
+      const [usage] = await db.select({ count: count() }).from(couponUsages)
+        .where(and(eq(couponUsages.couponId, record.id), eq(couponUsages.userId, userId)));
+      const eligibility = validateCouponEligibility(record, {
+        targetCourseId: course.id, userUsageCount: usage?.count ?? 0, coursePrice: amount,
+      });
+      if (!eligibility.valid) throw new OrderReviewError(eligibility.error || 'คูปองนี้ใช้ไม่ได้');
+      amount = Math.max(0, amount - calculateDiscount(amount, record.discountType, record.discountValue, record.maxDiscount));
+      amount = Math.round(amount * 100) / 100;
+      coupon = { id: record.id, code: record.code, description: record.description };
+    }
+    return {
+      target: { type: 'course', id: course.id, title: course.title, href: facts.actions.discovery.href },
+      price: { original: facts.price.effective.toFixed(2), discount: (facts.price.effective - amount).toFixed(2), amountDue: amount.toFixed(2), currency: 'THB' },
+      coupon,
+      access: { ownedCount: owned ? 1 : 0, totalCount: 1, description: owned ? 'คุณมีสิทธิ์เรียนคอร์สนี้แล้ว' : 'ได้รับสิทธิ์เรียนคอร์สนี้เมื่อระบบยืนยันการชำระเงิน หรือยืนยันการลงทะเบียนเรียนฟรีแล้ว' },
+      comparison: null,
+      action: owned ? 'owned' : facts.readiness !== 'ready' ? 'unavailable' : amount === 0 ? 'enroll-free' : 'pay',
+    };
+  }
+
+  const bundle = await db.query.bundles.findFirst({
+    where: and(eq(bundles.id, input.bundleId!), eq(bundles.status, 'published')),
+  });
+  if (!bundle) throw new OrderReviewError('ไม่พบ Bundle ที่เปิดขาย', 404);
+  const included = await db.select({ course: courses, orderIndex: bundleCourses.orderIndex }).from(bundleCourses)
+    .innerJoin(courses, eq(bundleCourses.courseId, courses.id)).where(eq(bundleCourses.bundleId, bundle.id));
+  if (included.some(({ course }) => course.status !== 'published')) {
+    throw new OrderReviewError('Bundle นี้ยังไม่พร้อมรับการลงทะเบียน', 409);
+  }
+  const ids = included.map(({ course }) => course.id);
+  const [lessonCounts, owned] = ids.length ? await Promise.all([
+    db.select({ courseId: lessons.courseId, count: count() }).from(lessons).where(inArray(lessons.courseId, ids)).groupBy(lessons.courseId),
+    db.select({ courseId: enrollments.courseId }).from(enrollments).where(and(eq(enrollments.userId, userId), inArray(enrollments.courseId, ids))),
+  ]) : [[], []];
+  const counts = new Map(lessonCounts.map((row) => [row.courseId, row.count]));
+  const ownedIds = new Set(owned.map((row) => row.courseId));
+  const facts = deriveBundleDecisionFacts({ slug: bundle.slug, price: bundle.price, courses: included.map(({ course, orderIndex }) => ({
+    id: course.id, title: course.title, slug: course.slug, orderIndex, regularPrice: course.price,
+    promotion: course.promoPrice === null ? null : { price: course.promoPrice, startsAt: course.promoStartsAt, endsAt: course.promoEndsAt },
+    lessonCount: counts.get(course.id) ?? 0, owned: ownedIds.has(course.id),
+  })) }, { now });
+  return {
+    target: { type: 'bundle', id: bundle.id, title: bundle.title, href: facts.actions.discovery.href },
+    price: { original: facts.price.bundle.toFixed(2), discount: '0.00', amountDue: facts.price.bundle.toFixed(2), currency: 'THB' },
+    coupon: null,
+    access: { ownedCount: facts.ownership.ownedCount, totalCount: ids.length, description: facts.ownership.disclosure || (facts.ownership.status === 'complete' ? 'คุณมีสิทธิ์เรียนทุกคอร์สใน Bundle นี้แล้ว' : 'ได้รับสิทธิ์เรียนทุกคอร์สใน Bundle เมื่อระบบยืนยันการชำระเงิน หรือยืนยันการลงทะเบียนเรียนฟรีแล้ว') },
+    comparison: { separate: facts.price.separateCurrent.toFixed(2), label: facts.price.comparison.label },
+    action: facts.ownership.status === 'complete' ? 'owned' : facts.readiness !== 'ready' ? 'unavailable' : facts.price.isFree ? 'enroll-free' : 'pay',
+  };
+}

--- a/src/lib/payment-presentation.ts
+++ b/src/lib/payment-presentation.ts
@@ -208,7 +208,7 @@ function describePayment(
           isConfirmed: false,
           label: 'รอแนบสลิป',
           heading: 'รายการนี้ยังรอหลักฐานการชำระเงิน',
-          description: 'หากโอนเงินแล้วอย่าชำระซ้ำ กรุณาติดต่อพร้อมเลขอ้างอิงจนกว่าจะมี resume contract ที่ตรวจ owner ได้',
+          description: 'หากโอนเงินแล้วอย่าชำระซ้ำ กรุณาแนบสลิปในรายการเดิมหรือติดต่อพร้อมเลขอ้างอิง',
           preventDuplicatePayment: true,
         },
         recovery: {

--- a/src/lib/promptpay-presentation.ts
+++ b/src/lib/promptpay-presentation.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+
+import { and, eq, inArray } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { bundleCourses, bundles, courses, enrollments, payments } from '@/lib/db/schema';
+import { derivePaymentPresentation } from '@/lib/payment-presentation';
+import { assertPromptPayIntentClaim } from '@/lib/promptpay-intent';
+
+export async function loadPromptPayPresentation(userId: string, paymentId: string) {
+  const attempt = await db.query.payments.findFirst({
+    where: and(eq(payments.id, paymentId), eq(payments.userId, userId), eq(payments.method, 'promptpay')),
+  });
+  if (!attempt || Boolean(attempt.courseId) === Boolean(attempt.bundleId)) return null;
+  const type = attempt.courseId ? 'course' : 'bundle';
+  const product = type === 'course'
+    ? await db.query.courses.findFirst({ where: eq(courses.id, attempt.courseId!), columns: { id: true, title: true, slug: true } })
+    : await db.query.bundles.findFirst({ where: eq(bundles.id, attempt.bundleId!), columns: { id: true, title: true, slug: true } });
+  if (!product) return null;
+  const ids = type === 'course' ? [product.id] : (await db.select({ courseId: bundleCourses.courseId }).from(bundleCourses).where(eq(bundleCourses.bundleId, product.id))).map((row) => row.courseId);
+  if (!ids.length) return null;
+  const owned = await db.select({ courseId: enrollments.courseId }).from(enrollments)
+    .where(and(eq(enrollments.userId, userId), inArray(enrollments.courseId, ids)));
+  const now = new Date();
+  const presentation = derivePaymentPresentation({
+    kind: 'exact-attempt', ownerId: userId, expectedAttemptId: paymentId,
+    target: { type, id: product.id, title: product.title, href: `/${type === 'course' ? 'courses' : 'bundles'}/${product.slug}` },
+    attempt, access: { enrolledCount: new Set(owned.map((row) => row.courseId)).size, totalCount: ids.length },
+  }, { now });
+  let canSubmitSlip = false;
+  try {
+    canSubmitSlip = assertPromptPayIntentClaim(attempt, { userId, targetType: type, now }).status === 'claimable';
+  } catch { /* Only the owner-checked claim contract permits a retry. */ }
+  return { presentation, canSubmitSlip };
+}

--- a/tests/api/order-review.test.ts
+++ b/tests/api/order-review.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { auth } from '@/lib/auth';
+import { POST } from '@/app/api/checkout/review/route';
+import { loadOrderReview } from '@/lib/order-review';
+import { checkRateLimit } from '@/lib/rate-limit';
+
+vi.mock('@/lib/order-review', () => ({ loadOrderReview: vi.fn(), OrderReviewError: class extends Error {} }));
+vi.mock('@/lib/rate-limit', () => ({ checkRateLimit: vi.fn(() => ({ success: true })), rateLimits: { sensitive: {} }, rateLimitResponse: () => new Response(null, { status: 429 }) }));
+const request = (body: unknown) => new Request('http://localhost/api/checkout/review', { method: 'POST', body: JSON.stringify(body) });
+beforeEach(() => { vi.clearAllMocks(); vi.mocked(auth).mockResolvedValue({ user: { id: 'member-1' } } as never); vi.mocked(checkRateLimit).mockReturnValue({ success: true } as never); });
+
+it('requires authentication before reading price and ownership', async () => {
+  vi.mocked(auth).mockResolvedValue(null as never);
+  expect((await POST(request({ courseId: 'course-1' }))).status).toBe(401);
+  expect(loadOrderReview).not.toHaveBeenCalled();
+});
+it.each([{ courseId: 'course-1', amount: 1 }, { courseId: 'course-1', bundleId: 'bundle-1' }, { bundleId: 'bundle-1', couponCode: 'FREE' }, {}, { courseId: 'x'.repeat(37) }])('rejects invalid or client-authored quote data', async (body) => {
+  expect((await POST(request(body))).status).toBe(400);
+  expect(loadOrderReview).not.toHaveBeenCalled();
+});
+it('rate limits and uses the authenticated owner for a private no-store review', async () => {
+  vi.mocked(checkRateLimit).mockReturnValueOnce({ success: false } as never);
+  expect((await POST(request({ courseId: 'course-1' }))).status).toBe(429);
+  vi.mocked(loadOrderReview).mockResolvedValue({ action: 'pay' } as never);
+  const response = await POST(request({ courseId: 'course-1' }));
+  expect(loadOrderReview).toHaveBeenCalledWith('member-1', { courseId: 'course-1' });
+  expect(response.headers.get('cache-control')).toBe('private, no-store');
+});

--- a/tests/api/payment.test.ts
+++ b/tests/api/payment.test.ts
@@ -303,6 +303,23 @@ describe('POST /api/stripe/checkout', () => {
         expect(createCall?.[1]).toEqual({ idempotencyKey: `checkout:${paymentId}` });
     });
 
+    it('does not create a payment or provider session after the reviewed price changes', async () => {
+        vi.mocked(db.query.courses.findFirst).mockResolvedValue(publishedCourse as never);
+        const res = await callCheckout({ courseId: 'course-1', expectedAmount: '490.00' });
+        expect(res.status).toBe(409);
+        expect(db.insert).not.toHaveBeenCalled();
+        expect(mockedStripe.checkout.sessions.create).not.toHaveBeenCalled();
+    });
+
+    it('does not silently discard a missing coupon and charge the full price', async () => {
+        vi.mocked(db.query.courses.findFirst).mockResolvedValue(publishedCourse as never);
+        mockDb.selectResults = [];
+        const res = await callCheckout({ courseId: 'course-1', couponId: 'missing-coupon' });
+        expect(res.status).toBe(400);
+        expect(db.insert).not.toHaveBeenCalled();
+        expect(mockedStripe.checkout.sessions.create).not.toHaveBeenCalled();
+    });
+
     // Note: coupon discount logic is thoroughly tested in tests/lib/coupon.test.ts
     // Complex multi-chain DB mocks for coupon flows are fragile in integration tests
 });

--- a/tests/api/promptpay-intent.test.ts
+++ b/tests/api/promptpay-intent.test.ts
@@ -87,6 +87,17 @@ describe('PromptPay intent creation boundary', () => {
     expect(body.expiresAt).toBeTruthy();
   });
 
+  it('rejects a stale reviewed amount without inserting an attempt', async () => {
+    selectQueue.push(
+      [{ id: 'course-1', title: 'Course', price: '990.00', promoPrice: null, promoStartsAt: null, promoEndsAt: null, status: 'published' }],
+      [{ lessonCount: 1 }], [],
+    );
+    const { POST } = await import('@/app/api/promptpay/intents/route');
+    const response = await POST(request({ courseId: 'course-1', expectedAmount: '490.00' }));
+    expect(response.status).toBe(409);
+    expect(inserted).toHaveLength(0);
+  });
+
   it('does not create an intent for an archived course', async () => {
     selectQueue.push([{
       id: 'course-1', title: 'Course', price: '990.00', promoPrice: null,

--- a/tests/components/bundle-enroll-button.test.tsx
+++ b/tests/components/bundle-enroll-button.test.tsx
@@ -58,6 +58,7 @@ describe('bundle enrollment purchase contract', () => {
       enrollEndpoint: '/api/bundles/enroll',
       stripeEndpoint: '/api/stripe/bundle-checkout',
       intentEndpoint: '/api/promptpay/intents',
+      reviewEndpoint: '/api/checkout/review',
       slipEndpoint: '/api/bundles/slip/verify',
       slipFields: {
         file: 'slip',
@@ -106,7 +107,7 @@ describe('bundle enrollment purchase contract', () => {
     );
 
     expect(html).toContain('Bundle นี้กำลังเตรียมเนื้อหา');
-    expect(html).toContain('disabled');
+    expect(html).not.toContain('<button');
     expect(html).not.toContain('ซื้อ Bundle');
   });
 

--- a/tests/components/bundle-enroll-interactions.test.tsx
+++ b/tests/components/bundle-enroll-interactions.test.tsx
@@ -1,377 +1,51 @@
 // @vitest-environment jsdom
-
-import type { ReactNode } from 'react';
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import BundleEnrollButton, {
-  BUNDLE_PAYMENT_CONTRACT,
-} from '@/components/bundle/BundleEnrollButton';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import BundleEnrollButton from '@/components/bundle/BundleEnrollButton';
 import { deriveBundleDecisionFacts } from '@/lib/bundle-decision-facts';
 
-vi.mock('next/image', () => ({ default: () => null }));
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
-}));
-vi.mock('next-auth/react', () => ({
-  useSession: () => ({ data: { user: { id: 'learner-1' } } }),
-}));
-vi.mock('@/components/analytics/analytics-client', () => ({
-  trackClientAnalyticsEvent: vi.fn(),
-}));
-vi.mock('@/components/ui/DialogShell', () => ({
-  default: ({
-    isOpen,
-    title,
-    body,
-    children,
-  }: {
-    isOpen: boolean;
-    title: ReactNode;
-    body: ReactNode;
-    children: ReactNode;
-  }) => isOpen ? (
-    <section role="dialog" aria-label={typeof title === 'string' ? title : 'payment'}>
-      {body}
-      <footer>{children}</footer>
-    </section>
-  ) : null,
-}));
-vi.mock('@/components/ui/Modal', () => ({
-  default: ({
-    isOpen,
-    title,
-    children,
-    onClose,
-  }: {
-    isOpen: boolean;
-    title?: string;
-    children: ReactNode;
-    onClose: () => void;
-  }) => isOpen ? (
-    <section role="dialog" aria-label={title}>
-      <p>{children}</p>
-      <button type="button" onClick={onClose}>ตกลง</button>
-    </section>
-  ) : null,
-}));
+const mocks = vi.hoisted(() => ({ push: vi.fn(), refresh: vi.fn(), member: true }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }) }));
+vi.mock('next-auth/react', () => ({ useSession: () => ({ data: mocks.member ? { user: { id: 'member-1' } } : null }) }));
+vi.mock('@/components/analytics/analytics-client', () => ({ trackClientAnalyticsEvent: vi.fn() }));
+const facts = (price = 2490) => deriveBundleDecisionFacts({ slug: 'full-stack', price, courses: [{ id: 'course-1', title: 'TypeScript', slug: 'typescript', orderIndex: 0, regularPrice: 3500, lessonCount: 1 }] }, { now: new Date() });
+const response = (body: unknown) => ({ ok: true, json: async () => body }) as Response;
+beforeEach(() => { vi.clearAllMocks(); mocks.member = true; });
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
-const DECISION_FACTS = deriveBundleDecisionFacts({
-  slug: 'full-stack',
-  price: 2490,
-  courses: [
-    {
-      id: 'course-1',
-      title: 'TypeScript',
-      slug: 'typescript',
-      orderIndex: 0,
-      regularPrice: 1800,
-      lessonCount: 8,
-    },
-    {
-      id: 'course-2',
-      title: 'Next.js',
-      slug: 'nextjs',
-      orderIndex: 1,
-      regularPrice: 1700,
-      lessonCount: 10,
-    },
-  ],
-}, { now: new Date('2026-09-02T05:00:00.000Z') });
-const jsonResponse = (body: unknown, ok = true) => ({
-  ok,
-  json: vi.fn().mockResolvedValue(body),
-}) as unknown as Response;
+it('preserves the exact Bundle destination when a visitor starts checkout', async () => {
+  mocks.member = false;
+  const user = userEvent.setup();
+  render(<BundleEnrollButton bundleId="bundle-1" bundleSlug="full-stack" decisionFacts={facts()} />);
+  await user.click(screen.getByRole('button', { name: /ซื้อ Bundle/ }));
+  expect(mocks.push).toHaveBeenCalledWith('/login?callbackUrl=/bundles/full-stack');
+});
 
-const deferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-};
+it('grants the Bundle learning action after explicit server-confirmed free enrollment', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(response({ success: true, totalEnrolled: 1 }));
+  vi.stubGlobal('fetch', fetchMock);
+  const user = userEvent.setup();
+  render(<BundleEnrollButton bundleId="bundle-1" bundleSlug="full-stack" decisionFacts={facts(0)} />);
+  await user.click(screen.getByRole('button', { name: 'ลงทะเบียน Bundle ฟรี' }));
+  expect(await screen.findByRole('link', { name: 'ไปการเรียนของฉัน' })).toBeTruthy();
+  expect(fetchMock).toHaveBeenCalledWith('/api/bundles/enroll', expect.objectContaining({ body: JSON.stringify({ bundleId: 'bundle-1' }) }));
+  expect(mocks.refresh).toHaveBeenCalled();
+});
 
-const urlOf = (input: RequestInfo | URL) => (
-  typeof input === 'string'
-    ? input
-    : input instanceof URL
-      ? input.toString()
-      : input.url
-);
-
-describe('bundle enrollment interactions', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    cleanup();
-    vi.unstubAllGlobals();
-  });
-
-  it('rejects an invalid slip type without retaining a previously valid bundle file', async () => {
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url === BUNDLE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'bundle-payment-1', amount: 2490 }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup({ applyAccept: false });
-    render(
-      <BundleEnrollButton
-        bundleId="bundle-1"
-        bundleSlug="full-stack"
-        decisionFacts={DECISION_FACTS}
-      />,
-    );
-
-    await user.click(screen.getByRole('button', { name: /2,490/ }));
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-
-    await user.upload(slipInput, new File(['valid-slip'], 'bundle.png', { type: 'image/png' }));
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-
-    await user.upload(slipInput, new File(['not-an-image'], 'bundle.pdf', { type: 'application/pdf' }));
-
-    expect(await screen.findByText('รองรับเฉพาะไฟล์ JPG, PNG, WEBP เท่านั้น')).toBeTruthy();
-    expect(slipInput.getAttribute('aria-invalid')).toBe('true');
-    expect(verifyButton.disabled).toBe(true);
-  });
-
-  it('rejects an oversized slip without retaining a previously valid file', async () => {
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url === BUNDLE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'bundle-payment-1', amount: 2490 }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(
-      <BundleEnrollButton
-        bundleId="bundle-1"
-        bundleSlug="full-stack"
-        decisionFacts={DECISION_FACTS}
-      />,
-    );
-
-    await user.click(screen.getByRole('button', { name: /2,490/ }));
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-
-    await user.upload(slipInput, new File(['valid-slip'], 'bundle.png', { type: 'image/png' }));
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-
-    const oversizedSlip = new File(
-      [new Uint8Array(BUNDLE_PAYMENT_CONTRACT.maxSlipBytes + 1)],
-      'bundle-too-large.png',
-      { type: 'image/png' },
-    );
-    await user.upload(slipInput, oversizedSlip);
-
-    expect(await screen.findByText('ไฟล์ต้องมีขนาดไม่เกิน 5MB')).toBeTruthy();
-    expect(slipInput.getAttribute('aria-invalid')).toBe('true');
-    expect(verifyButton.disabled).toBe(true);
-  });
-
-  it('keeps the bundle payment attempt retryable when slip verification rejects the HTTP response', async () => {
-    let verificationAttempt = 0;
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url === BUNDLE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'bundle-payment-1', amount: 2490 }));
-      }
-      if (url === BUNDLE_PAYMENT_CONTRACT.slipEndpoint) {
-        verificationAttempt += 1;
-        return Promise.resolve(verificationAttempt === 1
-          ? jsonResponse({ success: true, error: 'Bundle slip provider rejected the request' }, false)
-          : jsonResponse({ success: true, enrolled: ['course-1'] }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(
-      <BundleEnrollButton
-        bundleId="bundle-1"
-        bundleSlug="full-stack"
-        decisionFacts={DECISION_FACTS}
-      />,
-    );
-
-    await user.click(screen.getByRole('button', { name: /2,490/ }));
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    await user.upload(slipInput, new File(['bundle-slip'], 'bundle.webp', { type: 'image/webp' }));
-
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-    await user.click(verifyButton);
-
-    expect(await screen.findByText('Bundle slip provider rejected the request')).toBeTruthy();
-    expect(verifyButton.disabled).toBe(false);
-
-    await user.click(verifyButton);
-    expect(await screen.findByRole('link', { name: /ไปการเรียนของฉัน/ })).toBeTruthy();
-
-    const verificationCalls = fetchMock.mock.calls.filter(([input]) => (
-      urlOf(input) === BUNDLE_PAYMENT_CONTRACT.slipEndpoint
-    ));
-    expect(verificationCalls).toHaveLength(2);
-    for (const [, init] of verificationCalls) {
-      const formData = init?.body as FormData;
-      expect(formData.get(BUNDLE_PAYMENT_CONTRACT.slipFields.paymentId)).toBe('bundle-payment-1');
-      expect(formData.get(BUNDLE_PAYMENT_CONTRACT.slipFields.file)).toBeInstanceOf(File);
-    }
-  });
-
-  it('shows a bundle Stripe rejection and lets the learner retry checkout', async () => {
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url === BUNDLE_PAYMENT_CONTRACT.stripeEndpoint) {
-        return Promise.resolve(jsonResponse({ error: 'Bundle Stripe temporarily unavailable' }, false));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(
-      <BundleEnrollButton
-        bundleId="bundle-1"
-        bundleSlug="full-stack"
-        decisionFacts={DECISION_FACTS}
-      />,
-    );
-
-    const enrollmentButton = screen.getByRole('button', { name: /2,490/ });
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /Stripe/ }));
-
-    expect(await screen.findByText('Bundle Stripe temporarily unavailable')).toBeTruthy();
-    expect(fetchMock).toHaveBeenCalledWith(
-      BUNDLE_PAYMENT_CONTRACT.stripeEndpoint,
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ bundleId: 'bundle-1' }),
-      }),
-    );
-
-    await user.click(screen.getByRole('button', { name: 'ตกลง' }));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /Stripe/ }));
-
-    await waitFor(() => {
-      const stripeCalls = fetchMock.mock.calls.filter(([input]) => (
-        urlOf(input) === BUNDLE_PAYMENT_CONTRACT.stripeEndpoint
-      ));
-      expect(stripeCalls).toHaveLength(2);
-    });
-  });
-
-  it('shows the shared current-price comparison before payment method selection', async () => {
-    const user = userEvent.setup();
-    render(
-      <BundleEnrollButton
-        bundleId="bundle-1"
-        bundleSlug="full-stack"
-        decisionFacts={DECISION_FACTS}
-      />,
-    );
-
-    await user.click(screen.getByRole('button', { name: /2,490/ }));
-
-    const orderReview = screen.getByRole('dialog', { name: 'เลือกช่องทางชำระเงิน' });
-    expect(orderReview.textContent).toContain('ตรวจสอบรายการ Bundle');
-    expect(orderReview.textContent).toContain('ซื้อแยกวันนี้');
-    expect(orderReview.textContent).toContain('฿3,500');
-    expect(orderReview.textContent).toContain('ประหยัด ฿1,010 (29%)');
-  });
-
-  it('preserves PromptPay intent and slip fields while locking verification', async () => {
-    const verifyRequest = deferred<Response>();
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url === BUNDLE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'bundle-payment-1', amount: 2490 }));
-      }
-      if (url === BUNDLE_PAYMENT_CONTRACT.slipEndpoint) {
-        return verifyRequest.promise;
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(
-      <BundleEnrollButton
-        bundleId="bundle-1"
-        bundleSlug="full-stack"
-        decisionFacts={DECISION_FACTS}
-      />,
-    );
-
-    await user.click(screen.getByRole('button', { name: /2,490/ }));
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    expect(fetchMock).toHaveBeenCalledWith(
-      BUNDLE_PAYMENT_CONTRACT.intentEndpoint,
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ bundleId: 'bundle-1' }),
-      }),
-    );
-
-    await user.upload(slipInput, new File(['bundle-slip'], 'bundle.webp', { type: 'image/webp' }));
-
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-    await user.click(verifyButton);
-
-    expect(verifyButton.disabled).toBe(true);
-    expect(verifyButton.getAttribute('aria-busy')).toBe('true');
-    const verifyCall = fetchMock.mock.calls.find(([input]) => (
-      urlOf(input) === BUNDLE_PAYMENT_CONTRACT.slipEndpoint
-    ));
-    const formData = verifyCall?.[1]?.body as FormData;
-    expect(formData.get(BUNDLE_PAYMENT_CONTRACT.slipFields.file)).toBeInstanceOf(File);
-    expect(formData.get(BUNDLE_PAYMENT_CONTRACT.slipFields.paymentId)).toBe('bundle-payment-1');
-
-    await act(async () => {
-      verifyRequest.resolve(jsonResponse({ success: true, enrolled: ['course-1'] }));
-      await verifyRequest.promise;
-    });
-  });
+it('reviews the server-derived Bundle comparison before choosing a payment method', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(response({ review: {
+    target: { type: 'bundle', id: 'bundle-1', title: 'Bundle จาก server', href: '/bundles/full-stack' },
+    price: { original: '2490.00', discount: '0.00', amountDue: '2490.00', currency: 'THB' },
+    coupon: null, comparison: { separate: '3500.00', label: 'ประหยัด ฿1,010 (29%)' },
+    access: { ownedCount: 0, totalCount: 1, description: 'ยืนยันแล้วจึงมีสิทธิ์เรียน' }, action: 'pay',
+  } }));
+  vi.stubGlobal('fetch', fetchMock);
+  const user = userEvent.setup();
+  render(<BundleEnrollButton bundleId="bundle-1" bundleSlug="full-stack" decisionFacts={facts()} />);
+  await user.click(screen.getByRole('button', { name: /ซื้อ Bundle/ }));
+  expect(await screen.findByText('Bundle จาก server')).toBeTruthy();
+  expect(screen.getByText('฿3,500.00')).toBeTruthy();
+  expect(screen.getByText('ประหยัด ฿1,010 (29%)')).toBeTruthy();
+  expect(screen.queryByRole('textbox', { name: 'มีโค้ดส่วนลด?' })).toBeNull();
 });

--- a/tests/components/checkout-dialog.test.tsx
+++ b/tests/components/checkout-dialog.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { createRef, type ReactNode } from 'react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CheckoutDialog from '@/components/checkout/CheckoutDialog';
+import type { OrderReview } from '@/lib/order-review';
+
+vi.mock('next/image', () => ({ default: () => null }));
+vi.mock('@/components/ui/DialogShell', () => ({ default: ({ isOpen, title, body, children, onClose }: { isOpen: boolean; title: string; body: ReactNode; children: ReactNode; onClose: () => void }) => isOpen ? <section role="dialog" aria-label={title}><button onClick={onClose}>Close</button>{body}{children}</section> : null }));
+
+const response = (body: unknown, status = 200) => ({ ok: status < 400, status, json: async () => body }) as Response;
+const deferred = () => { let resolve!: (value: Response) => void; const promise = new Promise<Response>((done) => { resolve = done; }); return { promise, resolve }; };
+const intent = { paymentId: 'attempt-1', amount: 990.25, itemTitle: 'รายการภาษาไทย', expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString() };
+const completed = { canSubmitSlip: false, presentation: { payment: { state: 'completed-ready', heading: 'พร้อมเรียน', description: 'ยืนยันแล้ว' } } };
+const enrolled = vi.fn();
+const close = vi.fn();
+
+function review(type: 'course' | 'bundle', overrides: Partial<OrderReview> = {}): OrderReview {
+  return {
+    target: { type, id: 'product-1', title: 'รายการภาษาไทย', href: '/courses/thai' },
+    price: { original: '990.25', discount: '0.00', amountDue: '990.25', currency: 'THB' },
+    coupon: null, action: 'pay',
+    access: { ownedCount: 0, totalCount: 1, description: 'ได้รับสิทธิ์เมื่อระบบยืนยันแล้ว' },
+    comparison: type === 'bundle' ? { separate: '1500.00', label: 'ประหยัด ฿509.75' } : null,
+    ...overrides,
+  };
+}
+function mount(type: 'course' | 'bundle') {
+  return render(<CheckoutDialog open onClose={close} target={{ type, id: 'product-1' }} exposureId={null} returnFocusRef={createRef<HTMLButtonElement>()} onEnrolled={enrolled} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('URL', Object.assign(URL, { createObjectURL: vi.fn(() => 'blob:test'), revokeObjectURL: vi.fn() }));
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+describe.each(['course', 'bundle'] as const)('%s order review and payment', (type) => {
+  const body = type === 'course' ? { courseId: 'product-1' } : { bundleId: 'product-1' };
+  const slipEndpoint = type === 'course' ? '/api/slip/verify' : '/api/bundles/slip/verify';
+  const stripeEndpoint = type === 'course' ? '/api/stripe/checkout' : '/api/stripe/bundle-checkout';
+
+  it('waits for authoritative review and keeps method actions locked during creation', async () => {
+    const pendingReview = deferred();
+    const pendingIntent = deferred();
+    const fetchMock = vi.fn().mockReturnValueOnce(pendingReview.promise).mockReturnValueOnce(pendingIntent.promise);
+    vi.stubGlobal('fetch', fetchMock);
+    const user = userEvent.setup(); mount(type);
+    expect(screen.queryByRole('button', { name: /PromptPay/ })).toBeNull();
+    await act(async () => pendingReview.resolve(response({ review: review(type) })));
+    expect(await screen.findAllByText('฿990.25')).toHaveLength(2);
+    await user.click(screen.getByRole('button', { name: /PromptPay/ }));
+    expect((screen.getByRole('button', { name: /Stripe/ }) as HTMLButtonElement).disabled).toBe(true);
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(close).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/promptpay/intents', expect.objectContaining({ body: JSON.stringify({ ...body, expectedAmount: '990.25' }) }));
+    await act(async () => pendingIntent.resolve(response(intent, 201)));
+    expect(await screen.findByText('attempt-1')).toBeTruthy();
+    expect(screen.getByText(/เวลาไทย/)).toBeTruthy();
+    expect(screen.getByText(/ข้อมูลส่วนบุคคล/)).toBeTruthy();
+  });
+
+  it('retains the exact attempt on close/reopen and retries a rejected slip without another payment', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(response({ review: review(type) })).mockResolvedValueOnce(response(intent, 201))
+      .mockResolvedValueOnce(response({ error: 'สลิปไม่ตรงรายการ' }, 400)).mockResolvedValueOnce(response({ success: true })).mockResolvedValueOnce(response(completed));
+    vi.stubGlobal('fetch', fetchMock);
+    const user = userEvent.setup(); const mounted = mount(type);
+    await user.click(await screen.findByRole('button', { name: /PromptPay/ }));
+    await user.click(await screen.findByRole('button', { name: 'ปิดและเก็บรายการไว้' }));
+    const props = { onClose: close, target: { type, id: 'product-1' }, exposureId: null, returnFocusRef: createRef<HTMLButtonElement>(), onEnrolled: enrolled };
+    mounted.rerender(<CheckoutDialog {...props} open={false} />);
+    mounted.rerender(<CheckoutDialog {...props} open />);
+    expect(screen.getByText('attempt-1')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Stripe/ })).toBeNull();
+    await user.upload(screen.getByLabelText('แนบสลิปการโอนเงิน'), new File(['test'], 'test.png', { type: 'image/png' }));
+    await user.click(screen.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }));
+    expect(await screen.findByText('สลิปไม่ตรงรายการ')).toBeTruthy();
+    expect(enrolled).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }));
+    await waitFor(() => expect(enrolled).toHaveBeenCalledTimes(1));
+    const calls = fetchMock.mock.calls.filter(([url]) => url === slipEndpoint);
+    expect(calls).toHaveLength(2);
+    for (const [, options] of calls) expect((options.body as FormData).get('paymentId')).toBe('attempt-1');
+    expect(fetchMock.mock.calls.filter(([url]) => url === '/api/promptpay/intents')).toHaveLength(1);
+  });
+
+  it('blocks duplicate payment and slip submission after a timeout until owner-checked status permits retry', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(response({ review: review(type) })).mockResolvedValueOnce(response(intent, 201))
+      .mockResolvedValueOnce(response({ error: 'timeout' }, 503))
+      .mockResolvedValueOnce(response({ canSubmitSlip: false, presentation: { payment: { state: 'verifying', heading: 'กำลังตรวจสอบ', description: 'อย่าชำระซ้ำ' } } }))
+      .mockResolvedValueOnce(response({ canSubmitSlip: true, presentation: { payment: { state: 'pending', heading: 'รอแนบสลิป', description: 'ใช้รายการเดิม' } } }));
+    vi.stubGlobal('fetch', fetchMock);
+    const user = userEvent.setup(); mount(type);
+    await user.click(await screen.findByRole('button', { name: /PromptPay/ }));
+    await user.upload(await screen.findByLabelText('แนบสลิปการโอนเงิน'), new File(['test'], 'test.webp', { type: 'image/webp' }));
+    await user.click(screen.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }));
+    await screen.findByText(/ผลการตรวจสอบยังไม่ยืนยัน/);
+    expect(screen.queryByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'ตรวจสถานะอีกครั้ง' }));
+    expect(await screen.findByText('กำลังตรวจสอบ')).toBeTruthy();
+    expect(enrolled).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'ตรวจสถานะอีกครั้ง' }));
+    expect(await screen.findByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeTruthy();
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/promptpay/intents?paymentId=attempt-1', { cache: 'no-store' });
+  });
+
+  it('rejects oversize/unsupported slips, locks verifying, and grants no access while pending', async () => {
+    const verification = deferred();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ review: review(type) })).mockResolvedValueOnce(response(intent, 201)).mockReturnValueOnce(verification.promise).mockResolvedValueOnce(response(completed)));
+    const user = userEvent.setup({ applyAccept: false }); mount(type);
+    await user.click(await screen.findByRole('button', { name: /PromptPay/ }));
+    const input = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
+    await user.upload(input, new File(['bad'], 'bad.svg', { type: 'image/svg+xml' }));
+    expect(await screen.findByText('รองรับเฉพาะไฟล์ JPG, PNG, WEBP เท่านั้น')).toBeTruthy();
+    await user.upload(input, new File([new Uint8Array(5 * 1024 * 1024 + 1)], 'large.png', { type: 'image/png' }));
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect((screen.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }) as HTMLButtonElement).disabled).toBe(true);
+    await user.upload(input, new File(['test'], 'test.png', { type: 'image/png' }));
+    await user.click(screen.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }));
+    expect(input.disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'กำลังตรวจสอบสลิป...' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(enrolled).not.toHaveBeenCalled();
+    await act(async () => verification.resolve(response({ success: true })));
+  });
+
+  it('requires a fresh review after Stripe rejects the reviewed price', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(response({ review: review(type) })).mockResolvedValueOnce(response({ error: 'ราคาเปลี่ยนแปลง' }, 409));
+    vi.stubGlobal('fetch', fetchMock);
+    const user = userEvent.setup(); mount(type);
+    await user.click(await screen.findByRole('button', { name: /Stripe/ }));
+    expect(await screen.findByText('ราคาเปลี่ยนแปลง')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /PromptPay/ })).toBeNull();
+    expect(fetchMock).toHaveBeenLastCalledWith(stripeEndpoint, expect.objectContaining({ body: JSON.stringify({ ...body, expectedAmount: '990.25' }) }));
+    expect(screen.getByRole('button', { name: 'ตรวจสอบรายการใหม่โดยไม่ใช้คูปอง' })).toBeTruthy();
+  });
+
+  it('shows expired attempts without a second transfer prompt', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ review: review(type) })).mockResolvedValueOnce(response({ ...intent, expiresAt: '2020-01-01T00:00:00.000Z' }, 201)));
+    const user = userEvent.setup(); mount(type);
+    await user.click(await screen.findByRole('button', { name: /PromptPay/ }));
+    expect(await screen.findByText('รายการพร้อมเพย์หมดเวลาแล้ว')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeNull();
+    expect(screen.queryByText('เลขบัญชี')).toBeNull();
+  });
+});
+
+it('uses the explicit free-enrollment endpoint only after a server-confirmed 100% coupon', async () => {
+  const couponReview = deferred();
+  const enrollment = deferred();
+  const fetchMock = vi.fn().mockResolvedValueOnce(response({ review: review('course') })).mockReturnValueOnce(couponReview.promise).mockReturnValueOnce(enrollment.promise);
+  vi.stubGlobal('fetch', fetchMock);
+  const user = userEvent.setup(); mount('course');
+  await screen.findByRole('button', { name: /Stripe/ });
+  await user.type(screen.getByRole('textbox', { name: 'มีโค้ดส่วนลด?' }), 'FREE100');
+  await user.click(screen.getByRole('button', { name: 'ใช้โค้ด' }));
+  expect((screen.getByRole('button', { name: 'ใช้โค้ด' }) as HTMLButtonElement).disabled).toBe(true);
+  await act(async () => couponReview.resolve(response({ review: review('course', { coupon: { id: 'coupon-1', code: 'FREE100', description: null }, price: { original: '990.25', discount: '990.25', amountDue: '0.00', currency: 'THB' }, action: 'enroll-free' }) })));
+  expect(screen.queryByRole('button', { name: /Stripe/ })).toBeNull();
+  await user.click(screen.getByRole('button', { name: 'ลงทะเบียนเรียนฟรี (คูปอง 100%)' }));
+  expect(fetchMock).toHaveBeenLastCalledWith('/api/enroll', expect.objectContaining({ body: JSON.stringify({ courseId: 'product-1', couponId: 'coupon-1' }) }));
+  expect(enrolled).not.toHaveBeenCalled();
+  await act(async () => enrollment.resolve(response({ success: true })));
+  expect(enrolled).toHaveBeenCalledTimes(1);
+});
+
+it.each(['คูปองนี้หมดอายุแล้ว', 'คูปองนี้ไม่สามารถใช้กับคอร์สนี้ได้'])('keeps invalid coupons accessible: %s', async (error) => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ review: review('course') })).mockResolvedValueOnce(response({ error }, 400)));
+  const user = userEvent.setup(); mount('course');
+  await screen.findByRole('button', { name: /Stripe/ });
+  const input = screen.getByRole('textbox', { name: 'มีโค้ดส่วนลด?' });
+  await user.type(input, 'INVALID');
+  await user.click(screen.getByRole('button', { name: 'ใช้โค้ด' }));
+  expect(await screen.findByText(error)).toBeTruthy();
+  expect(input.getAttribute('aria-invalid')).toBe('true');
+  expect(screen.queryByRole('button', { name: /Stripe/ })).toBeNull();
+});
+
+it('does not claim learning access from a successful slip response while access is still pending', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ review: review('course') })).mockResolvedValueOnce(response(intent, 201))
+    .mockResolvedValueOnce(response({ success: true, alreadyFulfilled: true }))
+    .mockResolvedValueOnce(response({ canSubmitSlip: false, presentation: { payment: { state: 'completed-access-pending', heading: 'ชำระแล้ว กำลังเปิดสิทธิ์', description: 'อย่าชำระซ้ำ' } } })));
+  const user = userEvent.setup(); mount('course');
+  await user.click(await screen.findByRole('button', { name: /PromptPay/ }));
+  await user.upload(await screen.findByLabelText('แนบสลิปการโอนเงิน'), new File(['test'], 'test.png', { type: 'image/png' }));
+  await user.click(screen.getByRole('button', { name: 'ตรวจสอบและชำระเงิน' }));
+  expect(await screen.findByText('ชำระแล้ว กำลังเปิดสิทธิ์')).toBeTruthy();
+  expect(enrolled).not.toHaveBeenCalled();
+  expect(screen.queryByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeNull();
+});

--- a/tests/components/checkout-dialog.test.tsx
+++ b/tests/components/checkout-dialog.test.tsx
@@ -189,3 +189,17 @@ it('does not claim learning access from a successful slip response while access 
   expect(enrolled).not.toHaveBeenCalled();
   expect(screen.queryByRole('button', { name: 'ตรวจสอบและชำระเงิน' })).toBeNull();
 });
+
+it('recovers an uncertain free enrollment by reading current ownership rather than prompting for payment', async () => {
+  const fetchMock = vi.fn().mockResolvedValueOnce(response({ review: review('course', { action: 'enroll-free', price: { original: '0.00', discount: '0.00', amountDue: '0.00', currency: 'THB' } }) }))
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce(response({ review: review('course', { action: 'owned' }) }));
+  vi.stubGlobal('fetch', fetchMock);
+  const user = userEvent.setup(); mount('course');
+  await user.click(await screen.findByRole('button', { name: 'ยืนยันลงทะเบียนเรียนฟรี' }));
+  expect(await screen.findByText(/ยังยืนยันผลการลงทะเบียนไม่ได้/)).toBeTruthy();
+  expect(enrolled).not.toHaveBeenCalled();
+  await user.click(screen.getByRole('button', { name: 'ตรวจสอบรายการใหม่โดยไม่ใช้คูปอง' }));
+  expect(await screen.findByRole('link', { name: 'ไปการเรียนของฉัน' })).toBeTruthy();
+  expect(screen.queryByRole('link', { name: 'ดูประวัติการชำระเงิน' })).toBeNull();
+});

--- a/tests/components/course-enroll-button.test.tsx
+++ b/tests/components/course-enroll-button.test.tsx
@@ -26,6 +26,7 @@ describe('course enrollment purchase contract', () => {
       stripeEndpoint: '/api/stripe/checkout',
       couponEndpoint: '/api/coupons/validate',
       intentEndpoint: '/api/promptpay/intents',
+      reviewEndpoint: '/api/checkout/review',
       slipEndpoint: '/api/slip/verify',
       slipFields: {
         file: 'slip',

--- a/tests/components/course-enroll-interactions.test.tsx
+++ b/tests/components/course-enroll-interactions.test.tsx
@@ -1,408 +1,57 @@
 // @vitest-environment jsdom
-
-import type { ReactNode } from 'react';
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import EnrollButton from '@/components/course/EnrollButton';
 
-import EnrollButton, { COURSE_PAYMENT_CONTRACT } from '@/components/course/EnrollButton';
+const mocks = vi.hoisted(() => ({ push: vi.fn(), member: true }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }) }));
+vi.mock('next-auth/react', () => ({ useSession: () => ({ data: mocks.member ? { user: { id: 'member-1' } } : null, status: mocks.member ? 'authenticated' : 'unauthenticated' }) }));
+vi.mock('@/components/analytics/analytics-client', () => ({ trackClientAnalyticsEvent: vi.fn() }));
+const response = (body: unknown, ok = true) => ({ ok, json: async () => body }) as Response;
+beforeEach(() => { vi.clearAllMocks(); mocks.member = true; });
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
-vi.mock('next/image', () => ({ default: () => null }));
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
-}));
-vi.mock('next-auth/react', () => ({
-  useSession: () => ({
-    data: { user: { id: 'learner-1' } },
-    status: 'authenticated',
-  }),
-}));
-vi.mock('@/components/analytics/analytics-client', () => ({
-  trackClientAnalyticsEvent: vi.fn(),
-}));
-vi.mock('@/components/ui/DialogShell', () => ({
-  default: ({
-    isOpen,
-    title,
-    body,
-    children,
-  }: {
-    isOpen: boolean;
-    title: ReactNode;
-    body: ReactNode;
-    children: ReactNode;
-  }) => isOpen ? (
-    <section role="dialog" aria-label={typeof title === 'string' ? title : 'payment'}>
-      {body}
-      <footer>{children}</footer>
-    </section>
-  ) : null,
-}));
-vi.mock('@/components/ui/Modal', () => ({
-  default: ({
-    isOpen,
-    title,
-    children,
-    onClose,
-  }: {
-    isOpen: boolean;
-    title?: string;
-    children: ReactNode;
-    onClose: () => void;
-  }) => isOpen ? (
-    <section role="dialog" aria-label={title}>
-      <p>{children}</p>
-      <button type="button" onClick={onClose}>ตกลง</button>
-    </section>
-  ) : null,
-}));
+it('preserves the exact Course destination when a visitor starts checkout', async () => {
+  mocks.member = false;
+  const user = userEvent.setup();
+  render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
+  await user.click(await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }));
+  expect(mocks.push).toHaveBeenCalledWith('/login?callbackUrl=/courses/typescript');
+});
 
-const jsonResponse = (body: unknown, ok = true) => ({
-  ok,
-  json: vi.fn().mockResolvedValue(body),
-}) as unknown as Response;
+it('keeps free enrollment server-authoritative and updates the learning action after success', async () => {
+  const fetchMock = vi.fn().mockResolvedValueOnce(response({ enrolled: false })).mockResolvedValueOnce(response({ success: true }));
+  vi.stubGlobal('fetch', fetchMock);
+  const user = userEvent.setup(); const changed = vi.fn();
+  render(<EnrollButton courseId="course-1" courseSlug="typescript" price={0} onEnrollmentChange={changed} />);
+  await user.click(await screen.findByRole('button', { name: 'ลงทะเบียนเรียนฟรี' }));
+  await user.click(await screen.findByRole('button', { name: 'เข้าเรียน' }));
+  expect(fetchMock).toHaveBeenLastCalledWith('/api/enrollments', expect.objectContaining({ body: JSON.stringify({ courseId: 'course-1' }) }));
+  expect(changed).toHaveBeenLastCalledWith(true);
+  expect(mocks.push).toHaveBeenCalledWith('/courses/typescript/learn');
+});
 
-const deferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-};
+it('shows a server rejection without granting course access', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response({ enrolled: false })).mockResolvedValueOnce(response({ error: 'ยังลงทะเบียนไม่ได้' }, false)));
+  const user = userEvent.setup();
+  render(<EnrollButton courseId="course-1" courseSlug="typescript" price={0} />);
+  await user.click(await screen.findByRole('button', { name: 'ลงทะเบียนเรียนฟรี' }));
+  expect(await screen.findByText('ยังลงทะเบียนไม่ได้')).toBeTruthy();
+  expect(screen.queryByRole('button', { name: 'เข้าเรียน' })).toBeNull();
+});
 
-const urlOf = (input: RequestInfo | URL) => (
-  typeof input === 'string'
-    ? input
-    : input instanceof URL
-      ? input.toString()
-      : input.url
-);
-
-describe('course enrollment interactions', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    cleanup();
-    vi.unstubAllGlobals();
-  });
-
-  it('locks coupon actions while pending and preserves the coupon enrollment payload', async () => {
-    const couponRequest = deferred<Response>();
-    const enrollRequest = deferred<Response>();
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url.startsWith('/api/enrollments/check')) {
-        return Promise.resolve(jsonResponse({ enrolled: false }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.couponEndpoint) {
-        return couponRequest.promise;
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.enrollEndpoint) {
-        return enrollRequest.promise;
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
-
-    const enrollmentButton = await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }) as HTMLButtonElement;
-    await waitFor(() => expect(enrollmentButton.disabled).toBe(false));
-    await user.click(enrollmentButton);
-
-    const couponInput = screen.getByRole('textbox', { name: 'มีโค้ดส่วนลด?' });
-    await user.type(couponInput, 'FREE100');
-    const couponButton = screen.getByRole('button', { name: 'ใช้โค้ด' }) as HTMLButtonElement;
-    await user.click(couponButton);
-
-    expect(couponButton.disabled).toBe(true);
-    expect(fetchMock).toHaveBeenCalledWith(
-      COURSE_PAYMENT_CONTRACT.couponEndpoint,
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({
-          code: 'FREE100',
-          courseId: 'course-1',
-          originalPrice: 2490,
-        }),
-      }),
-    );
-
-    await act(async () => {
-      couponRequest.resolve(jsonResponse({
-        valid: true,
-        couponId: 'coupon-1',
-        code: 'FREE100',
-        discountAmount: 2490,
-        finalPrice: 0,
-        description: null,
-      }));
-      await couponRequest.promise;
-    });
-
-    const couponEnrollButton = screen.getByRole('button', {
-      name: /ลงทะเบียนเรียนฟรี/,
-    }) as HTMLButtonElement;
-    await user.click(couponEnrollButton);
-
-    expect(couponEnrollButton.disabled).toBe(true);
-    expect(couponEnrollButton.getAttribute('aria-busy')).toBe('true');
-    expect(fetchMock).toHaveBeenCalledWith(
-      COURSE_PAYMENT_CONTRACT.enrollEndpoint,
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ courseId: 'course-1', couponId: 'coupon-1' }),
-      }),
-    );
-
-    await act(async () => {
-      enrollRequest.resolve(jsonResponse({ enrolled: true }));
-      await enrollRequest.promise;
-    });
-  });
-
-  it('shows a Stripe rejection and lets the learner retry checkout', async () => {
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url.startsWith('/api/enrollments/check')) {
-        return Promise.resolve(jsonResponse({ enrolled: false }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.stripeEndpoint) {
-        return Promise.resolve(jsonResponse({ error: 'Stripe temporarily unavailable' }, false));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
-
-    const enrollmentButton = await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }) as HTMLButtonElement;
-    await waitFor(() => expect(enrollmentButton.disabled).toBe(false));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /Stripe/ }));
-
-    expect(await screen.findByText('Stripe temporarily unavailable')).toBeTruthy();
-    expect(fetchMock).toHaveBeenCalledWith(
-      COURSE_PAYMENT_CONTRACT.stripeEndpoint,
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ courseId: 'course-1' }),
-      }),
-    );
-
-    await user.click(screen.getByRole('button', { name: 'ตกลง' }));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /Stripe/ }));
-
-    await waitFor(() => {
-      const stripeCalls = fetchMock.mock.calls.filter(([input]) => (
-        urlOf(input) === COURSE_PAYMENT_CONTRACT.stripeEndpoint
-      ));
-      expect(stripeCalls).toHaveLength(2);
-    });
-  });
-
-  it('rejects an invalid slip type without retaining a previously valid file', async () => {
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url.startsWith('/api/enrollments/check')) {
-        return Promise.resolve(jsonResponse({ enrolled: false }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'payment-1', amount: 2490 }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup({ applyAccept: false });
-    render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
-
-    const enrollmentButton = await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }) as HTMLButtonElement;
-    await waitFor(() => expect(enrollmentButton.disabled).toBe(false));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-
-    await user.upload(slipInput, new File(['valid-slip'], 'slip.png', { type: 'image/png' }));
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-
-    await user.upload(slipInput, new File(['not-an-image'], 'slip.pdf', { type: 'application/pdf' }));
-
-    expect(await screen.findByText('รองรับเฉพาะไฟล์ JPG, PNG, WEBP เท่านั้น')).toBeTruthy();
-    expect(slipInput.getAttribute('aria-invalid')).toBe('true');
-    expect(verifyButton.disabled).toBe(true);
-  });
-
-  it('rejects an oversized slip without retaining a previously valid course file', async () => {
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url.startsWith('/api/enrollments/check')) {
-        return Promise.resolve(jsonResponse({ enrolled: false }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'payment-1', amount: 2490 }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
-
-    const enrollmentButton = await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }) as HTMLButtonElement;
-    await waitFor(() => expect(enrollmentButton.disabled).toBe(false));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-
-    await user.upload(slipInput, new File(['valid-slip'], 'slip.png', { type: 'image/png' }));
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-
-    const oversizedSlip = new File(
-      [new Uint8Array(COURSE_PAYMENT_CONTRACT.maxSlipBytes + 1)],
-      'course-too-large.png',
-      { type: 'image/png' },
-    );
-    await user.upload(slipInput, oversizedSlip);
-
-    expect(await screen.findByText('ไฟล์ต้องมีขนาดไม่เกิน 5MB')).toBeTruthy();
-    expect(slipInput.getAttribute('aria-invalid')).toBe('true');
-    expect(verifyButton.disabled).toBe(true);
-  });
-
-  it('keeps the payment attempt retryable when slip verification returns a rejected HTTP response', async () => {
-    let verificationAttempt = 0;
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url.startsWith('/api/enrollments/check')) {
-        return Promise.resolve(jsonResponse({ enrolled: false }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'payment-1', amount: 2490 }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.slipEndpoint) {
-        verificationAttempt += 1;
-        return Promise.resolve(verificationAttempt === 1
-          ? jsonResponse({ success: true, error: 'Slip provider rejected the request' }, false)
-          : jsonResponse({ success: true }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
-
-    const enrollmentButton = await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }) as HTMLButtonElement;
-    await waitFor(() => expect(enrollmentButton.disabled).toBe(false));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    await user.upload(slipInput, new File(['valid-slip'], 'slip.png', { type: 'image/png' }));
-
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-    await user.click(verifyButton);
-
-    expect(await screen.findByText('Slip provider rejected the request')).toBeTruthy();
-    expect(verifyButton.disabled).toBe(false);
-
-    await user.click(verifyButton);
-    expect(await screen.findByRole('dialog', { name: 'ชำระเงินสำเร็จ!' })).toBeTruthy();
-
-    const verificationCalls = fetchMock.mock.calls.filter(([input]) => (
-      urlOf(input) === COURSE_PAYMENT_CONTRACT.slipEndpoint
-    ));
-    expect(verificationCalls).toHaveLength(2);
-    for (const [, init] of verificationCalls) {
-      const formData = init?.body as FormData;
-      expect(formData.get(COURSE_PAYMENT_CONTRACT.slipFields.paymentId)).toBe('payment-1');
-      expect(formData.get(COURSE_PAYMENT_CONTRACT.slipFields.file)).toBeInstanceOf(File);
-    }
-  });
-
-  it('creates a PromptPay intent, accepts a valid slip, and locks verification while pending', async () => {
-    const verifyRequest = deferred<Response>();
-    const fetchMock = vi.fn<
-      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-    >((input) => {
-      const url = urlOf(input);
-      if (url.startsWith('/api/enrollments/check')) {
-        return Promise.resolve(jsonResponse({ enrolled: false }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.intentEndpoint) {
-        return Promise.resolve(jsonResponse({ paymentId: 'payment-1', amount: 2490 }));
-      }
-      if (url === COURSE_PAYMENT_CONTRACT.slipEndpoint) {
-        return verifyRequest.promise;
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const user = userEvent.setup();
-    render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
-
-    const enrollmentButton = await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }) as HTMLButtonElement;
-    await waitFor(() => expect(enrollmentButton.disabled).toBe(false));
-    await user.click(enrollmentButton);
-    await user.click(screen.getByRole('radio', { name: /PromptPay/ }));
-
-    const slipInput = await screen.findByLabelText<HTMLInputElement>('แนบสลิปการโอนเงิน');
-    expect(fetchMock).toHaveBeenCalledWith(
-      COURSE_PAYMENT_CONTRACT.intentEndpoint,
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ courseId: 'course-1' }),
-      }),
-    );
-
-    await user.upload(slipInput, new File(['valid-slip'], 'slip.png', { type: 'image/png' }));
-
-    const verifyButton = screen.getByRole('button', {
-      name: 'ตรวจสอบและชำระเงิน',
-    }) as HTMLButtonElement;
-    await waitFor(() => expect(verifyButton.disabled).toBe(false));
-    await user.click(verifyButton);
-
-    expect(verifyButton.disabled).toBe(true);
-    expect(verifyButton.getAttribute('aria-busy')).toBe('true');
-    const verifyCall = fetchMock.mock.calls.find(([input]) => (
-      urlOf(input) === COURSE_PAYMENT_CONTRACT.slipEndpoint
-    ));
-    const formData = verifyCall?.[1]?.body as FormData;
-    expect(formData.get(COURSE_PAYMENT_CONTRACT.slipFields.file)).toBeInstanceOf(File);
-    expect(formData.get(COURSE_PAYMENT_CONTRACT.slipFields.paymentId)).toBe('payment-1');
-
-    await act(async () => {
-      verifyRequest.resolve(jsonResponse({ success: true }));
-      await verifyRequest.promise;
-    });
-  });
+it('opens the shared authoritative order review for a paid Course', async () => {
+  const fetchMock = vi.fn().mockResolvedValueOnce(response({ enrolled: false })).mockResolvedValueOnce(response({ review: {
+    target: { type: 'course', id: 'course-1', title: 'คอร์สจาก server', href: '/courses/typescript' },
+    price: { original: '990.25', discount: '0.00', amountDue: '990.25', currency: 'THB' },
+    coupon: null, comparison: null, access: { ownedCount: 0, totalCount: 1, description: 'ยืนยันแล้วจึงมีสิทธิ์เรียน' }, action: 'pay',
+  } }));
+  vi.stubGlobal('fetch', fetchMock);
+  const user = userEvent.setup();
+  render(<EnrollButton courseId="course-1" courseSlug="typescript" price={2490} />);
+  await user.click(await screen.findByRole('button', { name: /ซื้อคอร์สนี้/ }));
+  expect(await screen.findByText('คอร์สจาก server')).toBeTruthy();
+  expect(screen.getAllByText('฿990.25')).toHaveLength(2);
+  expect(fetchMock).toHaveBeenLastCalledWith('/api/checkout/review', expect.objectContaining({ body: JSON.stringify({ courseId: 'course-1' }) }));
 });

--- a/tests/lib/order-review.test.ts
+++ b/tests/lib/order-review.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadOrderReview } from '@/lib/order-review';
+
+const mocks = vi.hoisted(() => ({ course: vi.fn(), bundle: vi.fn(), enrollment: vi.fn(), coupon: vi.fn(), select: vi.fn(), insert: vi.fn() }));
+vi.mock('@/lib/db', () => ({ db: { query: { courses: { findFirst: mocks.course }, bundles: { findFirst: mocks.bundle }, enrollments: { findFirst: mocks.enrollment }, coupons: { findFirst: mocks.coupon } }, select: mocks.select, insert: mocks.insert } }));
+const results: unknown[][] = [];
+function chain(rows: unknown[]) {
+  const query: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'groupBy']) query[method] = () => query;
+  query.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(rows).then(resolve);
+  return query;
+}
+const course = { id: 'course-1', slug: 'thai-course', title: 'คอร์สภาษาไทย', status: 'published', price: '1500.00', promoPrice: '1000.00', promoStartsAt: null, promoEndsAt: null, lessons: [{ id: 'lesson-1' }] };
+const coupon = { id: 'coupon-1', code: 'SAVE25', description: null, isActive: true, startsAt: null, expiresAt: null, courseId: null, usageLimit: null, usageCount: 0, perUserLimit: 1, minPurchase: null, discountType: 'percentage', discountValue: '25', maxDiscount: null };
+
+beforeEach(() => {
+  vi.clearAllMocks(); results.length = 0;
+  mocks.course.mockResolvedValue(course); mocks.enrollment.mockResolvedValue(undefined); mocks.coupon.mockResolvedValue(coupon);
+  mocks.select.mockImplementation(() => chain(results.shift() ?? []));
+});
+
+describe('server order review', () => {
+  it('derives current promotion and coupon breakdown without writing payment or enrollment', async () => {
+    results.push([{ count: 0 }]);
+    const review = await loadOrderReview('member-1', { courseId: 'course-1', couponCode: 'save25' });
+    expect(review.price).toEqual({ original: '1000.00', discount: '250.00', amountDue: '750.00', currency: 'THB' });
+    expect(review.target.title).toBe('คอร์สภาษาไทย');
+    expect(review.action).toBe('pay');
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('uses regular price after the promotion ends', async () => {
+    mocks.course.mockResolvedValue({ ...course, promoEndsAt: new Date('2000-01-01') });
+    expect((await loadOrderReview('member-1', { courseId: 'course-1' })).price.amountDue).toBe('1500.00');
+  });
+
+  it('keeps an exact satang amount', async () => {
+    mocks.course.mockResolvedValue({ ...course, promoPrice: '990.25' });
+    expect((await loadOrderReview('member-1', { courseId: 'course-1' })).price.amountDue).toBe('990.25');
+  });
+
+  it.each([
+    [{ expiresAt: new Date('2000-01-01') }, 'คูปองนี้หมดอายุแล้ว'],
+    [{ courseId: 'another-course' }, 'คูปองนี้ไม่สามารถใช้กับคอร์สนี้ได้'],
+    [{ isActive: false }, 'คูปองนี้ถูกปิดใช้งานแล้ว'],
+  ])('rejects invalid coupon eligibility', async (changes, message) => {
+    mocks.coupon.mockResolvedValue({ ...coupon, ...changes });
+    await expect(loadOrderReview('member-1', { courseId: 'course-1', couponCode: 'SAVE25' })).rejects.toThrow(message);
+  });
+
+  it('directs a 100% coupon to explicit free enrollment without granting it', async () => {
+    mocks.coupon.mockResolvedValue({ ...coupon, discountValue: '100' });
+    const result = await loadOrderReview('member-1', { courseId: 'course-1', couponCode: 'FREE' });
+    expect(result.action).toBe('enroll-free');
+    expect(result.price.amountDue).toBe('0.00');
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('prevents an owned course or an unready course from opening payment', async () => {
+    mocks.enrollment.mockResolvedValue({ id: 'enrollment-1' });
+    expect((await loadOrderReview('member-1', { courseId: 'course-1' })).action).toBe('owned');
+    mocks.enrollment.mockResolvedValue(undefined);
+    mocks.course.mockResolvedValue({ ...course, lessons: [] });
+    expect((await loadOrderReview('member-1', { courseId: 'course-1' })).action).toBe('unavailable');
+  });
+
+  it('keeps the full Bundle price and discloses partial ownership from current facts', async () => {
+    mocks.bundle.mockResolvedValue({ id: 'bundle-1', slug: 'thai-bundle', title: 'ชุดคอร์ส', price: '1200.00' });
+    results.push([{ course, orderIndex: 0 }, { course: { ...course, id: 'course-2' }, orderIndex: 1 }], [{ courseId: 'course-1', count: 1 }, { courseId: 'course-2', count: 1 }], [{ courseId: 'course-1' }]);
+    const result = await loadOrderReview('member-1', { bundleId: 'bundle-1' });
+    expect(result.price.amountDue).toBe('1200.00');
+    expect(result.access.ownedCount).toBe(1);
+    expect(result.access.description).toContain('ราคาชุดไม่หักมูลค่าคอร์สที่มีอยู่');
+    expect(result.comparison?.separate).toBe('2000.00');
+  });
+});

--- a/tests/lib/promptpay-presentation.test.ts
+++ b/tests/lib/promptpay-presentation.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { MySqlDialect } from 'drizzle-orm/mysql-core';
+import { loadPromptPayPresentation } from '@/lib/promptpay-presentation';
+
+const mocks = vi.hoisted(() => ({ payment: vi.fn(), course: vi.fn(), select: vi.fn() }));
+vi.mock('@/lib/db', () => ({ db: { query: { payments: { findFirst: mocks.payment }, courses: { findFirst: mocks.course } }, select: mocks.select } }));
+const attempt = { id: 'attempt-1', userId: 'member-1', courseId: 'course-1', bundleId: null, itemTitle: 'Course', amount: '990.25', currency: 'THB', method: 'promptpay', status: 'pending', createdAt: new Date() };
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.payment.mockResolvedValue(attempt);
+  mocks.course.mockResolvedValue({ id: 'course-1', slug: 'thai', title: 'Course' });
+  mocks.select.mockReturnValue({ from: () => ({ where: async () => [] }) });
+});
+
+it('binds status reads to the authenticated owner, exact attempt, and PromptPay method', async () => {
+  const result = await loadPromptPayPresentation('member-1', 'attempt-1');
+  const sql = new MySqlDialect().sqlToQuery(mocks.payment.mock.calls[0][0].where);
+  expect(sql.params).toEqual(['attempt-1', 'member-1', 'promptpay']);
+  expect(result?.canSubmitSlip).toBe(true);
+  expect(result?.presentation.quote?.amountDue).toBe('990.25');
+  expect(result?.presentation.attempt?.id).toBe('attempt-1');
+});
+it('does not reveal another owner or a missing attempt', async () => {
+  mocks.payment.mockResolvedValue(undefined);
+  expect(await loadPromptPayPresentation('other-member', 'attempt-1')).toBeNull();
+  expect(mocks.course).not.toHaveBeenCalled();
+});
+it.each(['verifying', 'failed', 'refunded', 'completed'])('never permits another slip for a %s attempt', async (status) => {
+  mocks.payment.mockResolvedValue({ ...attempt, status });
+  const result = await loadPromptPayPresentation('member-1', 'attempt-1');
+  expect(result?.canSubmitSlip).toBe(false);
+  if (status === 'completed') expect(result?.presentation.payment.state).toBe('completed-access-pending');
+});
+it('does not permit resubmitting an expired attempt', async () => {
+  mocks.payment.mockResolvedValue({ ...attempt, createdAt: new Date('2000-01-01') });
+  expect((await loadPromptPayPresentation('member-1', 'attempt-1'))?.canSubmitSlip).toBe(false);
+});


### PR DESCRIPTION
Course and Bundle buyers now review server-derived product, coupon, THB amount, and access facts before explicitly choosing Stripe or PromptPay. Checkout creation rejects a changed reviewed amount; Stripe also rejects a coupon that is no longer eligible instead of silently charging full price.

The shared checkout dialog shows the exact PromptPay amount, reference, expiry, and slip-privacy guidance. It retains the attempt when closed, retries rejected proof against the same attempt, and requires owner-checked status after uncertain verification. Successful proof is followed by an access check before showing the learning action. Stripe cancellation returns to the exact product with advisory feedback.

Validation:
- Vitest: 190 files, 987 tests passed on the latest commit, including coupon eligibility, satang amounts, owner checks, duplicate-submit prevention, and completed payment without access.
- ESLint, TypeScript, production build, Vitest, and Required E2E all passed in CI on commit 5eb0f33. The local production build also passed with a placeholder database target.
- Required Playwright coverage added for Course/Bundle order review at 320/390/768/1440px, keyboard focus/Escape, reduced motion, back/forward cancellation, and provider-mocked slip rejection/retry. Local Docker is unavailable; CI passed all 5 required journeys against isolated MySQL on the latest commit.
- git diff --check and changed-file UTF-8 scan passed.

Risk and recovery: changes affect checkout presentation, read-only review/status endpoints, and pre-creation amount/coupon checks. No schema changes, migrations, or fulfillment/webhook changes. Rollback can revert this PR without reversing payment or enrollment records. Real provider/live payment and production behavior were not exercised; this PR does not enable analytics or deploy. Exact return/history expansion remains in #50.

Closes #49